### PR TITLE
Ori bioin 2157 adapt srsnv training module to new feature map format finalize report

### DIFF
--- a/src/srsnv/tests/unit/test_srsnv_utils.py
+++ b/src/srsnv/tests/unit/test_srsnv_utils.py
@@ -1,0 +1,493 @@
+"""Unit tests for srsnv_utils module, specifically the HandlePPMSeqTagsInFeatureMapDataFrame class."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from ugbio_ppmseq.ppmSeq_utils import (
+    MAX_TOTAL_HMER_LENGTHS_IN_LOOPS,
+    MIN_TOTAL_HMER_LENGTHS_IN_LOOPS,
+    STRAND_RATIO_LOWER_THRESH,
+    STRAND_RATIO_UPPER_THRESH,
+    PpmseqCategories,
+)
+from ugbio_srsnv.srsnv_utils import AE, AS, ET, ET_FILLNA, ST, ST_FILLNA, TE, TS, HandlePPMSeqTagsInFeatureMapDataFrame
+
+
+class TestHandlePPMSeqTagsInFeatureMapDataFrame:
+    """Test class for HandlePPMSeqTagsInFeatureMapDataFrame."""
+
+    @pytest.fixture
+    def sample_data(self):
+        """Create sample test data with comprehensive edge cases."""
+        return pd.DataFrame(
+            {
+                AS: [0, 4, 2, 1, 4, 1, 3, 1, 5, np.nan, 2, 0, 2],  # A's in start
+                TS: [4, 0, 2, 4, 1, 3, 1, 1, 5, 1, np.nan, 0, 6],  # T's in start
+                AE: [2, 1, 1, 2, 1, 1, 1, np.nan, 1, 1, 1, 3, 1],  # A's in end
+                TE: [2, 3, 3, 2, 3, 3, 5, 1, 2, 2, 2, 1, 7],  # T's in end
+            }
+        )
+
+    @pytest.fixture
+    def expected_st_results(self):
+        """Expected results for the start tag (ST) column."""
+        return [
+            PpmseqCategories.MINUS.value,  # AS=0, TS=4, total=4 → MINUS
+            PpmseqCategories.PLUS.value,  # AS=4, TS=0, total=4 → PLUS
+            PpmseqCategories.MIXED.value,  # AS=2, TS=2, total=4, ratio=0.5 → MIXED
+            PpmseqCategories.UNDETERMINED.value,  # AS=1, TS=4, total=5, ratio=0.8 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AS=4, TS=1, total=5, ratio=0.2 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AS=1, TS=3, total=4, ratio=0.75 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AS=3, TS=1, total=4, ratio=0.25 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AS=1, TS=1, total=2 (out of range) → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AS=5, TS=5, total=10 (out of range) → UNDETERMINED
+            np.nan,  # AS=NaN, TS=1 → NaN
+            np.nan,  # AS=2, TS=NaN → NaN
+            PpmseqCategories.UNDETERMINED.value,  # AS=0, TS=0, total=0 (out of range) → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AS=2, TS=6, total=8 (in range), ratio=0.75 → UNDETERMINED
+        ]
+
+    @pytest.fixture
+    def expected_et_results(self):
+        """Expected results for the end tag (ET) column."""
+        return [
+            PpmseqCategories.MIXED.value,  # AE=2, TE=2, total=4, ratio=0.5 → MIXED
+            PpmseqCategories.UNDETERMINED.value,  # AE=1, TE=3, total=4, ratio=0.75 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AE=1, TE=3, total=4, ratio=0.75 → UNDETERMINED
+            PpmseqCategories.MIXED.value,  # AE=2, TE=2, total=4, ratio=0.5 → MIXED
+            PpmseqCategories.UNDETERMINED.value,  # AE=1, TE=3, total=4, ratio=0.75 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AE=1, TE=3, total=4, ratio=0.75 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AE=1, TE=5, total=6, ratio=0.83 → UNDETERMINED
+            np.nan,  # AE=NaN, TE=1 → NaN
+            PpmseqCategories.UNDETERMINED.value,  # AE=1, TE=2, total=3 (out of range) → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AE=1, TE=2, total=3 (out of range) → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AE=1, TE=2, total=3 (out of range) → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AE=3, TE=1, total=4, ratio=0.25 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AE=1, TE=7, total=8, ratio=0.875 → UNDETERMINED
+        ]
+
+    def test_add_ppmseq_tags_to_featuremap_basic(self, sample_data, expected_st_results, expected_et_results):
+        """Test basic functionality of _add_ppmseq_tags_to_featuremap."""
+        # Create handler instance
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=sample_data.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        # Call the function
+        handler._add_ppmseq_tags_to_featuremap()
+
+        # Check that ST and ET columns were added
+        assert ST in handler.featuremap_df.columns
+        assert ET in handler.featuremap_df.columns
+
+        # Verify ST results
+        for i, expected in enumerate(expected_st_results):
+            actual = handler.featuremap_df.iloc[i][ST]
+            if pd.isna(expected):
+                assert pd.isna(actual), f"Row {i}: Expected NaN for ST, got {actual}"
+            else:
+                assert actual == expected, f"Row {i}: Expected {expected} for ST, got {actual}"
+
+        # Verify ET results
+        for i, expected in enumerate(expected_et_results):
+            actual = handler.featuremap_df.iloc[i][ET]
+            if pd.isna(expected):
+                assert pd.isna(actual), f"Row {i}: Expected NaN for ET, got {actual}"
+            else:
+                assert actual == expected, f"Row {i}: Expected {expected} for ET, got {actual}"
+
+    def test_add_ppmseq_tags_to_featuremap_custom_parameters(self, sample_data):
+        """Test _add_ppmseq_tags_to_featuremap with custom parameters."""
+        # Create handler instance
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=sample_data.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        # Call the function with custom parameters
+        custom_sr_lower = 0.3
+        custom_sr_upper = 0.7
+        custom_min_total = 3
+        custom_max_total = 9
+
+        handler._add_ppmseq_tags_to_featuremap(
+            sr_lower=custom_sr_lower,
+            sr_upper=custom_sr_upper,
+            min_total_hmer=custom_min_total,
+            max_total_hmer=custom_max_total,
+        )
+
+        # Check that ST and ET columns were added
+        assert ST in handler.featuremap_df.columns
+        assert ET in handler.featuremap_df.columns
+
+        # Verify that the custom parameters affected the results
+        # Row 7: AS=1, TS=1, total=2 should now be in valid range (>= 3 is false, so still UNDETERMINED)
+        assert handler.featuremap_df.iloc[7][ST] == PpmseqCategories.UNDETERMINED.value
+
+        # Row 3: AS=1, TS=4, total=5, ratio=0.8 should still be UNDETERMINED (outside 0.3-0.7)
+        assert handler.featuremap_df.iloc[3][ST] == PpmseqCategories.UNDETERMINED.value
+
+    def test_strand_ratio_edge_cases(self):
+        """Test specific edge cases for strand ratio calculations."""
+        test_cases = pd.DataFrame(
+            {
+                AS: [0, 4, 2, 1, 4, 1, 3],
+                TS: [4, 0, 2, 1, 1, 3, 1],
+                AE: [0, 0, 0, 0, 0, 0, 0],  # Dummy values for ET calculation
+                TE: [4, 4, 4, 4, 4, 4, 4],  # Dummy values for ET calculation
+            }
+        )
+
+        expected_st = [
+            PpmseqCategories.MINUS.value,  # AS=0, TS=4, total=4 → MINUS
+            PpmseqCategories.PLUS.value,  # AS=4, TS=0, total=4 → PLUS
+            PpmseqCategories.MIXED.value,  # AS=2, TS=2, total=4, ratio=0.5 → MIXED
+            PpmseqCategories.MIXED.value,  # AS=1, TS=1, total=2 (out of range) → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AS=4, TS=1, total=5, ratio=0.2 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AS=1, TS=3, total=4, ratio=0.75 → UNDETERMINED
+            PpmseqCategories.UNDETERMINED.value,  # AS=3, TS=1, total=4, ratio=0.25 → UNDETERMINED
+        ]
+
+        # Fix the expected result for the case where total is out of range
+        expected_st[3] = PpmseqCategories.UNDETERMINED.value  # AS=1, TS=1, total=2 (out of range) → UNDETERMINED
+
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=test_cases.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        handler._add_ppmseq_tags_to_featuremap()
+
+        for i, expected in enumerate(expected_st):
+            actual = handler.featuremap_df.iloc[i][ST]
+            assert actual == expected, f"Row {i}: Expected {expected} for ST, got {actual}"
+
+    def test_nan_handling(self):
+        """Test proper handling of NaN values."""
+        test_data = pd.DataFrame(
+            {
+                AS: [np.nan, 2, np.nan, 1],
+                TS: [2, np.nan, np.nan, 2],
+                AE: [1, 1, 1, 1],
+                TE: [3, 3, 3, 3],
+            }
+        )
+
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=test_data.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        handler._add_ppmseq_tags_to_featuremap()
+
+        # All rows with NaN in AS or TS should result in NaN for ST
+        assert pd.isna(handler.featuremap_df.iloc[0][ST])  # AS=NaN
+        assert pd.isna(handler.featuremap_df.iloc[1][ST])  # TS=NaN
+        assert pd.isna(handler.featuremap_df.iloc[2][ST])  # Both NaN
+
+        # Row with valid values should not be NaN
+        assert not pd.isna(handler.featuremap_df.iloc[3][ST])
+
+    def test_zero_total_count(self):
+        """Test handling of zero total count."""
+        test_data = pd.DataFrame(
+            {
+                AS: [0, 0],
+                TS: [0, 4],
+                AE: [1, 1],
+                TE: [3, 3],
+            }
+        )
+
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=test_data.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        handler._add_ppmseq_tags_to_featuremap()
+
+        # AS=0, TS=0, total=0 (out of range) → UNDETERMINED
+        assert handler.featuremap_df.iloc[0][ST] == PpmseqCategories.UNDETERMINED.value
+
+        # AS=0, TS=4, total=4 (in range, AS=0) → MINUS
+        assert handler.featuremap_df.iloc[1][ST] == PpmseqCategories.MINUS.value
+
+    @pytest.mark.parametrize(
+        "sr_lower,sr_upper,min_total,max_total",
+        [
+            (0.2, 0.8, 3, 9),
+            (0.3, 0.6, 5, 7),
+            (0.1, 0.9, 2, 10),
+        ],
+    )
+    def test_parameter_variations(self, sample_data, sr_lower, sr_upper, min_total, max_total):
+        """Test function with various parameter combinations."""
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=sample_data.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        # Should not raise any exceptions
+        handler._add_ppmseq_tags_to_featuremap(
+            sr_lower=sr_lower, sr_upper=sr_upper, min_total_hmer=min_total, max_total_hmer=max_total
+        )
+
+        # Check that columns were added
+        assert ST in handler.featuremap_df.columns
+        assert ET in handler.featuremap_df.columns
+
+        # Check that all values are valid category values or NaN
+        valid_categories = {
+            PpmseqCategories.MIXED.value,
+            PpmseqCategories.MINUS.value,
+            PpmseqCategories.PLUS.value,
+            PpmseqCategories.UNDETERMINED.value,
+        }
+
+        for value in handler.featuremap_df[ST]:
+            assert pd.isna(value) or value in valid_categories
+
+        for value in handler.featuremap_df[ET]:
+            assert pd.isna(value) or value in valid_categories
+
+    def test_default_parameters_match_constants(self, sample_data):
+        """Test that default parameters match the imported constants."""
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=sample_data.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        # Call with defaults
+        handler._add_ppmseq_tags_to_featuremap()
+        result_default = handler.featuremap_df.copy()
+
+        # Reset and call with explicit constants
+        handler.featuremap_df = sample_data.copy()
+        handler._add_ppmseq_tags_to_featuremap(
+            sr_lower=STRAND_RATIO_LOWER_THRESH,
+            sr_upper=STRAND_RATIO_UPPER_THRESH,
+            min_total_hmer=MIN_TOTAL_HMER_LENGTHS_IN_LOOPS,
+            max_total_hmer=MAX_TOTAL_HMER_LENGTHS_IN_LOOPS,
+        )
+        result_explicit = handler.featuremap_df.copy()
+
+        # Results should be identical
+        pd.testing.assert_frame_equal(result_default, result_explicit)
+
+    def test_boundary_strand_ratios(self):
+        """Test edge cases exactly at the boundary thresholds."""
+        # Create test cases with exact boundary ratios
+        # sr_lower = 0.27, sr_upper = 0.73
+        # For total = 4: 0.27 * 4 = 1.08, 0.73 * 4 = 2.92
+        # For TS=1, ratio=0.25 (< 0.27) → UNDETERMINED
+        # For TS=2, ratio=0.50 (in [0.27, 0.73]) → MIXED
+        # For TS=3, ratio=0.75 (> 0.73) → UNDETERMINED
+        test_data = pd.DataFrame(
+            {
+                AS: [3, 2, 1, 1, 3],  # Corresponding to TS values below
+                TS: [1, 2, 3, 1, 1],  # Different ratios: 0.25, 0.5, 0.75, 0.5, 0.25
+                AE: [1, 1, 1, 1, 1],  # Dummy values
+                TE: [3, 3, 3, 3, 3],  # Dummy values
+            }
+        )
+
+        # Totals: 4, 4, 4, 2, 4
+        # Ratios: 0.25, 0.5, 0.75, 0.5, 0.25
+        # Valid ranges: yes, yes, yes, no, yes
+        expected_st = [
+            PpmseqCategories.UNDETERMINED.value,  # ratio=0.25 < 0.27
+            PpmseqCategories.MIXED.value,  # ratio=0.5 in [0.27, 0.73]
+            PpmseqCategories.UNDETERMINED.value,  # ratio=0.75 > 0.73
+            PpmseqCategories.UNDETERMINED.value,  # total=2 out of range
+            PpmseqCategories.UNDETERMINED.value,  # ratio=0.25 < 0.27
+        ]
+
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=test_data.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        handler._add_ppmseq_tags_to_featuremap()
+
+        for i, expected in enumerate(expected_st):
+            actual = handler.featuremap_df.iloc[i][ST]
+            assert actual == expected, f"Row {i}: Expected {expected} for ST, got {actual}"
+
+    def test_exact_boundary_thresholds(self):
+        """Test cases exactly at the strand ratio thresholds (0.27 and 0.73)."""
+        # For a total of 100, we can get exact ratios
+        test_data = pd.DataFrame(
+            {
+                AS: [73, 27, 50],  # Will give ratios of exactly 0.27, 0.73, 0.5
+                TS: [27, 73, 50],  # Total = 100 for each
+                AE: [1, 1, 1],  # Dummy values
+                TE: [3, 3, 3],  # Dummy values
+            }
+        )
+
+        # All totals are 100 (out of range for default 4-8), so all should be UNDETERMINED
+        expected_st = [
+            PpmseqCategories.UNDETERMINED.value,  # total=100 out of range
+            PpmseqCategories.UNDETERMINED.value,  # total=100 out of range
+            PpmseqCategories.UNDETERMINED.value,  # total=100 out of range
+        ]
+
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=test_data.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        handler._add_ppmseq_tags_to_featuremap()
+
+        for i, expected in enumerate(expected_st):
+            actual = handler.featuremap_df.iloc[i][ST]
+            assert actual == expected, f"Row {i}: Expected {expected} for ST, got {actual}"
+
+        # Test with extended range that includes 100
+        handler.featuremap_df = test_data.copy()
+        handler._add_ppmseq_tags_to_featuremap(min_total_hmer=4, max_total_hmer=100)
+
+        # Now ratios should be evaluated
+        expected_st_in_range = [
+            PpmseqCategories.MIXED.value,  # ratio=0.27 (at boundary)
+            PpmseqCategories.MIXED.value,  # ratio=0.73 (at boundary)
+            PpmseqCategories.MIXED.value,  # ratio=0.5 (in range)
+        ]
+
+        for i, expected in enumerate(expected_st_in_range):
+            actual = handler.featuremap_df.iloc[i][ST]
+            assert actual == expected, f"Row {i}: Expected {expected} for ST with extended range, got {actual}"
+
+    def test_empty_dataframe(self):
+        """Test function with empty DataFrame."""
+        empty_data = pd.DataFrame({AS: [], TS: [], AE: [], TE: []})
+
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=empty_data.copy(), categorical_features_names=[], ppmseq_adapter_version="legacy_v5"
+        )
+
+        # Should not raise an exception
+        handler._add_ppmseq_tags_to_featuremap()
+
+        # Should add empty ST and ET columns
+        assert ST in handler.featuremap_df.columns
+        assert ET in handler.featuremap_df.columns
+        assert len(handler.featuremap_df) == 0
+
+    def test_fill_nan_tags_with_tm_column(self):
+        """Test fill_nan_tags function with TM column present."""
+        # Import TM constant
+        from ugbio_srsnv.srsnv_utils import TM
+
+        # Create test data with NaN values in ST and ET columns
+        test_data = pd.DataFrame(
+            {
+                AS: [2, 3, 1, 4],
+                TS: [3, 1, 4, 1],
+                AE: [1, 2, 3, 2],
+                TE: [2, 4, 1, 3],
+                ST: ["MIXED", np.nan, "PLUS", np.nan],
+                ET: [np.nan, "MINUS", np.nan, np.nan],
+                TM: ["ABC", "XYZ", "ADE", "FGH"],  # positions 0,2 contain 'A', positions 1,3 don't
+            }
+        )
+
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=test_data,
+            categorical_features_names=[],
+            ppmseq_adapter_version="v1",
+            start_tag_col=ST,
+            end_tag_col=ET,
+        )
+
+        # Fill NaN values
+        handler.fill_nan_tags()
+
+        # Verify ST_FILLNA column: all NaN should be UNDETERMINED
+        assert handler.featuremap_df.loc[1, ST_FILLNA] == PpmseqCategories.UNDETERMINED.value
+        assert handler.featuremap_df.loc[3, ST_FILLNA] == PpmseqCategories.UNDETERMINED.value
+
+        # Verify ET_FILLNA column: based on TM content
+        assert handler.featuremap_df.loc[0, ET_FILLNA] == PpmseqCategories.UNDETERMINED.value  # tm='ABC' contains 'A'
+        assert handler.featuremap_df.loc[2, ET_FILLNA] == PpmseqCategories.UNDETERMINED.value  # tm='ADE' contains 'A'
+        assert handler.featuremap_df.loc[3, ET_FILLNA] == PpmseqCategories.END_UNREACHED.value  # tm='FGH' no 'A'
+
+        # Verify no NaN values remain in fillna columns
+        assert handler.featuremap_df[ST_FILLNA].isna().sum() == 0
+        assert handler.featuremap_df[ET_FILLNA].isna().sum() == 0
+
+        # Verify existing values are preserved in fillna columns
+        assert handler.featuremap_df.loc[0, ST_FILLNA] == "MIXED"
+        assert handler.featuremap_df.loc[2, ST_FILLNA] == "PLUS"
+        assert handler.featuremap_df.loc[1, ET_FILLNA] == "MINUS"
+
+        # Verify original columns are unchanged
+        assert pd.isna(handler.featuremap_df.loc[1, ST])
+        assert pd.isna(handler.featuremap_df.loc[3, ST])
+        assert pd.isna(handler.featuremap_df.loc[0, ET])
+        assert pd.isna(handler.featuremap_df.loc[2, ET])
+        assert pd.isna(handler.featuremap_df.loc[3, ET])
+
+    def test_fill_nan_tags_without_tm_column(self):
+        """Test fill_nan_tags function without TM column present."""
+        # Create test data without TM column
+        test_data = pd.DataFrame(
+            {
+                AS: [2, 3, 1, 4],
+                TS: [3, 1, 4, 1],
+                AE: [1, 2, 3, 2],
+                TE: [2, 4, 1, 3],
+                ST: ["MIXED", np.nan, "PLUS", np.nan],
+                ET: [np.nan, "MINUS", np.nan, "MIXED"],
+            }
+        )
+
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=test_data,
+            categorical_features_names=[],
+            ppmseq_adapter_version="v1",
+            start_tag_col=ST,
+            end_tag_col=ET,
+        )
+
+        # Fill NaN values (should log warning about missing TM column)
+        handler.fill_nan_tags()
+
+        # Verify all NaN values are filled with UNDETERMINED in fillna columns
+        assert handler.featuremap_df.loc[1, ST_FILLNA] == PpmseqCategories.UNDETERMINED.value
+        assert handler.featuremap_df.loc[3, ST_FILLNA] == PpmseqCategories.UNDETERMINED.value
+        assert handler.featuremap_df.loc[0, ET_FILLNA] == PpmseqCategories.UNDETERMINED.value
+        assert handler.featuremap_df.loc[2, ET_FILLNA] == PpmseqCategories.UNDETERMINED.value
+
+        # Verify no NaN values remain in fillna columns
+        assert handler.featuremap_df[ST_FILLNA].isna().sum() == 0
+        assert handler.featuremap_df[ET_FILLNA].isna().sum() == 0
+
+        # Verify existing values are preserved in fillna columns
+        assert handler.featuremap_df.loc[0, ST_FILLNA] == "MIXED"
+        assert handler.featuremap_df.loc[2, ST_FILLNA] == "PLUS"
+        assert handler.featuremap_df.loc[1, ET_FILLNA] == "MINUS"
+        assert handler.featuremap_df.loc[3, ET_FILLNA] == "MIXED"
+
+        # Verify original columns are unchanged
+        assert pd.isna(handler.featuremap_df.loc[1, ST])
+        assert pd.isna(handler.featuremap_df.loc[3, ST])
+        assert pd.isna(handler.featuremap_df.loc[0, ET])
+        assert pd.isna(handler.featuremap_df.loc[2, ET])
+
+    def test_fill_nan_tags_without_tag_columns_setup(self):
+        """Test fill_nan_tags function when tag columns are not set up."""
+        test_data = pd.DataFrame(
+            {
+                "some_col": [1, 2],
+                "other_col": [3, 4],
+            }
+        )
+
+        handler = HandlePPMSeqTagsInFeatureMapDataFrame(
+            featuremap_df=test_data,
+            categorical_features_names=[],
+            ppmseq_adapter_version="v1",
+            start_tag_col=None,  # Not set up
+            end_tag_col=None,  # Not set up
+        )
+
+        # Should log warning and return early
+        handler.fill_nan_tags()
+
+        # The fillna columns should not be created since start_tag_col and end_tag_col are None
+        assert ST_FILLNA not in handler.featuremap_df.columns
+        assert ET_FILLNA not in handler.featuremap_df.columns

--- a/src/srsnv/tests/unit/test_trinuc_histogram_plotting.py
+++ b/src/srsnv/tests/unit/test_trinuc_histogram_plotting.py
@@ -1,0 +1,397 @@
+"""Unit tests for trinucleotide histogram plotting functionality."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib import pyplot as plt
+from ugbio_srsnv.trinuc_histogram_plotting import (
+    calc_and_plot_trinuc_hist,
+    calc_trinuc_stats,
+    plot_trinuc_hist,
+    plot_trinuc_hist_and_qual_panels,
+    plot_trinuc_hist_panels,
+    plot_trinuc_qual,
+    reverse_engineer_hist_stats,
+)
+
+
+class TestTrinucHistogramPlotting:
+    """Test cases for trinucleotide histogram plotting functions."""
+
+    @pytest.fixture
+    def sample_data(self):
+        """Create sample data for testing."""
+        # Fix random seed for reproducibility
+        rng = np.random.default_rng(42)
+
+        trinuc_contexts = [
+            "AAAC",
+            "AAAG",
+            "AAAT",
+            "AACG",
+            "AACT",
+            "AAGT",
+            "ACAC",
+            "ACAG",
+            "ACAT",
+            "ACCG",
+            "ACCT",
+            "ACGT",
+            "AGAC",
+            "AGAG",
+            "AGAT",
+            "AGCG",
+            "AGCT",
+            "AGGT",
+            "ATAC",
+            "ATAG",
+            "ATAT",
+            "ATCG",
+            "ATCT",
+            "ATGT",
+        ] * 50  # Repeat to get more data
+
+        data = {
+            "tcwa_fwd": rng.choice(trinuc_contexts, 1000),
+            "label": rng.choice([False, True], 1000, p=[0.8, 0.2]),
+            "is_forward": rng.choice([True, False], 1000),
+            "SNVQ": rng.normal(35, 12, 1000).clip(5, 70),
+            "is_mixed": rng.choice([True, False], 1000, p=[0.7, 0.3]),
+            "is_cycle_skip": rng.choice([True, False], 1000, p=[0.3, 0.7]),
+        }
+
+        return pd.DataFrame(data)
+
+    def test_calc_trinuc_stats_basic(self, sample_data):
+        """Test basic functionality of calc_trinuc_stats."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=False, collapsed=True)
+
+        # Check basic structure
+        assert isinstance(stats_df, pd.DataFrame)
+        assert stats_df.shape[0] == 96  # TRINUC_FORWARD_COUNT for collapsed mode
+        assert len([col for col in stats_df.columns if ")" in col]) == 2  # Two label columns
+
+        # Check histogram columns exist
+        hist_cols = [
+            col
+            for col in stats_df.columns
+            if not col.endswith(("_median_qual", "_q1_qual", "_q2_qual")) and col != "is_cycle_skip"
+        ]
+        assert len(hist_cols) == 2  # False and True labels
+
+    def test_calc_trinuc_stats_with_quality(self, sample_data):
+        """Test calc_trinuc_stats with quality statistics."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=True)
+
+        # Check quality columns exist
+        qual_cols = [col for col in stats_df.columns if "qual" in col]
+        assert len(qual_cols) > 0
+
+        # Check for mixed categories
+        mixed_all_cols = [col for col in qual_cols if "mixed=all" in col]
+        mixed_true_cols = [col for col in qual_cols if "mixed=True" in col]
+        mixed_false_cols = [col for col in qual_cols if "mixed=False" in col]
+
+        assert len(mixed_all_cols) > 0
+        assert len(mixed_true_cols) > 0
+        assert len(mixed_false_cols) > 0
+
+    def test_calc_trinuc_stats_collapsed_vs_full(self, sample_data):
+        """Test difference between collapsed and full modes."""
+        stats_collapsed = calc_trinuc_stats(sample_data, labels=[False, True], collapsed=True)
+
+        stats_full = calc_trinuc_stats(sample_data, labels=[False, True], collapsed=False)
+
+        assert stats_collapsed.shape[0] == 96
+        assert stats_full.shape[0] == 192
+        assert stats_collapsed.shape[1] == stats_full.shape[1]  # Same number of columns
+
+    def test_plot_trinuc_hist_basic(self, sample_data):
+        """Test basic histogram plotting functionality."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=False, collapsed=True)
+
+        # Reverse engineer to get hist_stats format
+        labels, hist_stats, _ = reverse_engineer_hist_stats(stats_df[[col for col in stats_df.columns if ")" in col]])
+
+        fig, ax = plt.subplots(figsize=(16, 3))
+        returned_ax, bars = plot_trinuc_hist(hist_stats, labels=labels, panel_num=0, ax=ax)
+
+        assert returned_ax is ax
+        assert len(bars) == len(labels)
+        plt.close(fig)
+
+    def test_plot_trinuc_hist_annotations(self, sample_data):
+        """Test annotation functionality in histogram plotting."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=False, collapsed=True)
+
+        labels, hist_stats, _ = reverse_engineer_hist_stats(stats_df[[col for col in stats_df.columns if ")" in col]])
+
+        # Test with annotations
+        fig1, ax1 = plt.subplots(figsize=(16, 3))
+        plot_trinuc_hist(hist_stats, labels=labels, panel_num=0, ax=ax1, add_annotations=True)
+
+        # Test without annotations
+        fig2, ax2 = plt.subplots(figsize=(16, 3))
+        plot_trinuc_hist(hist_stats, labels=labels, panel_num=0, ax=ax2, add_annotations=False)
+
+        # Check that annotations were added in first case
+        assert len(ax1.texts) > len(ax2.texts)
+
+        plt.close(fig1)
+        plt.close(fig2)
+
+    def test_plot_trinuc_qual_basic(self, sample_data):
+        """Test basic quality plotting functionality."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=True)
+
+        fig, ax = plt.subplots(figsize=(16, 3))
+        returned_ax, lines = plot_trinuc_qual(stats_df, panel_num=0, ax=ax)
+
+        assert returned_ax is ax
+        assert isinstance(lines, dict)
+        assert len(lines) > 0  # Should have at least one quality line
+        plt.close(fig)
+
+    def test_plot_trinuc_qual_separators(self, sample_data):
+        """Test that quality plots include separators."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=True)
+
+        fig, ax = plt.subplots(figsize=(16, 3))
+        plot_trinuc_qual(stats_df, panel_num=0, ax=ax)
+
+        # Check that separator lines were added (5 separators expected)
+        lines = [line for line in ax.lines if line.get_linestyle() == "--"]
+        assert len(lines) == 5
+
+        plt.close(fig)
+
+    def test_plot_trinuc_qual_annotations(self, sample_data):
+        """Test annotation functionality in quality plotting."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=True)
+
+        # Test with annotations
+        fig1, ax1 = plt.subplots(figsize=(16, 3))
+        plot_trinuc_qual(stats_df, panel_num=0, ax=ax1, add_annotations=True)
+
+        # Test without annotations
+        fig2, ax2 = plt.subplots(figsize=(16, 3))
+        plot_trinuc_qual(stats_df, panel_num=0, ax=ax2, add_annotations=False)
+
+        # Check that annotations were added in first case
+        assert len(ax1.texts) > len(ax2.texts)
+
+        plt.close(fig1)
+        plt.close(fig2)
+
+    def test_plot_trinuc_hist_and_qual_panels_collapsed(self, sample_data):
+        """Test combined histogram and quality plotting in collapsed mode."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=True)
+
+        fig = plot_trinuc_hist_and_qual_panels(stats_df, collapsed=True, suptitle="Test Collapsed Mode")
+
+        # Should have 2 axes (quality + histogram)
+        assert len(fig.axes) == 2
+        plt.close(fig)
+
+    def test_plot_trinuc_hist_and_qual_panels_full(self, sample_data):
+        """Test combined plotting in non-collapsed mode."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=False)
+
+        fig = plot_trinuc_hist_and_qual_panels(stats_df, collapsed=False, suptitle="Test Full Mode")
+
+        # Should have 4 axes (quality1 + hist1 + quality2 + hist2)
+        assert len(fig.axes) == 4
+        plt.close(fig)
+
+    def test_height_ratio_parameter(self, sample_data):
+        """Test configurable height ratio parameter."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=True)
+
+        # Test default ratio
+        fig1 = plot_trinuc_hist_and_qual_panels(stats_df, collapsed=True, hist_to_qual_height_ratio=2.0)
+
+        # Test custom ratio
+        fig2 = plot_trinuc_hist_and_qual_panels(stats_df, collapsed=True, hist_to_qual_height_ratio=3.0)
+
+        # Both should succeed without error
+        assert len(fig1.axes) == 2
+        assert len(fig2.axes) == 2
+
+        plt.close(fig1)
+        plt.close(fig2)
+
+    def test_bottom_scale_parameter(self, sample_data):
+        """Test bottom_scale parameter for legend positioning."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=True)
+
+        # Test with different bottom_scale values
+        fig1 = plot_trinuc_hist_and_qual_panels(stats_df, collapsed=True, bottom_scale=1.0)
+
+        fig2 = plot_trinuc_hist_and_qual_panels(stats_df, collapsed=True, bottom_scale=1.5)
+
+        # Both should succeed without error
+        assert len(fig1.axes) == 2
+        assert len(fig2.axes) == 2
+
+        plt.close(fig1)
+        plt.close(fig2)
+
+    def test_legend_labels_tp_fp(self, sample_data):
+        """Test that legend labels show TP/FP instead of True/False."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=True)
+
+        fig = plot_trinuc_hist_and_qual_panels(stats_df, collapsed=True)
+
+        # Check that legends exist
+        legends = fig.legends
+        assert len(legends) > 0
+
+        # Check that at least one legend contains TP/FP labels
+        legend_texts = []
+        for legend in legends:
+            legend_texts.extend([text.get_text() for text in legend.get_texts()])
+
+        has_tp_fp = any("TP" in text or "FP" in text for text in legend_texts)
+        assert has_tp_fp, f"Expected TP/FP in legend labels, got: {legend_texts}"
+
+        plt.close(fig)
+
+    def test_calc_and_plot_trinuc_hist_with_quality(self, sample_data):
+        """Test the main calc_and_plot function with quality."""
+        fig, stats_df = calc_and_plot_trinuc_hist(
+            sample_data, labels=[False, True], collapsed=True, include_quality=True, suptitle="Test Integration"
+        )
+
+        assert isinstance(fig, plt.Figure)
+        assert isinstance(stats_df, pd.DataFrame)
+        assert len(fig.axes) == 2  # Quality + histogram panels
+
+        plt.close(fig)
+
+    def test_calc_and_plot_trinuc_hist_histogram_only(self, sample_data):
+        """Test the main calc_and_plot function without quality."""
+        fig, stats_df = calc_and_plot_trinuc_hist(
+            sample_data, labels=[False, True], collapsed=True, include_quality=False, suptitle="Test Histogram Only"
+        )
+
+        assert isinstance(fig, plt.Figure)
+        assert isinstance(stats_df, pd.DataFrame)
+        assert len(fig.axes) == 1  # Only histogram panel
+
+        plt.close(fig)
+
+    def test_height_ratio_in_calc_and_plot(self, sample_data):
+        """Test height ratio parameter in main function."""
+        fig, _ = calc_and_plot_trinuc_hist(
+            sample_data, labels=[False, True], collapsed=True, include_quality=True, hist_to_qual_height_ratio=3.0
+        )
+
+        assert len(fig.axes) == 2
+        plt.close(fig)
+
+    def test_reverse_engineer_hist_stats(self, sample_data):
+        """Test the reverse engineering function."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=False, collapsed=True)
+
+        hist_cols = [col for col in stats_df.columns if ")" in col]
+        hist_stats_df = stats_df[hist_cols]
+
+        labels, hist_stats, total_snvs = reverse_engineer_hist_stats(hist_stats_df)
+
+        assert len(labels) == 2
+        assert len(hist_stats) == 2
+        assert len(total_snvs) == 2
+        assert all(isinstance(count, int) for count in total_snvs.values())
+
+    def test_plot_trinuc_hist_panels(self, sample_data):
+        """Test histogram-only panels function."""
+        stats_df = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=False, collapsed=True)
+
+        hist_cols = [col for col in stats_df.columns if ")" in col]
+        hist_stats_df = stats_df[hist_cols]
+
+        fig = plot_trinuc_hist_panels(hist_stats_df, collapsed=True, suptitle="Test Histogram Panels")
+
+        assert len(fig.axes) == 1  # Only one panel for collapsed mode
+        plt.close(fig)
+
+    def test_error_handling_empty_data(self):
+        """Test error handling with empty data."""
+        empty_df = pd.DataFrame(
+            {
+                "tcwa_fwd": pd.Series([], dtype="object"),  # Ensure proper dtype for string operations
+                "label": pd.Series([], dtype="object"),
+                "is_forward": pd.Series([], dtype="bool"),
+                "SNVQ": pd.Series([], dtype="float64"),
+                "is_mixed": pd.Series([], dtype="bool"),
+            }
+        )
+
+        # Should not crash, but return empty or minimal stats
+        # Use fwd_only to avoid string processing complications with empty data
+        stats_df = calc_trinuc_stats(
+            empty_df,
+            labels=[False, True],
+            include_quality=True,
+            collapsed=True,
+            motif_orientation="fwd_only",  # Avoid string processing on empty data
+        )
+
+        assert isinstance(stats_df, pd.DataFrame)
+        assert stats_df.shape[0] == 96  # Should still have proper index
+
+    def test_quality_mixed_category_detection(self, sample_data):
+        """Test automatic detection of mixed categories in quality plotting."""
+        # Test with mixed=True/False data
+        stats_df_mixed = calc_trinuc_stats(sample_data, labels=[False, True], include_quality=True, collapsed=True)
+
+        fig, ax = plt.subplots(figsize=(16, 3))
+        _, lines_mixed = plot_trinuc_qual(stats_df_mixed, panel_num=0, ax=ax)
+
+        # Should detect both mixed=True and mixed=False, so plot only those
+        mixed_keys = list(lines_mixed.keys())
+        has_mixed_specific = any("mixed=True" in key or "mixed=False" in key for key in mixed_keys)
+        has_mixed_all = any("mixed=all" in key for key in mixed_keys)
+
+        # Should prioritize mixed=True/False over mixed=all
+        assert has_mixed_specific or has_mixed_all
+
+        plt.close(fig)
+
+    def test_motif_orientation_parameter(self, sample_data):
+        """Test the new motif_orientation parameter."""
+        # Test fwd_only
+        stats_df_fwd = calc_trinuc_stats(
+            sample_data, labels=[False, True], motif_orientation="fwd_only", collapsed=True
+        )
+
+        # Test seq_dir (default)
+        stats_df_seq = calc_trinuc_stats(sample_data, labels=[False, True], motif_orientation="seq_dir", collapsed=True)
+
+        # Test ref_dir
+        stats_df_ref = calc_trinuc_stats(sample_data, labels=[False, True], motif_orientation="ref_dir", collapsed=True)
+
+        # All should produce valid DataFrames
+        assert isinstance(stats_df_fwd, pd.DataFrame)
+        assert isinstance(stats_df_seq, pd.DataFrame)
+        assert isinstance(stats_df_ref, pd.DataFrame)
+
+        # All should have same structure
+        assert stats_df_fwd.shape[0] == 96
+        assert stats_df_seq.shape[0] == 96
+        assert stats_df_ref.shape[0] == 96
+
+    def test_motif_orientation_invalid_value(self, sample_data):
+        """Test that invalid motif_orientation values raise errors."""
+        with pytest.raises(ValueError, match="motif_orientation"):
+            calc_trinuc_stats(sample_data, labels=[False, True], motif_orientation="invalid_value", collapsed=True)
+
+    def test_calc_and_plot_with_motif_orientation(self, sample_data):
+        """Test the main function with motif_orientation parameter."""
+        fig, stats_df = calc_and_plot_trinuc_hist(
+            sample_data, labels=[False, True], collapsed=True, include_quality=True, motif_orientation="fwd_only"
+        )
+
+        assert isinstance(fig, plt.Figure)
+        assert isinstance(stats_df, pd.DataFrame)
+        plt.close(fig)

--- a/src/srsnv/ugbio_srsnv/shap_plotting.py
+++ b/src/srsnv/ugbio_srsnv/shap_plotting.py
@@ -1,0 +1,1115 @@
+#!/env/python
+# Copyright 2023 Ultima Genomics Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+# DESCRIPTION
+#    Standalone SHAP plotting utilities for XGBoost models trained with cross-validation
+# CHANGELOG in reverse chronological order
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import shap
+import xgboost as xgb
+from matplotlib import cm
+
+# Constants for plot formatting and colorbar display
+MAX_LABEL_LENGTH_FOR_HORIZONTAL = 5  # Maximum character length before rotating colorbar labels
+
+
+class SHAPPlotter:
+    """
+    Standalone SHAP plotting utilities for XGBoost models trained with cross-validation.
+
+    This class provides functionality to calculate and plot SHAP values for XGBoost models
+    without requiring the full SRSNVReport infrastructure. It's designed to work with
+    cross-validation trained models and supports plotting on data subsets.
+
+    The class assumes:
+    - Models were trained using cross-validation with XGBoost's "objective": "multi:softprob"
+      which returns 3D SHAP arrays with shape (n_samples, n_classes, n_features+1)
+    - Data contains a fold_id column indicating which fold each sample belongs to
+    - fold_id can be NaN for samples not used in training (test data) - these can use any model
+    - Both categorical and numerical features are present
+    - Features information is provided either in srsnv_metadata format or as separate lists/dicts
+
+    Categorical Feature Handling:
+    - Categorical features are assumed to be correctly encoded in the input data
+    - The srsnv_metadata.json file contains the categorical encodings with proper value mappings
+    - XGBoost models are trained with enable_categorical=True using these pre-encoded features
+    - For SHAP visualization, categorical features are converted to integers purely for display
+      purposes so that SHAP's beeswarm plots can apply color gradients (otherwise they remain grey)
+    - This integer conversion is NOT for model inference - the original categorical encodings
+      from metadata are preserved and used correctly by the trained XGBoost models
+
+    Note:
+    - TODO: Add support for standard binary classification models that return 2D SHAP arrays
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        models: list[xgb.XGBClassifier],
+        data: pd.DataFrame,
+        fold_id_col: str = "fold_id",
+        features_metadata: list[dict] = None,
+        feature_names: list[str] = None,
+        categorical_features_dict: dict[str, list] = None,
+        label_col: str = "label",
+        random_state: int = 42,
+    ):
+        """
+        Initialize the SHAPPlotter.
+
+        Parameters
+        ----------
+        models : list[xgb.XGBClassifier]
+            List of trained XGBoost models, one for each CV fold.
+        data : pd.DataFrame
+            DataFrame containing features, labels, and fold assignments.
+            Must contain the fold_id_col and label_col columns.
+        fold_id_col : str, default "fold_id"
+            Name of the column containing fold assignments. Values should be integers
+            from 0 to len(models)-1 for training data, or NaN for test data.
+            Test data (NaN fold_id) can be used with any model.
+        features_metadata : list[dict], optional
+            List of feature metadata dictionaries in srsnv_metadata format. Each dict
+            should have 'name', 'type', and optionally 'values' keys. If provided,
+            this takes precedence over feature_names and categorical_features_dict.
+        feature_names : list[str], optional
+            List of feature names in the order they were used for training.
+            Only used if features_metadata is not provided.
+        categorical_features_dict : dict[str, list], optional
+            Dictionary mapping categorical feature names to their possible values.
+            Only used if features_metadata is not provided.
+        label_col : str, default "label"
+            Name of the column containing the target labels.
+        random_state : int, default 42
+            Random state for reproducible sampling.
+
+        Raises
+        ------
+        ValueError
+            If the number of models doesn't match the number of unique fold IDs,
+            if required columns are missing from the data, or if feature information
+            is not provided in any valid format.
+        """
+        self.models = models
+        self.data = data
+        self.fold_id_col = fold_id_col
+        self.label_col = label_col
+        self.rng = np.random.default_rng(random_state)
+
+        # Validate inputs
+        if fold_id_col not in data.columns:
+            raise ValueError(f"fold_id_col '{fold_id_col}' not found in data columns")
+        if label_col not in data.columns:
+            raise ValueError(f"label_col '{label_col}' not found in data columns")
+
+        # Process features information
+        if features_metadata is not None:
+            # Extract features from srsnv_metadata format
+            self.feature_names, self.categorical_features_dict = self._parse_features_metadata(features_metadata)
+        elif feature_names is not None:
+            # Use provided feature names and categorical dict
+            self.feature_names = feature_names
+            self.categorical_features_dict = categorical_features_dict or {}
+        elif hasattr(models[0], "feature_names_in_"):
+            # Try to get feature names from the first model
+            self.feature_names = list(models[0].feature_names_in_)
+            self.categorical_features_dict = categorical_features_dict or {}
+        else:
+            raise ValueError(
+                "Feature information must be provided either through features_metadata, "
+                "feature_names, or the model must have feature_names_in_ attribute"
+            )
+
+        # Check that number of models matches number of folds
+        fold_values = data[fold_id_col].dropna().unique()
+        if len(models) != len(fold_values):
+            raise ValueError(f"Number of models ({len(models)}) doesn't match number of folds ({len(fold_values)})")
+
+    def _parse_features_metadata(self, features_metadata: list[dict]) -> tuple[list[str], dict[str, list]]:
+        """
+        Parse features metadata from srsnv_metadata format.
+
+        This method extracts categorical feature encodings from the metadata. The categorical
+        features in the srsnv_metadata.json file already contain the correct encodings that
+        were used during model training with XGBoost's enable_categorical=True.
+
+        Example from srsnv_metadata.json:
+        {
+          "name": "REF",
+          "type": "c",
+          "values": {"A": 0, "C": 1, "G": 2, "T": 3}
+        }
+
+        These encodings ensure that:
+        1. XGBoost models were trained with consistent categorical representations
+        2. The same encodings are used for SHAP value calculation
+        3. The integer conversion for visualization preserves the correct order/mapping
+
+        Parameters
+        ----------
+        features_metadata : list[dict]
+            List of feature metadata dictionaries from srsnv_metadata.json.
+            Each dict should have 'name', 'type', and optionally 'values' keys.
+            For categorical features (type='c'), 'values' contains the string-to-integer
+            mapping that was used during model training.
+
+        Returns
+        -------
+        tuple[list[str], dict[str, list]]
+            Feature names list and categorical features dictionary mapping feature names
+            to their ordered categorical values (sorted by the integer codes from metadata).
+        """
+        feature_names = []
+        categorical_features_dict = {}
+
+        for feature_info in features_metadata:
+            name = feature_info["name"]
+            feature_names.append(name)
+
+            # Extract categorical feature encodings from metadata
+            if feature_info.get("type") == "c" and "values" in feature_info:
+                # Sort by the numeric values to preserve the encoding order used in training
+                values_dict = feature_info["values"]
+                sorted_values = sorted(values_dict.items(), key=lambda x: x[1])
+                categorical_features_dict[name] = [item[0] for item in sorted_values]
+
+        return feature_names, categorical_features_dict
+
+    def plot_feature_importance(  # noqa: PLR0913
+        self,
+        data_subset: pd.DataFrame = None,
+        fold_id: int = 0,
+        n_sample: int = 10_000,
+        n_features: int = 15,
+        xlims: tuple[float, float] = None,
+        output_filename: str = None,
+        figsize: tuple[int, int] = (20, 10),
+        *,
+        shap_values: np.ndarray = None,
+        x_sample: pd.DataFrame = None,
+    ) -> tuple[np.ndarray, pd.DataFrame, plt.Figure]:
+        """
+        Plot SHAP feature importance using a bar plot.
+
+        This method calculates SHAP values for a sample of data and creates a bar plot
+        showing the mean absolute SHAP value for each feature, indicating their
+        relative importance to the model.
+
+        Parameters
+        ----------
+        data_subset : pd.DataFrame, optional
+            Subset of data to use for SHAP calculation. If None, uses data from
+            the specified fold_id. This allows plotting SHAP values for specific
+            subsets of interest (e.g., specific mutation types, quality ranges, etc.).
+        fold_id : int, default 0
+            Which fold's model to use for SHAP calculation. Only used if data_subset
+            is None.
+        n_sample : int, default 10_000
+            Number of samples to use for SHAP calculation. Larger values give more
+            stable results but take longer to compute.
+        n_features : int, default 15
+            Number of top features to display in the plot.
+        xlims : tuple[float, float], optional
+            X-axis limits for the plot. If None, automatically determined.
+        output_filename : str, optional
+            Path to save the plot. If None, plot is displayed but not saved.
+        figsize : tuple[int, int], default (20, 10)
+            Figure size as (width, height) in inches.
+        shap_values : np.ndarray, optional
+            Pre-calculated SHAP values with shape (n_samples, n_classes, n_features+1).
+            If provided, skips SHAP calculation. Must be provided together with x_sample.
+        x_sample : pd.DataFrame, optional
+            Sampled features corresponding to the shap_values. Must be provided
+            together with shap_values.
+
+        Returns
+        -------
+        tuple[np.ndarray, pd.DataFrame, plt.Figure]
+            A tuple containing:
+            - shap_values: Array of SHAP values with shape (n_samples, n_classes, n_features+1)
+            - X_sample: DataFrame of the sampled data used for SHAP calculation
+            - fig: The matplotlib figure object
+
+        Notes
+        -----
+        - For binary classification, uses the difference between class 1 and class 0 SHAP values
+        - Categorical features are automatically converted to integer representation for display
+        - Features are ranked by mean absolute SHAP value
+        """
+        # Use pre-calculated SHAP values if provided, otherwise calculate them
+        if shap_values is not None and x_sample is not None:
+            if shap_values.shape[0] != len(x_sample):
+                raise ValueError(
+                    f"Shape mismatch: shap_values has {shap_values.shape[0]} samples "
+                    f"but x_sample has {len(x_sample)} samples"
+                )
+        elif shap_values is not None or x_sample is not None:
+            raise ValueError("Both shap_values and x_sample must be provided together, or neither")
+        else:
+            # Calculate SHAP values
+            shap_values, x_sample, _ = self.sample_and_calculate_shap_values(
+                data_subset=data_subset, fold_id=fold_id, n_sample=n_sample
+            )
+
+        # Prepare data for plotting
+        # x_sample_plot = self._prepare_data_for_plotting(x_sample)
+        x_sample_plot = x_sample.copy()
+
+        # Create SHAP explanation object
+        base_values_plot = shap_values[0, 1, -1] - shap_values[0, 0, -1]
+        shap_values_plot = shap_values[:, 1, :-1] - shap_values[:, 0, :-1]
+        explanation = shap.Explanation(
+            values=shap_values_plot,
+            base_values=base_values_plot,
+            feature_names=x_sample_plot.columns,
+            data=x_sample_plot,
+        )
+
+        # Create the plot
+        fig, ax = plt.subplots(figsize=figsize)
+        plt.sca(ax)
+        shap.plots.bar(
+            explanation,
+            max_display=n_features,
+            show=False,
+        )
+        ax.set_xlabel("")
+        if xlims is not None:
+            ax.set_xlim(xlims)
+        ticklabels = ax.get_ymajorticklabels()
+        ax.set_yticklabels(ticklabels)
+        ax.grid(visible=True, axis="x", linestyle=":", linewidth=1)
+
+        # Save or show the plot
+        if output_filename:
+            fig.savefig(output_filename, bbox_inches="tight", dpi=300)
+
+        return shap_values, x_sample, fig
+
+    def plot_beeswarm(  # noqa: PLR0913 C901 PLR0912 PLR0915
+        self,
+        data_subset: pd.DataFrame = None,
+        fold_id: int = 0,
+        n_sample: int = 10_000,
+        n_features: int = 10,
+        nplot_sample: int = None,
+        cmap: str = "brg",
+        xlims: tuple[float, float] = None,
+        output_filename: str = None,
+        figsize: tuple[int, int] = (20, 10),
+        *,
+        shap_values: np.ndarray = None,
+        x_sample: pd.DataFrame = None,
+        show_colorbar: bool = True,
+        include_range: bool = True,
+        show_other_features: bool = True,
+    ) -> tuple[np.ndarray, pd.DataFrame, plt.Figure]:
+        """
+        Plot SHAP beeswarm plot showing individual SHAP values and feature interactions.
+
+        This method creates a beeswarm plot where each dot represents a single sample's
+        SHAP value for a feature. The x-axis shows the SHAP value (impact on model output),
+        the y-axis shows the features, and the color represents the feature value.
+
+        Parameters
+        ----------
+        data_subset : pd.DataFrame, optional
+            Subset of data to use for SHAP calculation. If None, uses data from
+            the specified fold_id.
+        fold_id : int, default 0
+            Which fold's model to use for SHAP calculation. Only used if data_subset
+            is None.
+        n_sample : int, default 10_000
+            Number of samples to use for SHAP calculation.
+        n_features : int, default 10
+            Number of top features to display in the plot.
+        nplot_sample : int, optional
+            Number of samples to actually plot (subset of n_sample). If None,
+            plots all samples. Useful for reducing visual clutter in dense plots.
+        cmap : str, default "brg"
+            Colormap name for the plot. Used to color points by feature value.
+        xlims : tuple[float, float], optional
+            X-axis limits for the plot. If None, automatically determined.
+        output_filename : str, optional
+            Path to save the plot. If None, plot is displayed but not saved.
+        figsize : tuple[int, int], default (20, 10)
+            Figure size as (width, height) in inches.
+        shap_values : np.ndarray, optional
+            Pre-calculated SHAP values with shape (n_samples, n_classes, n_features+1).
+            If provided, skips SHAP calculation. Must be provided together with x_sample.
+        x_sample : pd.DataFrame, optional
+            Sampled features corresponding to the shap_values. Must be provided
+            together with shap_values.
+        show_colorbar : bool, default True
+            Whether to show colorbars for categorical features. Colorbars help
+            interpret the meaning of colors for categorical features.
+        include_range : bool, default True
+            Whether to include all categories between the first and last present category
+            when filtering categorical features. If True, avoids color normalization
+            mismatches by ensuring continuous range of category indices. If False,
+            includes only actually present categories. NaN values (mapped to -1 by XGBoost)
+            are always included when present and labeled as "NA" in the colorbar.
+        show_other_features : bool, default True
+            Whether to add an "Other features" row at the bottom of the beeswarm plot.
+            This row shows the sum of SHAP values for all features not in the top n_features,
+            displayed in grey without coloring. If all features are being plotted
+            (n_features >= total features), this row is not added regardless of this parameter.
+
+        Returns
+        -------
+        tuple[np.ndarray, pd.DataFrame, plt.Figure]
+            A tuple containing:
+            - shap_values: Array of SHAP values with shape (n_samples, n_classes, n_features+1)
+            - X_sample: DataFrame of the sampled data used for SHAP calculation
+            - fig: The matplotlib figure object
+
+        Notes
+        -----
+        - Categorical features are grouped by their category values and displayed with
+          separate colorbars when show_colorbar=True
+        - Features are ranked by mean absolute SHAP value
+        - The plot shows both the magnitude (x-position) and direction (color intensity)
+          of feature impacts
+        - When show_other_features=True, an additional grey row is added showing the sum
+          of SHAP values for features not in the top n_features
+        """
+        # Validate and calculate SHAP values
+        if shap_values is not None and x_sample is not None:
+            # Use pre-calculated values - validate consistency
+            if len(shap_values) != len(x_sample):
+                raise ValueError(
+                    f"Length mismatch: shap_values has {len(shap_values)} samples "
+                    f"but x_sample has {len(x_sample)} samples"
+                )
+        elif shap_values is not None or x_sample is not None:
+            raise ValueError("Both shap_values and x_sample must be provided together, or both must be None")
+        else:
+            # Calculate SHAP values
+            shap_values, x_sample, _ = self.sample_and_calculate_shap_values(
+                data_subset=data_subset, fold_id=fold_id, n_sample=n_sample
+            )
+
+        # Get filtered categorical features based on actual data present
+        filtered_categorical_features = self._get_present_categorical_features(x_sample, include_range=include_range)
+
+        # Prepare data for plotting and group categorical features
+        grouped_features = self._group_categorical_features(
+            categorical_features_dict={col: val[1] for col, val in filtered_categorical_features.items()}
+        )
+        x_sample_plot = self._prepare_data_for_plotting(
+            x_sample, filtered_categorical_features=filtered_categorical_features
+        )
+
+        # Get top features by SHAP importance
+        total_features = shap_values.shape[2] - 1  # Exclude bias term
+        top_features = np.abs(shap_values[:, 1, :-1] - shap_values[:, 0, :-1]).mean(axis=0).argsort()[::-1][:n_features]
+
+        # Filter grouped_features to only include groups represented in top features
+        top_feature_names = [x_sample_plot.columns[i] for i in top_features]
+
+        filtered_grouped_features = {}
+        for group_key, feature_list in grouped_features.items():
+            # Check if any feature in this group is in the top features
+            if any(feature in top_feature_names for feature in feature_list):
+                filtered_grouped_features[group_key] = feature_list
+
+        # Rename features to include group information
+        x_sample_plot = x_sample_plot.rename(
+            columns={
+                feature: f"{feature} [{group_idx}]"
+                for group_idx, features in enumerate(filtered_grouped_features.values(), start=1)
+                for feature in features
+            }
+        )
+
+        # Determine if we should add "other features" row
+        other_features = np.setdiff1d(np.arange(total_features), top_features)
+        add_other_features = show_other_features and len(other_features) > 0
+
+        # Sample for plotting if needed
+        inds_for_plot = np.arange(x_sample_plot.shape[0])
+        if nplot_sample is not None and nplot_sample < x_sample_plot.shape[0]:
+            inds_for_plot = self.rng.choice(inds_for_plot, size=nplot_sample, replace=False)
+
+        # Prepare SHAP values and data
+        base_values_plot = shap_values[0, 1, -1] - shap_values[0, 0, -1]
+
+        if add_other_features:
+            # SHAP values for top features
+            shap_top = (
+                shap_values[inds_for_plot.reshape((-1, 1)), 1, top_features]
+                - shap_values[inds_for_plot.reshape((-1, 1)), 0, top_features]
+            )
+            # SHAP values for "other features" (sum across other features)
+            shap_other = (
+                shap_values[inds_for_plot, 1, :][:, other_features]
+                - shap_values[inds_for_plot, 0, :][:, other_features]
+            ).sum(axis=1, keepdims=True)
+            # Concatenate
+            shap_values_plot = np.hstack([shap_top, shap_other])
+
+            # Data for top features + dummy data for "Other features" (categorical 0 for grey coloring)
+            other_data = pd.DataFrame({"Other features": [0] * len(inds_for_plot)}, index=inds_for_plot).astype(
+                "category"
+            )
+            data_for_plot = pd.concat(
+                [
+                    x_sample_plot.iloc[inds_for_plot, top_features].reset_index(drop=True),
+                    other_data.reset_index(drop=True),
+                ],
+                axis=1,
+            )
+
+            # Feature names including "other features"
+            feature_names = list(x_sample_plot.columns[top_features]) + [f"Other features ({len(other_features)})"]
+
+            # Calculate mean absolute SHAP values for ordering
+            mean_abs_shap = np.abs(shap_values_plot).mean(axis=0)
+            # Force "Other features" (last column) to appear at the bottom
+            order = np.argsort(np.concatenate([mean_abs_shap[:-1], [mean_abs_shap[-1] - 1e6]]))[::-1]
+            # Move "Other features" to the end
+            order = np.concatenate([order[order != shap_values_plot.shape[1] - 1], [shap_values_plot.shape[1] - 1]])
+        else:
+            # No other features - standard processing
+            shap_values_plot = (
+                shap_values[inds_for_plot.reshape((-1, 1)), 1, top_features]
+                - shap_values[inds_for_plot.reshape((-1, 1)), 0, top_features]
+            )
+            data_for_plot = x_sample_plot.iloc[inds_for_plot, top_features]
+            feature_names = list(x_sample_plot.columns[top_features])
+
+            # Order by decreasing mean absolute SHAP values
+            mean_abs_shap = np.abs(shap_values_plot).mean(axis=0)
+            order = np.argsort(mean_abs_shap)[::-1]
+
+        explanation = shap.Explanation(
+            values=shap_values_plot,
+            base_values=base_values_plot,
+            feature_names=feature_names,
+            data=data_for_plot,
+        )
+
+        # Create figure and plot
+        fig, ax = plt.subplots(figsize=figsize)
+        if xlims is None:
+            xlims = [
+                np.floor(shap_values_plot.min() - base_values_plot),
+                np.ceil(shap_values_plot.max() - base_values_plot),
+            ]
+        plt.sca(ax)
+        shap_plot_kwargs = {
+            "color": plt.get_cmap(cmap),
+            "max_display": 30,
+            "alpha": 0.2,
+            "show": False,
+            "plot_size": 0.4,
+            "color_bar": False,
+        }
+        if order is not None:
+            shap_plot_kwargs["order"] = order
+
+        shap.plots.beeswarm(explanation, **shap_plot_kwargs)
+        ax.set_xlabel("SHAP value", fontsize=12)
+        ax.set_xlim(xlims)
+        fig.tight_layout()
+
+        # Add colorbars if requested
+        if show_colorbar and grouped_features:
+            self._add_colorbars_to_plot(fig, filtered_grouped_features, cmap)
+
+        # Save or show the plot
+        if output_filename:
+            fig.savefig(output_filename, bbox_inches="tight", dpi=300)
+
+        return shap_values, x_sample, fig
+
+    def sample_and_calculate_shap_values(
+        self,
+        data_subset: pd.DataFrame = None,
+        fold_id: int = 0,
+        n_sample: int = 10_000,
+    ) -> tuple[np.ndarray, pd.DataFrame, pd.Series]:
+        """
+        Calculate SHAP values for a given dataset and model.
+
+        This is the core method that computes SHAP values using XGBoost's built-in
+        SHAP calculation. It can be used independently or called by the plotting methods.
+
+        The method assumes that categorical features are already correctly encoded
+        according to the mappings stored in srsnv_metadata.json. XGBoost models
+        were trained with enable_categorical=True using these same encodings, ensuring
+        consistency between training and SHAP calculation phases.
+
+        Parameters
+        ----------
+        data_subset : pd.DataFrame, optional
+            Subset of data to use for SHAP calculation. If None, uses data from
+            the specified fold_id plus any test data (NaN fold_id). Data should
+            contain categorical features already encoded as they were during training.
+            NOTE: If data_subset is provided, it overrides the fold_id logic, which
+            might result in using the model with data used in its training.
+        fold_id : int, default 0
+            Which fold's model to use for SHAP calculation. Test data (NaN fold_id)
+            can be processed by any model since it wasn't used in training.
+        n_sample : int, default 10_000
+            Number of samples to use for SHAP calculation. Samples are randomly
+            selected from the provided data.
+
+        Returns
+        -------
+        tuple[np.ndarray, pd.DataFrame, pd.Series]
+            A tuple containing:
+            - shap_values: Array of SHAP values with shape (n_samples, n_classes, n_features+1)
+                          The last column contains the base values.
+            - X_sample: DataFrame of the sampled features used for SHAP calculation
+                       (contains categorical features with their original encodings)
+            - y_sample: Series of the corresponding labels for the sampled data
+
+        Notes
+        -----
+        - Uses XGBoost's pred_contribs=True for efficient SHAP calculation
+        - Categorical features are used directly with their metadata-based encodings
+        - Handles both numerical and categorical features automatically
+        - Ensures reproducible sampling using the class's random_state
+        - Test data (NaN fold_id) can be processed by any model
+        - Assumes XGBoost models trained with "objective": "multi:softprob" which returns
+          3D SHAP arrays with shape (n_samples, n_classes, n_features+1)
+        - TODO: Add support for standard binary classification models that return 2D arrays
+        """
+        # Determine which data to use
+        if data_subset is not None:
+            data_to_use = data_subset
+        else:
+            # Use data from the specified fold, but if fold_id=NaN in data, that's test data
+            # For test data (NaN fold_id), we can use any model since it wasn't used in training
+            fold_mask = self.data[self.fold_id_col] == fold_id
+            test_mask = self.data[self.fold_id_col].isna()
+            data_to_use = self.data[fold_mask | test_mask]
+
+        if len(data_to_use) == 0:
+            raise ValueError(f"No data available for fold {fold_id}")
+
+        # Get the model for this fold
+        if fold_id < 0 or fold_id >= len(self.models):
+            raise ValueError(f"fold_id {fold_id} out of range [0, {len(self.models)-1}]")
+        model = self.models[fold_id]
+
+        # Sample the data (using all features from the model)
+        x_sample, y_sample = self._sample_data(data_to_use, n_sample, self.feature_names)
+
+        # Calculate SHAP values using XGBoost's built-in method
+        if not hasattr(model, "best_ntree_limit"):
+            try:
+                model.best_ntree_limit = model.best_iteration + 1
+            except AttributeError:
+                # best_iteration is only available with early stopping
+                # Use all trees if early stopping wasn't used
+                model.best_ntree_limit = model.n_estimators
+
+        # Create DMatrix with categorical features properly encoded
+        # x_sample contains categorical features with their original metadata-based encodings
+        # enable_categorical=True tells XGBoost to handle them as categorical (not ordinal)
+        x_sample_dm = xgb.DMatrix(data=x_sample, label=y_sample, enable_categorical=True)
+        shap_values = model.get_booster().predict(
+            x_sample_dm, pred_contribs=True, iteration_range=(0, model.best_ntree_limit)
+        )
+
+        return shap_values, x_sample, y_sample
+
+    def get_feature_importance_summary(
+        self,
+        data_subset: pd.DataFrame = None,
+        fold_id: int = 0,
+        n_sample: int = 10_000,
+    ) -> pd.Series:
+        """
+        Get a summary of feature importance based on mean absolute SHAP values.
+
+        Parameters
+        ----------
+        data_subset : pd.DataFrame, optional
+            Subset of data to use for SHAP calculation.
+        fold_id : int, default 0
+            Which fold's model to use for SHAP calculation.
+        n_sample : int, default 10_000
+            Number of samples to use for SHAP calculation.
+
+        Returns
+        -------
+        pd.Series
+            Series with feature names as index and mean absolute SHAP values as values,
+            sorted in descending order of importance.
+        """
+        # Calculate SHAP values
+        shap_values, x_sample, _ = self.sample_and_calculate_shap_values(
+            data_subset=data_subset, fold_id=fold_id, n_sample=n_sample
+        )
+
+        # Calculate mean absolute SHAP values for feature importance
+        # For binary classification, use difference between class 1 and class 0
+        mean_abs_shap_scores = pd.Series(
+            np.abs(shap_values[:, 1, :-1] - shap_values[:, 0, :-1]).mean(axis=0), index=x_sample.columns
+        ).sort_values(ascending=False)
+
+        return mean_abs_shap_scores
+
+    def _get_present_categorical_features(  # noqa: C901
+        self, x_sample: pd.DataFrame, nan_value: str = "NA", *, include_range: bool = True
+    ) -> dict[str, list[str]]:
+        """
+        Create filtered categorical features dict with only present categories.
+
+        This method analyzes the actual data to determine which categorical values
+        are present and creates a filtered version of the categorical features dictionary.
+
+        Parameters
+        ----------
+        x_sample : pd.DataFrame
+            Sample data to analyze for present categories.
+        nan_value : str, default "NA"
+            Value to use for NaN entries in categorical features. This will be included
+            in the filtered categories if NaN values are present in the data.
+        include_range : bool, default True
+            If True, include all categories between the first and last present category
+            to ensure consistent color mapping. If False, include only actually present categories.
+
+        Returns
+        -------
+        dict[str, list[str]]
+            Filtered categorical features dictionary containing only relevant categories
+            in their original metadata ordering. NaN values are represented as 'NA'.
+
+        Notes
+        -----
+        - Preserves original category ordering from metadata
+        - NaN values are included as 'NA' when present in the data
+        - When include_range=True, fills gaps between min and max present categories
+        """
+        filtered_categorical_features = {}
+
+        for feature_name, original_categories in self.categorical_features_dict.items():
+            if feature_name not in x_sample.columns:
+                continue
+
+            # Get unique values, including NaN
+            present_values = x_sample[feature_name].unique()
+
+            # Find which category indices are present
+            present_indices = []
+            has_nan = False
+
+            for val in present_values:
+                if pd.isna(val):
+                    has_nan = True
+                elif str(val) in original_categories:
+                    present_indices.append(original_categories.index(str(val)))
+
+            if not present_indices and not has_nan:
+                continue
+
+            # Determine which indices to include
+            if include_range and present_indices:
+                # Include all categories between min and max present indices
+                min_idx, max_idx = min(present_indices), max(present_indices)
+                category_indices = list(range(min_idx, max_idx + 1))
+            else:
+                # Include only actually present indices
+                category_indices = sorted(present_indices)
+
+            # Build filtered categories list
+            filtered_categories = []
+            if has_nan:
+                filtered_categories.append(nan_value)
+            for idx in category_indices:
+                filtered_categories.append(original_categories[idx])
+
+            if filtered_categories:
+                filtered_categorical_features[feature_name] = (has_nan, filtered_categories)
+
+        return filtered_categorical_features
+
+    def _prepare_data_for_plotting(
+        self, x_sample: pd.DataFrame, filtered_categorical_features: dict[str, tuple[bool, list[str]]] = None
+    ) -> pd.DataFrame:
+        """
+        Prepare data for SHAP plotting by converting categorical features to integer codes.
+
+        This method converts categorical features to integer representations PURELY FOR VISUALIZATION
+        purposes. The categorical features in the input data are already correctly encoded according
+        to the mappings stored in srsnv_metadata.json and used by XGBoost during training.
+
+        The integer conversion here serves only to enable SHAP's beeswarm plot to apply color
+        gradients to categorical features. Without this conversion, categorical features would
+        appear as grey dots in the beeswarm plot because SHAP cannot apply colors to non-numeric data.
+
+        IMPORTANT: This conversion is NOT for model inference. The XGBoost models continue to use
+        the original categorical encodings from the metadata. This method only facilitates proper
+        visualization of SHAP values with meaningful colors and colorbars.
+
+        Parameters
+        ----------
+        x_sample : pd.DataFrame
+            Sample data with original feature values (already properly encoded for XGBoost).
+        filtered_categorical_features : dict[str, tuple[bool, list[str]]], optional
+            Filtered categorical features dictionary (output of
+            self._get_present_categorical_features), containing only the categories
+            actually present in the data. If None, uses self.categorical_features_dict
+            and assumes has_nan=False.
+
+        Returns
+        -------
+        pd.DataFrame
+            Data with categorical features converted to integer codes for visualization.
+            NaN values are mapped to 0, and other categories to their indices in the
+            filtered category list. This maintains color consistency in SHAP plots.
+
+        Notes
+        -----
+        - Integer codes are used directly for color mapping (no normalization to [0, 1])
+        - This ensures proper colorbar alignment regardless of which categories are present
+        - The conversion preserves the order of categories as defined in the metadata
+        - NaN values consistently map to index 0 across all categorical features
+        """
+        if filtered_categorical_features is None:
+            filtered_categorical_features = {col: (False, vals) for col, vals in self.categorical_features_dict.items()}
+        x_sample_display = x_sample.copy()
+
+        # Convert categorical features to integer codes for SHAP visualization
+        for col, (_has_nan, filtered_categories) in filtered_categorical_features.items():
+            if col not in x_sample_display.columns:
+                continue
+            value_to_int_map = {cv: i for i, cv in enumerate(filtered_categories)}
+            x_sample_display[col] = x_sample_display[col].astype(object).map(value_to_int_map)
+            x_sample_display[col] = x_sample_display[col].fillna(0).astype(int)
+
+        return x_sample_display
+
+    def _group_categorical_features(
+        self, categorical_features_dict: dict[str, list[str]] = None
+    ) -> dict[tuple, list[str]]:
+        """
+        Group categorical features by their present category values for colorbar grouping.
+
+        Features are grouped based on the actual set of categories present in the data (including NaN as 'NA'),
+        not the full set of possible categories. This ensures that features with different present categories
+        (including different NaN presence) are grouped separately for colorbar display.
+
+        Parameters
+        ----------
+        categorical_features_dict : dict[str, list[str]], optional
+            Categorical features dictionary to use for grouping. If None, uses
+            self.categorical_features_dict. This should be the filtered dictionary
+            that contains only actually present categories.
+
+        Returns
+        -------
+        dict[tuple, list[str]]
+            Dictionary mapping tuples of present category values to lists of feature names
+            that have those categories. Features with different sets of present
+            categories (including different NaN presence) will be in separate groups.
+
+        Notes
+        -----
+        - Groups are based on the exact set of categories that will appear in the plot.
+        - Features with NaN vs without NaN will be in different groups.
+        - Features with different subsets of categories will be in different groups.
+
+        TODO: shap's _beeswarm.py (with the functions that draw the beeswarm plot) does the
+        following when plotting numerical features: it filters out the bottom and top 5%-iles
+        of the data, and only then plots (so that outliers don't affect the feature value colors).
+        This is a problem for us, because it could be that the first of last categories have less than
+        5% of the data, and thus they will not be shown in the beeswarm plot at all. What is worse, this
+        will not be reflected in the colorbars, which will show the full range of categories.
+        We should implement a similar filtering here, so that the colorbars match the actual categories
+        shown in the beeswarm plot.
+        """
+        if categorical_features_dict is None:
+            categorical_features_dict = self.categorical_features_dict
+
+        # Create a defaultdict to hold lists of feature names for each tuple of values
+        grouped_features = defaultdict(list)
+
+        for feature, values in categorical_features_dict.items():
+            # Convert the list of values to a tuple (so it can be used as a dictionary key)
+            # This now uses the FILTERED categories, ensuring proper grouping
+            value_tuple = tuple(values)
+            # Append the feature name to the list corresponding to this tuple of values
+            grouped_features[value_tuple].append(feature)
+
+        # Convert the defaultdict to a regular dict before returning
+        return dict(grouped_features)
+
+    def _add_colorbars_to_plot(
+        self, fig: plt.Figure, grouped_features: dict[tuple, list[str]], cmap: str = "brg", **kwargs
+    ) -> None:
+        """
+        Add colorbars to a SHAP beeswarm plot for categorical features.
+
+        Parameters
+        ----------
+        fig : plt.Figure
+            The matplotlib figure to add colorbars to.
+        grouped_features : dict[tuple, list[str]]
+            Grouped categorical features from _group_categorical_features.
+        cmap : str, default "brg"
+            Colormap name to use for the colorbars.
+        **kwargs
+            Additional arguments for colorbar positioning and styling.
+        """
+        total_width = kwargs.get("total_width", 0.3)
+        vertical_padding = kwargs.get("vertical_padding", 0.2)
+        start_y = kwargs.get("start_y", 0.9)
+        rotated_padding_factor = kwargs.get("rotated_padding_factor", 8.0)
+
+        group_labels = []
+        for i, (cat_values, features) in enumerate(grouped_features.items()):
+            n_cat = len(cat_values)
+            cbar_length = total_width
+            max_cat_val_length = max(len(f"{val}") for val in cat_values)
+            rotation = 0 if max_cat_val_length <= MAX_LABEL_LENGTH_FOR_HORIZONTAL else 1
+            ha = "center" if rotation == 0 else "right"
+
+            group_label = f"[{i + 1}]"
+            group_labels.append(f"{group_label}: {', '.join(features)}")
+
+            # Calculate the rectangle for the colorbar axis
+            cbar_ax = fig.add_axes([1.1, start_y - 0.03, cbar_length, 0.03])
+
+            # Create the colorbar
+            fig_cbar = fig.colorbar(
+                cm.ScalarMappable(norm=None, cmap=plt.get_cmap(cmap, n_cat)), cax=cbar_ax, orientation="horizontal"
+            )
+            fig_cbar.set_label(group_label, fontsize=12)
+            fig_cbar.set_ticks(np.arange(0, 1, 1 / n_cat) + 1 / (2 * n_cat))
+            fig_cbar.set_ticklabels(cat_values, fontsize=12, rotation=rotation * 25, ha=ha)
+            fig_cbar.outline.set_visible(False)
+
+            # Update the start position for the next colorbar
+            start_y -= vertical_padding + rotation / rotated_padding_factor
+
+        # Add an extra colorbar for numerical features below the others
+        cbar_num_ax = fig.add_axes([1.1, start_y - 0.03, total_width, 0.03])
+        fig_num_cbar = fig.colorbar(
+            cm.ScalarMappable(norm=None, cmap=plt.get_cmap(cmap)), cax=cbar_num_ax, orientation="horizontal"
+        )
+        fig_num_cbar.set_label("Numerical features", fontsize=12)
+        fig_num_cbar.set_ticks([0, 1])
+        fig_num_cbar.set_ticklabels(["Low value", "High value"], fontsize=12)
+        fig_num_cbar.outline.set_visible(False)
+
+    def _get_model_for_fold(self, fold_id: int) -> xgb.XGBClassifier:
+        """
+        Get the model for a specific fold.
+
+        Parameters
+        ----------
+        fold_id : int
+            The fold ID to get the model for.
+
+        Returns
+        -------
+        xgb.XGBClassifier
+            The XGBoost model for the specified fold.
+
+        Raises
+        ------
+        ValueError
+            If fold_id is out of range.
+        """
+        if fold_id < 0 or fold_id >= len(self.models):
+            raise ValueError(f"fold_id {fold_id} out of range [0, {len(self.models)-1}]")
+        return self.models[fold_id]
+
+    def _sample_data(
+        self, data: pd.DataFrame, n_sample: int, features: list[str] = None
+    ) -> tuple[pd.DataFrame, pd.Series]:
+        """
+        Sample data for SHAP calculation.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            Data to sample from.
+        n_sample : int
+            Number of samples to take.
+        features : list[str], optional
+            Features to include. If None, uses all model features.
+
+        Returns
+        -------
+        tuple[pd.DataFrame, pd.Series]
+            Sampled features and corresponding labels.
+        """
+        if features is None:
+            features = self.feature_names
+
+        # Ensure we don't sample more than available
+        n_sample = min(n_sample, len(data))
+
+        # Sample the data
+        if n_sample < len(data):
+            sampled_indices = self.rng.choice(data.index, size=n_sample, replace=False)
+            data_sampled = data.loc[sampled_indices]
+        else:
+            data_sampled = data
+
+        x_sample = data_sampled[features]
+        y_sample = data_sampled[self.label_col]
+
+        return x_sample, y_sample
+
+    def plot_both(  # noqa: PLR0913
+        self,
+        data_subset: pd.DataFrame = None,
+        fold_id: int = 0,
+        n_sample: int = 10_000,
+        *,
+        n_features_importance: int = 15,
+        n_features_beeswarm: int = 10,
+        nplot_sample: int = None,
+        cmap: str = "brg",
+        xlims_importance: tuple[float, float] = None,
+        xlims_beeswarm: tuple[float, float] = None,
+        output_filename_importance: str = None,
+        output_filename_beeswarm: str = None,
+        figsize_importance: tuple[int, int] = (20, 10),
+        figsize_beeswarm: tuple[int, int] = (20, 10),
+        show_colorbar: bool = True,
+        show_other_features: bool = True,
+    ) -> tuple[plt.Figure, plt.Figure, np.ndarray, pd.DataFrame]:
+        """
+        Generate both feature importance and beeswarm plots efficiently.
+
+        This method calculates SHAP values once and generates both plots,
+        avoiding redundant computation. This is much more efficient than
+        calling plot_feature_importance() and plot_beeswarm() separately.
+
+        Parameters
+        ----------
+        data_subset : pd.DataFrame, optional
+            Subset of data to use for SHAP calculation. If None, uses data from
+            the specified fold_id.
+        fold_id : int, default 0
+            Which fold's model to use for SHAP calculation. Only used if data_subset
+            is None.
+        n_sample : int, default 10_000
+            Number of samples to use for SHAP calculation.
+        n_features_importance : int, default 15
+            Number of top features to display in the feature importance plot.
+        n_features_beeswarm : int, default 10
+            Number of top features to display in the beeswarm plot.
+        nplot_sample : int, optional
+            Number of samples to actually plot in beeswarm (subset of n_sample).
+            If None, plots all samples.
+        cmap : str, default "brg"
+            Colormap name for the beeswarm plot.
+        xlims_importance : tuple[float, float], optional
+            X-axis limits for the feature importance plot.
+        xlims_beeswarm : tuple[float, float], optional
+            X-axis limits for the beeswarm plot.
+        output_filename_importance : str, optional
+            Path to save the feature importance plot.
+        output_filename_beeswarm : str, optional
+            Path to save the beeswarm plot.
+        figsize_importance : tuple[int, int], default (20, 10)
+            Figure size for the feature importance plot.
+        figsize_beeswarm : tuple[int, int], default (20, 10)
+            Figure size for the beeswarm plot.
+        show_colorbar : bool, default True
+            Whether to show colorbars in the beeswarm plot.
+        show_other_features : bool, default True
+            Whether to add an "Other features" row to the beeswarm plot showing
+            the sum of SHAP values for features not in the top n_features_beeswarm.
+
+        Returns
+        -------
+        tuple[plt.Figure, plt.Figure, np.ndarray, pd.DataFrame]
+            A tuple containing:
+            - fig_importance: Feature importance plot figure
+            - fig_beeswarm: Beeswarm plot figure
+            - shap_values: Array of SHAP values used for both plots
+            - x_sample: DataFrame of sampled data used for both plots
+        """
+        # Calculate SHAP values once
+        shap_values, x_sample, _ = self.sample_and_calculate_shap_values(
+            data_subset=data_subset, fold_id=fold_id, n_sample=n_sample
+        )
+
+        # Generate feature importance plot using pre-calculated values
+        _, _, fig_importance = self.plot_feature_importance(
+            n_features=n_features_importance,
+            xlims=xlims_importance,
+            output_filename=output_filename_importance,
+            figsize=figsize_importance,
+            shap_values=shap_values,
+            x_sample=x_sample,
+        )
+
+        # Generate beeswarm plot using pre-calculated values
+        _, _, fig_beeswarm = self.plot_beeswarm(
+            n_features=n_features_beeswarm,
+            nplot_sample=nplot_sample,
+            cmap=cmap,
+            xlims=xlims_beeswarm,
+            output_filename=output_filename_beeswarm,
+            figsize=figsize_beeswarm,
+            show_colorbar=show_colorbar,
+            show_other_features=show_other_features,
+            shap_values=shap_values,
+            x_sample=x_sample,
+        )
+
+        return fig_importance, fig_beeswarm, shap_values, x_sample
+
+
+if __name__ == "__main__":
+    import json
+
+    base_path = "/data/Runs/data/srsnv/debug/new_pipeline/test_data/out/"
+    data_df = pd.read_parquet(base_path + "416119_L7402.featuremap_df.parquet")
+    print(data_df.shape)
+
+    with open(base_path + "416119_L7402.srsnv_metadata.json") as f:
+        metadata = json.load(f)
+
+    # Load XGBoost models from the paths in metadata
+    model_paths = metadata["model_paths"]
+    models = []
+
+    for fold, model_path in model_paths.items():  # noqa: B007
+        model = xgb.XGBClassifier()
+        model.load_model(model_path)
+        models.append(model)
+
+    num_CV_folds = len(models)  # noqa: N816
+
+    print(f"Successfully loaded {num_CV_folds} XGBoost models")
+
+    shap_plotter = SHAPPlotter(
+        models,
+        data_df,
+        features_metadata=metadata["features"],
+    )
+
+    shap_values, x_sample, fig = shap_plotter.plot_both(
+        n_sample=1_000,
+    )
+    plt.show()
+    print("done")

--- a/src/srsnv/ugbio_srsnv/trinuc_histogram_plotting.py
+++ b/src/srsnv/ugbio_srsnv/trinuc_histogram_plotting.py
@@ -24,7 +24,7 @@ HIST_COLORS = {
 def _get_trinuc_with_alt_in_order(order: str = "symmetric"):
     """Get trinuc_with_context in right order, so that each SNV in position i
     has the opposite SNV in position i+96.
-    E.g., in position 0 we have A[A>C]A and in posiiton 96 we have A[C>A]A
+    E.g., in position 0 we have A[A>C]A and in position 96 we have A[C>A]A
     """
     if order not in {"symmetric", "reverse"}:
         raise ValueError(f'order must be either "symmetric" or "reverse". Got {order}')
@@ -888,8 +888,8 @@ def calc_and_plot_trinuc_hist(  # noqa: PLR0913
     if collapsed and (order != "reverse"):
         # raise warning that collapsing not by motif and its reverse complement
         warnings.warn(
-            "Collapsing trinuc motifs with their symmetricly reversed partners W[X>Y]Z with W[Y>Z]X "
-            "rather than with their reversed complements. Results may not be as expected. "
+            "Collapsing trinuc motifs with their symmetrically reversed partners W[X>Y]Z with W[Y>Z]X "
+            "rather than with their reverse complements. Results may not be as expected. "
             "Consider using 'reverse' order.",
             stacklevel=2,
         )

--- a/src/srsnv/ugbio_srsnv/trinuc_histogram_plotting.py
+++ b/src/srsnv/ugbio_srsnv/trinuc_histogram_plotting.py
@@ -1,0 +1,930 @@
+import re
+import warnings
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib import gridspec
+
+from ugbio_srsnv.srsnv_utils import FLOW_ORDER, get_trinuc_context_with_alt_fwd_vectorized, is_cycle_skip
+
+# Constants
+IS_FORWARD = "is_forward"
+TRINUC_FORWARD_COUNT = 96
+X_VALUES = list(range(TRINUC_FORWARD_COUNT))
+HIST_COLORS = {
+    "False": "tab:blue",
+    "True": "tab:orange",
+    False: "tab:blue",
+    True: "tab:orange",
+    "all reads": "tab:blue",
+}
+
+
+def _get_trinuc_with_alt_in_order(order: str = "symmetric"):
+    """Get trinuc_with_context in right order, so that each SNV in position i
+    has the opposite SNV in position i+96.
+    E.g., in position 0 we have A[A>C]A and in posiiton 96 we have A[C>A]A
+    """
+    if order not in {"symmetric", "reverse"}:
+        raise ValueError(f'order must be either "symmetric" or "reverse". Got {order}')
+    if order == "symmetric":
+        trinuc_ref_alt = [
+            c1 + r + c2 + a
+            for r, a in (("A", "C"), ("A", "G"), ("A", "T"), ("C", "G"), ("C", "T"), ("G", "T"))
+            for c1 in ("A", "C", "G", "T")
+            for c2 in ("A", "C", "G", "T")
+            if r != a
+        ] + [
+            c1 + r + c2 + a
+            for a, r in (("A", "C"), ("A", "G"), ("A", "T"), ("C", "G"), ("C", "T"), ("G", "T"))
+            for c1 in ("A", "C", "G", "T")
+            for c2 in ("A", "C", "G", "T")
+            if r != a
+        ]
+    elif order == "reverse":
+        trinuc_ref_alt = [
+            c1 + r + c2 + a
+            for r, a in (("A", "C"), ("A", "G"), ("A", "T"), ("C", "G"), ("C", "T"), ("G", "T"))
+            for c1 in ("A", "C", "G", "T")
+            for c2 in ("A", "C", "G", "T")
+            if r != a
+        ] + [
+            c1 + r + c2 + a
+            for r, a in (("T", "G"), ("T", "C"), ("T", "A"), ("G", "C"), ("G", "A"), ("C", "A"))
+            for c2 in ("T", "G", "C", "A")
+            for c1 in ("T", "G", "C", "A")
+            if r != a
+        ]
+    trinuc_index = np.array([f"{t[0]}[{t[1]}>{t[3]}]{t[2]}" for t in trinuc_ref_alt])
+    snv_labels = [" ".join(trinuc_snv[2:5]) for trinuc_snv in trinuc_index[np.arange(0, 16 * 12, 16)]]
+    return trinuc_ref_alt, trinuc_index, snv_labels
+
+
+def plot_trinuc_hist(  # noqa: C901
+    hist_stats,
+    labels=None,
+    panel_num=0,
+    ax=None,
+    ylim=None,
+    x_values=None,
+    hist_colors=None,
+    xtick_fontsize=10,
+    order="symmetric",
+    *,
+    add_annotations=True,
+):
+    if labels is None:
+        labels = [False, True]
+    if x_values is None:
+        x_values = X_VALUES
+    if hist_colors is None:
+        hist_colors = HIST_COLORS
+
+    trinuc_symmetric_ref_alt, symmetric_index, snv_labels = _get_trinuc_with_alt_in_order(order=order)
+    trinuc_is_cycle_skip = np.array([is_cycle_skip(tcwa, flow_order=FLOW_ORDER) for tcwa in trinuc_symmetric_ref_alt])
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(16, 3))
+    inds = np.array(x_values) + 96 * panel_num
+    bars = {}
+    # Plot histogram bars
+    for label in labels:
+        bars[label] = ax.bar(x_values, hist_stats[label][inds], color=hist_colors[f"{label}"], width=1.0, alpha=0.5)
+    if ylim is None:
+        ylim = 1.05 * max([hist_stats[label].max() for label in labels])
+        # _, ylim = ax.get_ylim()
+    # Plot separators for ref, alt pair-groups
+    for j in range(5):
+        ax.plot([(j + 1) * 16 - 0.5] * 2, [0, ylim], "k--")
+    ax.set_xticks(x_values, symmetric_index[inds], rotation=90, fontsize=xtick_fontsize)
+    tick_label_colors = ["green" if trinuc_is_cycle_skip[j] else "red" for j in inds]
+    for j in x_values:
+        ax.get_xticklabels()[j].set_color(tick_label_colors[j])
+    ax.tick_params(axis="x", pad=-2)
+    ax.grid(visible=True)
+    ax.set_xlim([-0.5, 95.5])
+    ax.set_ylim([0, ylim])
+    ax.grid(visible=True, axis="both", alpha=0.75, linestyle=":")
+
+    # Add ref > alt annotations (optional)
+    if add_annotations:
+        snv_positions = [8, 24, 40, 56, 72, 88]  # Midpoint for each SNV titles in plot
+        i = panel_num
+        for label, pos in zip(snv_labels[6 * i : 6 * i + 6], snv_positions, strict=False):
+            ax.annotate(
+                label,
+                xy=(pos, ylim),  # Position at the top of the plot
+                xytext=(-2, 6),  # Offset from the top of the plot
+                textcoords="offset points",
+                ha="center",
+                fontsize=12,
+                fontweight="bold",
+            )
+    return ax, bars
+
+
+def plot_trinuc_qual(  # noqa: C901, PLR0912, PLR0915
+    stats_df,
+    panel_num=0,
+    ax=None,
+    x_values=None,
+    xtick_fontsize=10,
+    order="symmetric",
+    qual_colors=None,
+    *,
+    add_annotations=True,
+):
+    """Plot trinucleotide quality statistics.
+
+    Parameters
+    ----------
+    stats_df : pd.DataFrame
+        DataFrame with quality statistics in new format (mixed=all, mixed=True, mixed=False)
+    panel_num : int
+        Panel number (0 or 1 for forward/reverse)
+    ax : matplotlib.Axes, optional
+        Axis to plot on
+    x_values : list, optional
+        X-axis values
+    xtick_fontsize : int
+        Font size for x-tick labels
+    order : str
+        Trinucleotide ordering
+    qual_colors : dict, optional
+        Colors for quality lines
+
+    Returns
+    -------
+    ax : matplotlib.Axes
+        The axis
+    lines : dict
+        Dictionary of line objects for legend
+    """
+    if x_values is None:
+        x_values = X_VALUES
+    if qual_colors is None:
+        qual_colors = {"mixed=all": "tab:blue", "mixed=True": "tab:green", "mixed=False": "tab:red"}
+
+    trinuc_symmetric_ref_alt, symmetric_index, snv_labels = _get_trinuc_with_alt_in_order(order=order)
+    trinuc_is_cycle_skip = np.array([is_cycle_skip(tcwa, flow_order=FLOW_ORDER) for tcwa in trinuc_symmetric_ref_alt])
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(16, 3))
+
+    inds = np.array(x_values) + 96 * panel_num
+    lines = {}
+
+    # Determine which mixed categories to plot
+    # Check if we have mixed=True and mixed=False columns
+    has_mixed_true = any("mixed=True median_qual" in col for col in stats_df.columns)
+    has_mixed_false = any("mixed=False median_qual" in col for col in stats_df.columns)
+    has_mixed_all = any("mixed=all median_qual" in col for col in stats_df.columns)
+
+    # Determine which categories to plot based on priority
+    if has_mixed_true and has_mixed_false:
+        # If we have both True and False, plot only these (not 'all')
+        mixed_categories = ["mixed=True", "mixed=False"]
+    elif has_mixed_all:
+        # If we only have 'all', plot only this
+        mixed_categories = ["mixed=all"]
+    else:
+        # No quality data available
+        mixed_categories = []
+
+    # Create extended x_values for step plotting (like in calc_and_plot_trinuc_plot)
+    x_values_ext = (
+        [x_values[0] - (x_values[1] - x_values[0]) / 2] + x_values + [x_values[-1] + (x_values[-1] - x_values[-2]) / 2]
+    )
+    inds_ext = [inds[0]] + list(inds) + [inds[-1]]
+
+    # Plot quality lines and shaded areas for each mixed category
+    for mixed_cat in mixed_categories:
+        median_col = f"{mixed_cat} median_qual"
+        q1_col = f"{mixed_cat} q1_qual"
+        q2_col = f"{mixed_cat} q2_qual"
+
+        if median_col in stats_df.columns:
+            color = qual_colors.get(mixed_cat, "black")
+
+            # Get data for this panel (extended for step plotting)
+            median_data = stats_df[median_col].iloc[inds_ext]
+            q1_data = stats_df[q1_col].iloc[inds_ext] if q1_col in stats_df.columns else median_data
+            q2_data = stats_df[q2_col].iloc[inds_ext] if q2_col in stats_df.columns else median_data
+
+            # Plot shaded area for quantile range
+            ax.fill_between(x_values_ext, q1_data, q2_data, step="mid", color=color, alpha=0.2)
+
+            # Plot median line using step plot (like in reference implementation)
+            (line,) = ax.step(
+                x_values_ext,
+                median_data,
+                where="mid",
+                color=color,
+                alpha=0.7,
+                label=(
+                    mixed_cat.replace("mixed=", "")
+                    .replace("all", "All reads")
+                    .replace("True", "Mixed reads")
+                    .replace("False", "Non-mixed reads")
+                ),
+            )
+            lines[mixed_cat] = line
+
+    # Set x-tick labels and colors based on cycle skip
+    ax.set_xticks(x_values)
+    ax.set_xticklabels(symmetric_index[inds], rotation=90, fontsize=xtick_fontsize)
+    tick_label_colors = ["green" if trinuc_is_cycle_skip[j] else "red" for j in inds]
+    for j, _ in enumerate(x_values):
+        ax.get_xticklabels()[j].set_color(tick_label_colors[j])
+
+    ax.tick_params(axis="x", pad=-2)
+    ax.grid(visible=True, axis="both", alpha=0.75, linestyle=":")
+    ax.set_xlim([-0.5, 95.5])
+
+    # Set y-limits based on data range
+    if mixed_categories:
+        all_q1s = []
+        all_q2s = []
+        for mixed_cat in mixed_categories:
+            q1_col = f"{mixed_cat} q1_qual"
+            q2_col = f"{mixed_cat} q2_qual"
+            if q1_col in stats_df.columns:
+                all_q1s.extend(stats_df[q1_col].dropna().values)
+            if q2_col in stats_df.columns:
+                all_q2s.extend(stats_df[q2_col].dropna().values)
+        if all_q1s and all_q2s:
+            snvq_min = min(all_q1s)
+            snvq_max = max(all_q2s)
+            ymin = snvq_min - 0.03 * (snvq_max - snvq_min)
+            ymax = snvq_max + 0.03 * (snvq_max - snvq_min)
+            ax.set_ylim([ymin, ymax])
+
+    # Plot separators for ref, alt pair-groups
+    ylim_min, ylim_max = ax.get_ylim()
+    for j in range(5):
+        ax.plot([(j + 1) * 16 - 0.5] * 2, [ylim_min, ylim_max], "k--")
+
+    # Add ref > alt annotations (optional)
+    if add_annotations:
+        snv_positions = [8, 24, 40, 56, 72, 88]
+        i = panel_num
+        for label, pos in zip(snv_labels[6 * i : 6 * i + 6], snv_positions, strict=False):
+            ylim = ax.get_ylim()[1]
+            ax.annotate(
+                label,
+                xy=(pos, ylim),
+                xytext=(-2, 6),
+                textcoords="offset points",
+                ha="center",
+                fontsize=12,
+                fontweight="bold",
+            )
+
+    return ax, lines
+
+
+def calc_trinuc_stats(  # noqa: C901, PLR0912, PLR0913, PLR0915
+    plot_df,
+    trinuc_col="tcwa_fwd",
+    label_col="label",
+    is_forward_col="is_forward",
+    qual_col="SNVQ",
+    cycle_skip_col="is_cycle_skip",
+    is_mixed_col="is_mixed",
+    order: str = "symmetric",
+    labels=None,
+    q1: float = 0.1,
+    q2: float = 0.9,
+    motif_orientation: str = "seq_dir",
+    *,
+    collapsed: bool = False,
+    include_quality: bool = True,
+    include_cycle_skip: bool = True,
+):
+    """Calculate trinuc stats (histogram and optionally quality) for each label, return as DataFrame.
+
+    Parameters
+    ----------
+    plot_df : pd.DataFrame
+        Input dataframe with trinucleotide and quality data
+    trinuc_col : str
+        Column name containing trinucleotide context with alt
+    label_col : str
+        Column name for grouping labels
+    is_forward_col : str
+        Column name for forward/reverse orientation
+    qual_col : str
+        Column name for quality values
+    cycle_skip_col : str
+        Column name for cycle skip information
+    order : str
+        Order of trinucleotides ("symmetric" or "reverse")
+    labels : list, optional
+        List of labels to include
+    q1, q2 : float
+        Quantiles for quality statistics
+    collapsed : bool
+        Whether to collapse forward/reverse into single values
+    motif_orientation : str
+        "seq_dir": as read in sequencing direction,
+        "ref_dir": aligned to reference direction by reverse-complementing reverse-strand reads, or
+        "fwd_only": using only forward-strand reads.
+    include_quality : bool
+        Whether to include quality statistics
+    include_cycle_skip : bool
+        Whether to include cycle skip statistics
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with histogram counts, quality stats, and cycle skip info indexed by trinucleotide context
+    """
+    trinuc_symmetric_ref_alt, symmetric_index, snv_labels = _get_trinuc_with_alt_in_order(order=order)
+    plot_df = plot_df.copy()
+    if motif_orientation not in {"seq_dir", "ref_dir", "fwd_only"}:
+        raise ValueError(f"{motif_orientation=} is not one of the allowed values {{'seq_dir', 'ref_dir', 'fwd_only'}}.")
+    if motif_orientation == "fwd_only":
+        plot_df = plot_df.loc[plot_df[is_forward_col], :]
+    elif motif_orientation == "seq_dir":
+        plot_df[trinuc_col] = get_trinuc_context_with_alt_fwd_vectorized(plot_df[trinuc_col], plot_df[is_forward_col])
+    plot_df["trinuc_context_with_alt_int"] = plot_df[trinuc_col].map(
+        {trinuc: i for i, trinuc in enumerate(trinuc_symmetric_ref_alt)}
+    )
+
+    if labels is None:
+        plot_df[label_col] = "all reads"
+        labels = ["all reads"]
+
+    stats_data = {}
+    total_snvs_per_label = {}
+
+    for label in labels:
+        hist_cond = plot_df[label_col] == label
+
+        # Calculate histogram stats
+        counts = (
+            plot_df.loc[hist_cond, "trinuc_context_with_alt_int"]
+            .value_counts()
+            .reindex(range(2 * TRINUC_FORWARD_COUNT), fill_value=0)
+            .sort_index()
+            .to_numpy()
+        )
+        total_snvs_per_label[label] = counts.sum()
+        normed = counts / counts.sum() if counts.sum() > 0 else counts
+        if collapsed:
+            normed = normed[:TRINUC_FORWARD_COUNT] + normed[TRINUC_FORWARD_COUNT:]
+
+        # Store histogram data
+        hist_col_name = f"{label} ({total_snvs_per_label[label]})"
+        stats_data[hist_col_name] = normed
+
+    # Calculate quality stats if requested
+    if include_quality and qual_col in plot_df.columns:
+        qual_cond = plot_df[label_col]
+        qual_subset = plot_df.loc[qual_cond].copy()
+
+        if not qual_subset.empty:
+            stats_to_calculate = {
+                "median_qual": "median",
+                "q1_qual": lambda x: x.quantile(q1),
+                "q2_qual": lambda x: x.quantile(q2),
+                "count": "count",
+            }
+
+            # Calculate stats on all data first
+            all_qual_stats = (
+                qual_subset.groupby("trinuc_context_with_alt_int")[qual_col]
+                .agg(list(stats_to_calculate.values()))
+                .reindex(range(TRINUC_FORWARD_COUNT * 2), fill_value=np.nan)
+            )
+
+            # Store all data stats with 'all' prefix
+            for i, (stat_key, _) in enumerate(stats_to_calculate.items()):
+                stat_array = all_qual_stats.iloc[:, i].to_numpy()
+                if collapsed:
+                    # Average forward and reverse for collapsed mode
+                    stat_array = (stat_array[:TRINUC_FORWARD_COUNT] + stat_array[TRINUC_FORWARD_COUNT:]) / 2
+                stats_data[f"mixed=all {stat_key}"] = stat_array
+
+            if is_mixed_col in qual_subset.columns:
+                # Calculate stats for each is_mixed value slice
+                for is_mixed in qual_subset[is_mixed_col].unique():
+                    mixed_subset = qual_subset[qual_subset[is_mixed_col] == is_mixed]
+                    if not mixed_subset.empty:
+                        mixed_qual_stats = (
+                            mixed_subset.groupby("trinuc_context_with_alt_int")[qual_col]
+                            .agg(list(stats_to_calculate.values()))
+                            .reindex(range(TRINUC_FORWARD_COUNT * 2), fill_value=np.nan)
+                        )
+
+                        # Store mixed-specific stats
+                        for i, (stat_key, _) in enumerate(stats_to_calculate.items()):
+                            stat_array = mixed_qual_stats.iloc[:, i].to_numpy()
+                            if collapsed:
+                                # Average forward and reverse for collapsed mode
+                                stat_array = (stat_array[:TRINUC_FORWARD_COUNT] + stat_array[TRINUC_FORWARD_COUNT:]) / 2
+                            stats_data[f"mixed={is_mixed} {stat_key}"] = stat_array
+
+    # Calculate cycle skip stats if requested
+    if include_cycle_skip and cycle_skip_col in plot_df.columns:
+        cycle_skip_stats = (
+            plot_df.groupby("trinuc_context_with_alt_int")[cycle_skip_col].mean().reindex(range(192), fill_value=np.nan)
+        )
+        if collapsed:
+            cycle_skip_stats = (
+                cycle_skip_stats.iloc[:TRINUC_FORWARD_COUNT].to_numpy()
+                + cycle_skip_stats.iloc[TRINUC_FORWARD_COUNT:].to_numpy()
+            ) / 2
+        stats_data["is_cycle_skip"] = cycle_skip_stats.to_numpy() if not collapsed else cycle_skip_stats
+    elif include_cycle_skip:
+        # Column doesn't exist, fill with None/NaN
+        length = TRINUC_FORWARD_COUNT if collapsed else TRINUC_FORWARD_COUNT * 2
+        stats_data["is_cycle_skip"] = [None] * length
+
+    # Set index
+    if collapsed:
+        index = symmetric_index[:TRINUC_FORWARD_COUNT]
+    else:
+        index = symmetric_index
+
+    # was:
+    # hist_stats_df = pd.DataFrame(
+    #     {f'{label} ({total_snvs_per_label[label]})': hist_stats[label] for label in labels},
+    #     index=index
+    # )
+    # return hist_stats_df
+    stats_df = pd.DataFrame(stats_data, index=index)
+    return stats_df
+
+
+def reverse_engineer_hist_stats(hist_stats_df: pd.DataFrame):
+    labels = []
+    hist_stats = {}
+    total_snvs_per_label = {}
+
+    for col in hist_stats_df.columns:
+        # Extract label and count using regex
+        match = re.match(r"^(.*?)\s*\((\d+)\)$", col)
+        if match:
+            label, count = match.group(1), int(match.group(2))
+        else:
+            raise ValueError(f"Column name '{col}' is not in the expected format 'label (count)'")
+
+        labels.append(label)
+        hist_stats[label] = hist_stats_df[col].to_numpy()
+        total_snvs_per_label[label] = count
+
+    return labels, hist_stats, total_snvs_per_label
+
+
+def plot_trinuc_hist_and_qual_panels(  # noqa: C901, PLR0912, PLR0913, PLR0915
+    stats_df,
+    q1=0.1,
+    q2=0.9,
+    order="symmetric",
+    suptitle=None,
+    figsize=None,
+    collapsed=None,
+    ytick_fontsize=12,
+    xtick_fontsize=10,
+    ylabel_fontsize=16,
+    hspace=0.1,
+    bottom_scale=1.0,
+    hist_to_qual_height_ratio=2.0,
+    motif_orientation="seq_dir",
+):
+    """Plot trinuc histogram and quality panels from stats_df DataFrame.
+
+    Layout:
+    - For collapsed mode: Quality panel above histogram panel
+    - For non-collapsed mode: Quality1, Hist1, [space], Quality2, Hist2
+    """
+    # Extract histogram labels from columns
+    hist_labels = []
+    hist_stats = {}
+    total_snvs_per_label = {}
+
+    for col in stats_df.columns:
+        if not col.endswith(("_median_qual", "_q1_qual", "_q2_qual")) and col != "is_cycle_skip":
+            # Extract label and count using regex
+            match = re.match(r"^(.*?)\s*\((\d+)\)$", col)
+            if match:
+                label, count = match.group(1), int(match.group(2))
+                hist_labels.append(label)
+                hist_stats[label] = stats_df[col].to_numpy()
+                total_snvs_per_label[label] = count
+
+    # Infer collapsed if not given
+    hist_len = stats_df.shape[0]
+    if collapsed is None:
+        collapsed = hist_len == TRINUC_FORWARD_COUNT
+
+    # Determine layout
+    if figsize is None:
+        figsize = (18, 5) if collapsed else (18, 10)
+    fig = plt.figure(figsize=figsize)
+    height_ratios = [1, hist_to_qual_height_ratio]  # Configurable ratio
+
+    if collapsed:
+        # Simple case: Quality above histogram with no space
+        gs = gridspec.GridSpec(2, 1, height_ratios=height_ratios, hspace=0.0)
+    else:
+        # Complex case: Need custom spacing between panels
+        # Create two separate gridspecs for the two panel pairs
+        gs_top = gridspec.GridSpec(
+            2, 1, height_ratios=height_ratios, hspace=0.0, top=0.95, bottom=0.5 + hspace / 2
+        )  # Top half of figure
+        gs_bottom = gridspec.GridSpec(
+            2, 1, height_ratios=height_ratios, hspace=0.0, top=0.5 - hspace / 2, bottom=0.05
+        )  # Bottom half of figure
+
+    # Create panels
+    axes = []
+    bars_for_legend = {}
+    lines_for_legend = {}
+
+    panels_to_plot = 1 if collapsed else 2
+
+    for panel_idx in range(panels_to_plot):
+        if collapsed:
+            qual_ax = fig.add_subplot(gs[0])
+            hist_ax = fig.add_subplot(gs[1], sharex=qual_ax)
+        elif panel_idx == 0:
+            # First panel pair (top)
+            qual_ax = fig.add_subplot(gs_top[0])
+            hist_ax = fig.add_subplot(gs_top[1], sharex=qual_ax)
+        else:
+            # Second panel pair (bottom)
+            qual_ax = fig.add_subplot(gs_bottom[0])
+            hist_ax = fig.add_subplot(gs_bottom[1], sharex=qual_ax)
+
+        # Plot quality panel
+        _, lines = plot_trinuc_qual(
+            stats_df, panel_num=panel_idx, ax=qual_ax, order=order, xtick_fontsize=xtick_fontsize, add_annotations=True
+        )
+        qual_ax.set_ylabel("SNVQ", fontsize=ylabel_fontsize)
+        qual_ax.tick_params(axis="y", labelsize=ytick_fontsize)
+
+        # Remove x-tick labels from quality panel since it shares x-axis
+        qual_ax.set_xticklabels([])
+
+        # Plot histogram panel
+        _, bars = plot_trinuc_hist(
+            hist_stats,
+            labels=hist_labels,
+            panel_num=panel_idx,
+            ax=hist_ax,
+            order=order,
+            xtick_fontsize=xtick_fontsize,
+            add_annotations=False,
+        )
+        hist_ax.set_ylabel("Density", fontsize=ylabel_fontsize)
+        hist_ax.tick_params(axis="y", labelsize=ytick_fontsize)
+
+        # Store for legend (only need one set)
+        if panel_idx == 0:
+            bars_for_legend = bars
+            lines_for_legend = lines
+
+        axes.extend([qual_ax, hist_ax])
+
+    # Create legends with improved labels
+    handles_hist, labels_hist = [], []
+    handles_qual, labels_qual = [], []
+
+    for label in hist_labels:
+        if label in bars_for_legend:
+            handles_hist.append(bars_for_legend[label].patches[0])
+            # Determine TP/FP based on label
+            if str(label).lower() in ["true", "1", 1, True]:
+                label_name = "TP"
+            elif str(label).lower() in ["false", "0", 0, False]:
+                label_name = "FP"
+            else:
+                label_name = str(label)
+            labels_hist.append(f"{label_name} ({total_snvs_per_label[label]})")
+
+    for mixed_cat in lines_for_legend:
+        handles_qual.append(lines_for_legend[mixed_cat])
+        clean_label = (
+            mixed_cat.replace("mixed=", "")
+            .replace("all", "All reads")
+            .replace("True", "Mixed reads")
+            .replace("False", "Non-mixed reads")
+        )
+        labels_qual.append(clean_label)
+
+    # Apply bottom_scale to layout
+    bottom_margin = 0.15 * bottom_scale
+    fig.tight_layout(rect=[0, bottom_margin, 1, 1])
+
+    # Position legends with bottom_scale
+    legend_y_offset = (-0.08 if collapsed else -0.165) * bottom_scale  # text_y
+    # legend_y_offset = text_y - 0.04* bottom_scale  # Adjusted for legend position
+    # legend_y_offset = -0.08 * bottom_scale
+    if collapsed:
+        hist_bbox = (0.24, legend_y_offset)
+        qual_bbox = (0.5, legend_y_offset)
+    else:
+        hist_bbox = (0.24, legend_y_offset * 0.75)
+        qual_bbox = (0.5, legend_y_offset * 0.75)
+
+    fig.legend(
+        handles_hist,
+        labels_hist,
+        title="Histogram: Labels (# SNVs total)",
+        fontsize=14,
+        title_fontsize=14,
+        loc="lower center",
+        bbox_to_anchor=hist_bbox,
+        ncol=1,
+        frameon=False,
+    )
+
+    fig.legend(
+        handles_qual,
+        labels_qual,
+        title=f"SNVQ on TP (median + {int(q1*100)}%-{int(q2*100)}% range)",
+        fontsize=14,
+        title_fontsize=14,
+        loc="lower center",
+        bbox_to_anchor=qual_bbox,
+        ncol=1,
+        frameon=False,
+    )
+
+    # Explanatory text with bottom_scale
+    if motif_orientation == "fwd_only":
+        is_forward_text = "(forward reads only)"
+    elif motif_orientation == "seq_dir":
+        is_forward_text = "(sequencing direction)"
+    elif motif_orientation == "ref_dir":
+        is_forward_text = "(reference direction)"
+    # For collapsed=False case, align bottom of explanatory text with bottom of legends
+    if not collapsed:
+        # Calculate text positions so bottom aligns with legend bottom
+        legend_bottom = legend_y_offset * 0.75  # Same as legend position
+        text_y_top = legend_bottom + 0.075  # Top line position (bottom + 3 lines * line_spacing)
+        text_y_middle = legend_bottom + 0.045  # Middle line position
+        text_y_bottom = legend_bottom + 0.02  # Bottom line position (aligned with legend bottom)
+    else:
+        # Keep original positioning for collapsed case (to be adjusted later)
+        legend_bottom = legend_y_offset * 0.75
+        text_y_top = legend_bottom + 0.12  # Top line position (bottom + 3 lines * line_spacing)
+        text_y_middle = legend_bottom + 0.07  # Middle line position
+        text_y_bottom = legend_bottom + 0.02  # Bottom line position (aligned with legend bottom)
+
+    fig.text(
+        0.7,  # x-position (slightly to the right of the second legend)
+        text_y_top,  # y-position (adjust as necessary)
+        f"Trinuc-SNV {is_forward_text}:",
+        ha="left",  # Horizontal alignment
+        fontsize=14,  # Font size
+        color="black",  # Text color
+    )
+    fig.text(
+        0.73,  # x-position (slightly to the right of the second legend)
+        text_y_middle,  # y-position (adjust as necessary)
+        "Green: Cycle skip",
+        ha="left",  # Horizontal alignment
+        fontsize=14,  # Font size
+        color="green",  # Text color
+    )
+    fig.text(
+        0.73,  # x-position (slightly to the right of the second legend)
+        text_y_bottom,  # y-position (adjust as necessary)
+        "Red: No cycle skip",
+        ha="left",  # Horizontal alignment
+        fontsize=14,  # Font size
+        color="red",  # Text color
+    )
+    if suptitle:
+        fig.suptitle(suptitle, fontsize=20)
+
+    return fig
+
+
+def plot_trinuc_hist_panels(  # noqa: C901, PLR0912, PLR0915
+    hist_stats_df,
+    order="symmetric",
+    suptitle=None,
+    figsize=None,
+    collapsed=None,
+    ytick_fontsize=12,
+    xtick_fontsize=10,
+    ylabel_fontsize=16,
+    bottom_scale=1.0,
+    motif_orientation: str = "seq_dir",
+):
+    """Plot trinuc histogram panels from hist_stats_df DataFrame."""
+    # Reverse engineer labels, hist_stats dict, and total_snvs_per_label
+    labels, hist_stats, total_snvs_per_label = reverse_engineer_hist_stats(hist_stats_df)
+    # Infer collapsed if not given
+    hist_len = hist_stats_df.shape[0]  # len(next(iter(hist_stats.values())))
+    if collapsed is None:
+        collapsed = hist_len == TRINUC_FORWARD_COUNT
+    figrows = 1 if collapsed else 2
+    if figsize is None:
+        figsize = (18, 4) if collapsed else (18, 8)
+    fig = plt.figure(figsize=figsize)
+    gs = gridspec.GridSpec(figrows, 1, height_ratios=[1] * figrows, hspace=0.4)
+    ax_hist_orig = fig.add_subplot(gs[0])
+    _, bars = plot_trinuc_hist(
+        hist_stats, labels=labels, panel_num=0, ax=ax_hist_orig, order=order, xtick_fontsize=xtick_fontsize
+    )
+    ax_hist_orig.set_ylabel("Density", fontsize=ylabel_fontsize)  # <-- Add ylabel
+    ax_hist_orig.tick_params(axis="y", labelsize=ytick_fontsize)  # <-- Set ytick label size
+    if not collapsed:
+        ax_hist_rev = fig.add_subplot(gs[1])
+        plot_trinuc_hist(
+            hist_stats, labels=labels, panel_num=1, ax=ax_hist_rev, order=order, xtick_fontsize=xtick_fontsize
+        )
+        ax_hist_rev.set_ylabel("Density", fontsize=ylabel_fontsize)  # <-- Add ylabel
+        ax_hist_rev.tick_params(axis="y", labelsize=ytick_fontsize)  # <-- Set ytick label size
+    # Legend
+    handles_frac, labels_frac = [], []
+    for label in labels:
+        if str(label).lower() in ["true", "1", 1, True]:
+            label_name = "TP"
+        elif str(label).lower() in ["false", "0", 0, False]:
+            label_name = "FP"
+        else:
+            label_name = str(label)
+        handles_frac.append(bars[label].patches[0])
+        labels_frac.append(f"{label_name} ({total_snvs_per_label[label]})")
+    fig.tight_layout(rect=[0, 0.1, 1, 1])
+    # Calculate scaling factor based on height/width ratio
+    width, height = figsize
+    # Reference aspect ratio (looks good at 18x8)
+    ref_width, ref_height = (18, 4) if collapsed else (18, 8)
+    ref_aspect = ref_height / ref_width
+    current_aspect = height / width
+    # Scale bottom margin: higher aspect ratio (taller) needs less bottom margin
+    aspect_scale = (ref_aspect / current_aspect) * bottom_scale
+
+    # Use scaled bottom margin
+    base_bottom = 0.10 * (1.5 * int(collapsed) + 1)
+    plt.subplots_adjust(bottom=base_bottom * aspect_scale, top=1 - 0.10 * (2 * int(collapsed)))
+    # Also scale bbox_to_anchor for the legend
+    # For collapsed=True case, use less aggressive scaling to avoid too much white space
+    if collapsed:
+        legend_y = -0.12  # Fixed position for collapsed case to reduce white space
+    else:
+        legend_y = -0.08 * aspect_scale  # Original scaling for non-collapsed case
+
+    fig.legend(
+        handles_frac,
+        labels_frac,
+        title="Histogram: Labels (# SNVs total)",
+        fontsize=14,
+        title_fontsize=14,
+        loc="lower center",
+        bbox_to_anchor=(0.33, legend_y),
+        ncol=2,
+        frameon=False,
+    )
+    # Explanatory text
+    # Explanatory text with bottom_scale
+    if motif_orientation == "fwd_only":
+        is_forward_text = "(forward reads only)"
+    elif motif_orientation == "seq_dir":
+        is_forward_text = "(sequencing direction)"
+    elif motif_orientation == "ref_dir":
+        is_forward_text = "(reference direction)"
+
+    # Adjust text positioning for collapsed case
+    if collapsed:
+        # Fixed positioning for collapsed case to align with adjusted legend
+        text_base_y = -0.075  # Closer to the plot
+        text_height = 0.05  # Reduced spacing between lines
+    else:
+        # Original positioning for non-collapsed case
+        text_base_y = -0.06
+        text_height = 0.025
+
+    fig.text(
+        0.63, text_base_y + 2 * text_height, f"Trinuc-SNV {is_forward_text}:", ha="left", fontsize=14, color="black"
+    )
+    fig.text(0.66, text_base_y + text_height, "Green: Cycle skip", ha="left", fontsize=14, color="green")
+    fig.text(0.66, text_base_y, "Red: No cycle skip", ha="left", fontsize=14, color="red")
+    if suptitle:
+        fig.suptitle(suptitle, fontsize=20)
+    return fig
+
+
+def calc_and_plot_trinuc_hist(  # noqa: PLR0913
+    plot_df,
+    trinuc_col,
+    label_col="label",
+    is_forward_col="is_forward",
+    qual_col="SNVQ",
+    order: str = "symmetric",
+    hspace=0.1,
+    suptitle=None,
+    figsize=None,
+    labels=None,
+    hist_to_qual_height_ratio=2.0,
+    bottom_scale=1.0,
+    q1: float = 0.1,
+    q2: float = 0.9,
+    motif_orientation: str = "seq_dir",
+    *,
+    collapsed=False,
+    include_quality: bool = False,
+):
+    """Calculate and plot trinuc histogram, optionally with quality panels.
+
+    Parameters
+    ----------
+    plot_df : pd.DataFrame
+        Input dataframe
+    trinuc_col : str
+        Column name for trinucleotide context
+    label_col : str
+        Column name for labels
+    is_forward_col : str
+        Column name for forward/reverse orientation
+    qual_col : str
+        Column name for quality values
+    order : str
+        Trinucleotide ordering
+    suptitle : str, optional
+        Figure title
+    figsize : tuple, optional
+        Figure size
+    labels : list, optional
+        Labels to include
+    collapsed : bool
+        Whether to collapse forward/reverse
+    motif_orientation : str
+        "seq_dir": as read in sequencing direction,
+        "ref_dir": aligned to reference direction by reverse-complementing reverse-strand reads, or
+        "fwd_only": using only forward-strand reads.
+    include_quality : bool
+        Whether to include quality panels
+
+    Returns
+    -------
+    fig : matplotlib.Figure
+        The figure
+    stats_df : pd.DataFrame
+        Statistics dataframe
+    """
+    stats_df = calc_trinuc_stats(
+        plot_df,
+        trinuc_col=trinuc_col,
+        label_col=label_col,
+        is_forward_col=is_forward_col,
+        qual_col=qual_col,
+        order=order,
+        labels=labels,
+        q1=q1,
+        q2=q2,
+        collapsed=collapsed,
+        motif_orientation=motif_orientation,
+        include_quality=include_quality,
+    )
+
+    if collapsed and (order != "reverse"):
+        # raise warning that collapsing not by motif and its reverse complement
+        warnings.warn(
+            "Collapsing trinuc motifs with their symmetricly reversed partners W[X>Y]Z with W[Y>Z]X "
+            "rather than with their reversed complements. Results may not be as expected. "
+            "Consider using 'reverse' order.",
+            stacklevel=2,
+        )
+
+    if include_quality:
+        fig = plot_trinuc_hist_and_qual_panels(
+            stats_df,
+            q1=q1,
+            q2=q2,
+            order=order,
+            suptitle=suptitle,
+            figsize=figsize,
+            collapsed=collapsed,
+            motif_orientation=motif_orientation,
+            hspace=hspace,
+            hist_to_qual_height_ratio=hist_to_qual_height_ratio,
+            bottom_scale=bottom_scale,
+        )
+    else:
+        # Extract only histogram columns for backward compatibility
+        hist_cols = [
+            col
+            for col in stats_df.columns
+            if not col.endswith(("_median_qual", "_q1_qual", "_q2_qual")) and col != "is_cycle_skip"
+        ]
+        hist_stats_df = stats_df[hist_cols]
+
+        fig = plot_trinuc_hist_panels(
+            hist_stats_df,
+            order=order,
+            suptitle=suptitle,
+            figsize=figsize,
+            collapsed=collapsed,
+            motif_orientation=motif_orientation,
+            bottom_scale=bottom_scale,
+        )
+
+    return fig, stats_df


### PR DESCRIPTION
This pull request refactors and modernizes the SHAP plotting functionality in `srsnv_plotting_utils.py`, moving SHAP-related plotting logic into a new `SHAPPlotter` class, and updates the handling of PPMSeq tag columns and "is_mixed" logic in both plotting and reporting utilities. The changes improve code modularity, maintainability, and clarity, especially around SHAP value calculation and plotting, and PPMSeq tag handling.

**SHAP plotting refactor and improvements:**

* Removed all SHAP plotting and feature transformation helper methods from `SRSNVReport`, replacing them with a new `SHAPPlotter` class (imported from `ugbio_srsnv.shap_plotting`). All SHAP value calculation and plotting is now delegated to this class, simplifying the `SRSNVReport` code and centralizing SHAP-related logic. (`src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py`, [[1]](diffhunk://#diff-52e64b87e811c6ae7d9532ac8ae91ff5ac1b778a5585c392d32b5cb8512151f3L2321-L2514) [[2]](diffhunk://#diff-52e64b87e811c6ae7d9532ac8ae91ff5ac1b778a5585c392d32b5cb8512151f3L2524-R2406) [[3]](diffhunk://#diff-52e64b87e811c6ae7d9532ac8ae91ff5ac1b778a5585c392d32b5cb8512151f3R35-R41)
* Updated the `calc_and_plot_shap_values` method to use the new `SHAPPlotter.plot_both` interface for efficient SHAP value calculation and plotting, and to save plots using the report's standard method. (`src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py`, [src/srsnv/ugbio_srsnv/srsnv_plotting_utils.pyL2524-R2406](diffhunk://#diff-52e64b87e811c6ae7d9532ac8ae91ff5ac1b778a5585c392d32b5cb8512151f3L2524-R2406))

**PPMSeq tag and "is_mixed" handling:**

* Replaced legacy "is_mixed" column logic in `add_is_mixed_to_featuremap_df` with a call to the new `HandlePPMSeqTagsInFeatureMapDataFrame` class, improving robustness and making use of adapter version and feature metadata. (`src/srsnv/ugbio_srsnv/srsnv_report.py`, [[1]](diffhunk://#diff-47e9ee714d6a9cf68c9de5c4e1ae27f335cb5dcc8535b4eca1fabc543a2cd9e2L69-R87) [[2]](diffhunk://#diff-47e9ee714d6a9cf68c9de5c4e1ae27f335cb5dcc8535b4eca1fabc543a2cd9e2L204-R215)
* Improved logic for selecting start/end tag columns in `quality_per_ppmseq_tags` to prefer filled-na tags if available, then fall back to raw tags or defaults. (`src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py`, [src/srsnv/ugbio_srsnv/srsnv_plotting_utils.pyL2175-R2198](diffhunk://#diff-52e64b87e811c6ae7d9532ac8ae91ff5ac1b778a5585c392d32b5cb8512151f3L2175-R2198))

**Other notable updates:**

* Adjusted the calculation in `_get_snvq_and_recall` to divide `fpr/tpr` by 3, and refactored `_get_recall_at_snvq` to use a more direct calculation based on filtered dataframe columns. (`src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py`, [src/srsnv/ugbio_srsnv/srsnv_plotting_utils.pyL1577-R1618](diffhunk://#diff-52e64b87e811c6ae7d9532ac8ae91ff5ac1b778a5585c392d32b5cb8512151f3L1577-R1618))
* Commented out unused training info fields in `calc_run_info_table`. (`src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py`, [src/srsnv/ugbio_srsnv/srsnv_plotting_utils.pyL1825-R1843](diffhunk://#diff-52e64b87e811c6ae7d9532ac8ae91ff5ac1b778a5585c392d32b5cb8512151f3L1825-R1843))
* Minor import cleanups and additions for new dependencies. (`src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py`, [[1]](diffhunk://#diff-52e64b87e811c6ae7d9532ac8ae91ff5ac1b778a5585c392d32b5cb8512151f3L6) [[2]](diffhunk://#diff-52e64b87e811c6ae7d9532ac8ae91ff5ac1b778a5585c392d32b5cb8512151f3L16-R17); `src/srsnv/ugbio_srsnv/srsnv_report.py`, [[3]](diffhunk://#diff-47e9ee714d6a9cf68c9de5c4e1ae27f335cb5dcc8535b4eca1fabc543a2cd9e2R36); `src/srsnv/ugbio_srsnv/srsnv_training.py`, [[4]](diffhunk://#diff-9938ff9b205b333fe08c43726d3e45ff6588efdce8df98a13f2c559417dd2c04R36)