### PR TITLE
define internal dockers list

### DIFF
--- a/.github/actions/get-workspaces/action.yml
+++ b/.github/actions/get-workspaces/action.yml
@@ -16,20 +16,35 @@ runs:
   using: "composite"
 
   steps:
-  - name: Filter out internal dockers members
-    shell: bash
-    if: ${{ inputs.remove-internal-dockers == 'true' }}
-    run: echo "EXCLUDE_FOLDERS=("omics", "core")" >> ${GITHUB_ENV}
+  # - name: Filter out internal dockers members
+  #   shell: bash
+  #   if: ${{ inputs.remove-internal-dockers == 'true' }}
+  #   run: echo "EXCLUDE_FOLDERS=("omics", "core")" >> ${GITHUB_ENV}
 
-  - name: Do not filter out internal dockers members
-    shell: bash
-    if: ${{ inputs.remove-internal-dockers == 'false' }}
-    run: echo "EXCLUDE_FOLDERS=("dummy")" >> ${GITHUB_ENV} #some non exiting folder
+  # - name: Do not filter out internal dockers members
+  #   shell: bash
+  #   if: ${{ inputs.remove-internal-dockers == 'false' }}
+  #   run: echo "EXCLUDE_FOLDERS=("dummy")" >> ${GITHUB_ENV} #some non exiting folder
 
   - id: list_dirs
     shell: bash
     run: |
-      folders_to_filter_out=${{ env.EXCLUDE_FOLDERS }}
-      filter_pattern=$(printf "|%s" "${folders_to_filter_out[@]}")
-      filter_pattern="${filter_pattern:1}"  # Remove the leading "|"
-      echo "::set-output name=matrix::$(ls src   | grep -v "__" | grep -v "/\." | grep -Ev "$filter_pattern" | sed 's|src/||' | jq -R -s -c 'split("\n")[:-1]')"
+      filter_flag="${{ inputs.remove-internal-dockers }}"
+
+      # Generate the list of directories in src/ that don't contain "__"
+      all_folders=$(ls src | grep -v "__" | grep -v "/\." | jq -R -s -c 'split("\n")[:-1]')
+
+      # Conditionally apply filtering based on the flag
+      if [ "$filter_flag" = "true" ]; then
+        # Read the folders to filter out from cfg json
+        folders_to_filter_out=$(jq -r '.InternalMembers' .github/actions/get-workspaces/workspaces.json)
+        
+        # Use jq to filter out the folders listed in cfg json
+        filtered_folders=$(echo "$all_folders" | jq --compact-output --argjson filter "$folders_to_filter_out" '[.[] | select(. as $item | $filter | index($item) | not)]')
+      else
+        # No filtering, just use all_folders
+        filtered_folders="$all_folders"
+      fi
+
+      # Set the output matrix (one-line array)
+      echo "::set-output name=matrix::$filtered_folders"

--- a/.github/actions/get-workspaces/action.yml
+++ b/.github/actions/get-workspaces/action.yml
@@ -3,7 +3,7 @@ description: "utilty action to dynamically get the workspaces under ugbio-utils"
 
 inputs:
     remove-internal-dockers:
-      description: "whether to filter out internal docker that used only for tests"
+      description: "whether to filter out internal dockers that used only for tests"
       type: boolean
       required: true
 
@@ -16,16 +16,6 @@ runs:
   using: "composite"
 
   steps:
-  # - name: Filter out internal dockers members
-  #   shell: bash
-  #   if: ${{ inputs.remove-internal-dockers == 'true' }}
-  #   run: echo "EXCLUDE_FOLDERS=("omics", "core")" >> ${GITHUB_ENV}
-
-  # - name: Do not filter out internal dockers members
-  #   shell: bash
-  #   if: ${{ inputs.remove-internal-dockers == 'false' }}
-  #   run: echo "EXCLUDE_FOLDERS=("dummy")" >> ${GITHUB_ENV} #some non exiting folder
-
   - id: list_dirs
     shell: bash
     run: |
@@ -36,14 +26,13 @@ runs:
 
       # Conditionally apply filtering based on the flag
       if [ "$filter_flag" = "true" ]; then
-        ls -la ./.github/actions/get-workspaces/
-        # Read the folders to filter out from cfg json
+        # Read the folders to filter out from workspaces json
         folders_to_filter_out=$(jq -r '.InternalMembers' .github/actions/get-workspaces/workspaces.json)
         
-        # Use jq to filter out the folders listed in cfg json
+        # Use jq to filter out the folders listed in workspaces json
         filtered_folders=$(echo "$all_folders" | jq --compact-output --argjson filter "$folders_to_filter_out" '[.[] | select(. as $item | $filter | index($item) | not)]')
       else
-        # No filtering, just use all_folders
+        # No filtering, just list all_folders
         filtered_folders="$all_folders"
       fi
 

--- a/.github/actions/get-workspaces/action.yml
+++ b/.github/actions/get-workspaces/action.yml
@@ -1,6 +1,12 @@
 name: "Get ugbio workspaces"
 description: "utilty action to dynamically get the workspaces under ugbio-utils"
 
+inputs:
+    remove-internal-dockers:
+      description: "whether to filter out internal docker that used only for tests"
+      type: boolean
+      required: true
+
 outputs:
     workspaces: 
       description: "Workspaces list"
@@ -10,6 +16,20 @@ runs:
   using: "composite"
 
   steps:
+  - name: Filter out internal dockers members
+    shell: bash
+    if: ${{ inputs.remove-internal-dockers == 'true' }}
+    run: echo "EXCLUDE_FOLDERS=("omics", "core")" >> ${GITHUB_ENV}
+
+  - name: Do not filter out internal dockers members
+    shell: bash
+    if: ${{ inputs.remove-internal-dockers == 'false' }}
+    run: echo "EXCLUDE_FOLDERS=("dummy")" >> ${GITHUB_ENV} #some non exiting folder
+
   - id: list_dirs
     shell: bash
-    run: echo "::set-output name=matrix::$(ls src   | grep -v "__" | grep -v "/\." | sed 's|src/||' | jq -R -s -c 'split("\n")[:-1]')"
+    run: |
+      folders_to_filter_out=${{ env.EXCLUDE_FOLDERS }}
+      filter_pattern=$(printf "|%s" "${folders_to_filter_out[@]}")
+      filter_pattern="${filter_pattern:1}"  # Remove the leading "|"
+      echo "::set-output name=matrix::$(ls src   | grep -v "__" | grep -v "/\." | grep -Ev "$filter_pattern" | sed 's|src/||' | jq -R -s -c 'split("\n")[:-1]')"

--- a/.github/actions/get-workspaces/action.yml
+++ b/.github/actions/get-workspaces/action.yml
@@ -36,7 +36,7 @@ runs:
 
       # Conditionally apply filtering based on the flag
       if [ "$filter_flag" = "true" ]; then
-        ls -la
+        ls -la ./.github/actions/get-workspaces/
         # Read the folders to filter out from cfg json
         folders_to_filter_out=$(jq -r '.InternalMembers' .github/actions/get-workspaces/workspaces.json)
         

--- a/.github/actions/get-workspaces/action.yml
+++ b/.github/actions/get-workspaces/action.yml
@@ -37,7 +37,7 @@ runs:
       # Conditionally apply filtering based on the flag
       if [ "$filter_flag" = "true" ]; then
         # Read the folders to filter out from cfg json
-        folders_to_filter_out=$(jq -r '.InternalMembers' .github/actions/get-workspaces/workspaces.json)
+        folders_to_filter_out=$(jq -r '.InternalMembers' workspaces.json)
         
         # Use jq to filter out the folders listed in cfg json
         filtered_folders=$(echo "$all_folders" | jq --compact-output --argjson filter "$folders_to_filter_out" '[.[] | select(. as $item | $filter | index($item) | not)]')

--- a/.github/actions/get-workspaces/action.yml
+++ b/.github/actions/get-workspaces/action.yml
@@ -36,6 +36,7 @@ runs:
 
       # Conditionally apply filtering based on the flag
       if [ "$filter_flag" = "true" ]; then
+        ls -la
         # Read the folders to filter out from cfg json
         folders_to_filter_out=$(jq -r '.InternalMembers' workspaces.json)
         

--- a/.github/actions/get-workspaces/action.yml
+++ b/.github/actions/get-workspaces/action.yml
@@ -38,7 +38,7 @@ runs:
       if [ "$filter_flag" = "true" ]; then
         ls -la
         # Read the folders to filter out from cfg json
-        folders_to_filter_out=$(jq -r '.InternalMembers' workspaces.json)
+        folders_to_filter_out=$(jq -r '.InternalMembers' .github/actions/get-workspaces/workspaces.json)
         
         # Use jq to filter out the folders listed in cfg json
         filtered_folders=$(echo "$all_folders" | jq --compact-output --argjson filter "$folders_to_filter_out" '[.[] | select(. as $item | $filter | index($item) | not)]')

--- a/.github/actions/get-workspaces/workspaces.json
+++ b/.github/actions/get-workspaces/workspaces.json
@@ -1,0 +1,3 @@
+{
+    "InternalMembers": ["core", "omics"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/get-workspaces
         id: list_dirs
+        with:
+          remove-internal-dockers: false
 
   ugbio-utils-CI:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: ./.github/actions/get-workspaces
         id: list_dirs
         with:
-          remove-internal-dockers: false
+          remove-internal-dockers: true
 
   ugbio-utils-CI:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: ./.github/actions/get-workspaces
         id: list_dirs
         with:
-          remove-internal-dockers: true
+          remove-internal-dockers: false
 
   ugbio-utils-CI:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Build workspaces list
         id: list_dirs
         uses: ./.github/actions/get-workspaces
+        with: 
+          remove-internal-dockers: true
 
       - uses: actions-ecosystem/action-get-latest-tag@v1
         id: get-latest-tag


### PR DESCRIPTION
in ugbio-utils under src - we have many folders- that represent the workspaces. Each of them have a docker file that needs to be build in the publish/CI and the ci should run the tests under each of them

instead of having an hard coded list in the ci /publish action - we use this action to build a dynamic list of all the folders under src.

But now we came into a use case that we need some of the dockers to stay internal only for testing and not to be published out.
