### PR TITLE
BIOIN-2452 In SV comparison pipeline SVLEN value remains tuple

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,11 +63,6 @@ docker run --rm -v .:/workdir <image> run_tests /workdir/src/<module>
 
 ```
 
-### Docker Integration Points
-- **Base Image**: `ugbio_base` provides bcftools, samtools, tabix, common tools
-- **AWS ECR**: `337532070941.dkr.ecr.us-east-1.amazonaws.com/ugbio_<module>`
-- **Multi-stage Builds**: Build wheels in Python 3.11, deploy in tool-specific base
-
 ### AWS/Cloud Patterns
 ```python
 # HealthOmics workflow analysis

--- a/src/comparison/tests/system/test_sv_comparison_pipeline_system.py
+++ b/src/comparison/tests/system/test_sv_comparison_pipeline_system.py
@@ -27,7 +27,7 @@ class TestSVComparisonPipeline:
                 "--output_filename",
                 output_file,
                 "--outdir",
-                str(tmpdir) + "truvari",
+                os.path.join(str(tmpdir), "truvari"),
             ]
         )
         assert os.path.exists(output_file)

--- a/src/comparison/tests/unit/test_sv_comparison_pipeline_unit.py
+++ b/src/comparison/tests/unit/test_sv_comparison_pipeline_unit.py
@@ -14,10 +14,10 @@ def test_collapse_vcf(mocker):
     mock_p1.stdout = mocker.Mock()
     mock_p1.returncode = 0
     mock_p2.returncode = 0
-    open("removed.vcf", "w").close()  # Create the file to be removed
+    open("tmp.vcf", "w").close()  # Create the file to be removed
     sv_comparison.collapse_vcf("input.vcf", "output.vcf.gz", bed="regions.bed", pctseq=0.9, pctsize=0.8)
 
-    mock_logger.info.assert_called_with("Deleted temporary file: removed.vcf")
+    mock_logger.info.assert_called_with("Deleted temporary file: tmp.vcf")
     mock_subprocess_popen.assert_any_call(
         [
             "truvari",
@@ -26,7 +26,7 @@ def test_collapse_vcf(mocker):
             "input.vcf",
             "-t",
             "-c",
-            "removed.vcf",
+            "tmp.vcf",
             "--passonly",
             "--bed",
             "regions.bed",
@@ -56,14 +56,14 @@ def test_collapse_vcf_ignore_filter(mocker):
     mock_p1.stdout = mocker.Mock()
     mock_p1.returncode = 0
     mock_p2.returncode = 0
-    with open("removed.vcf", "w"):
+    with open("tmp.vcf", "w"):
         pass  # Create the file to be removed
 
     sv_comparison.collapse_vcf(
         "input.vcf", "output.vcf.gz", bed="regions.bed", pctseq=0.9, pctsize=0.8, ignore_filter=True
     )
 
-    mock_logger.info.assert_called_with("Deleted temporary file: removed.vcf")
+    mock_logger.info.assert_called_with("Deleted temporary file: tmp.vcf")
     # Verify --passonly is NOT included when ignore_filter=True
     mock_subprocess_popen.assert_any_call(
         [
@@ -73,7 +73,7 @@ def test_collapse_vcf_ignore_filter(mocker):
             "input.vcf",
             "-t",
             "-c",
-            "removed.vcf",
+            "tmp.vcf",
             "--bed",
             "regions.bed",
             "--pctseq",
@@ -171,7 +171,7 @@ def test_truvari_to_dataframes_svlen_processing(mocker):
 
     # Mock dataframes with various svlen formats including tuples and single values
     mock_vcftools.side_effect = [
-        pd.DataFrame([{"svtype": "DEL", "svlen": (100, 50)}]),  # tp-base.vcf.gz with tuple
+        pd.DataFrame([{"svtype": "DEL", "svlen": (100,)}]),  # tp-base.vcf.gz with tuple
         pd.DataFrame([{"svtype": "INS", "svlen": 200}]),  # fn.vcf.gz with single value
         pd.DataFrame([{"svtype": "DEL", "svlen": (150, 75)}]),  # tp-comp.vcf.gz with tuple
         pd.DataFrame([{"svtype": "INS", "svlen": None}]),  # fp.vcf.gz with None value
@@ -187,7 +187,7 @@ def test_truvari_to_dataframes_svlen_processing(mocker):
     assert "svlen_int" in df_calls.columns, "svlen_int column should be created"
 
     # Check that original svlen values are preserved
-    assert df_base.iloc[0]["svlen"] == (100, 50), "Original tuple svlen should be preserved"
+    assert df_base.iloc[0]["svlen"] == (100,), "Original tuple svlen should be preserved"
     assert df_base.iloc[1]["svlen"] == 200, "Original single svlen should be preserved"
 
     # Check that svlen_int contains correct integer values

--- a/src/comparison/ugbio_comparison/sv_comparison_pipeline.py
+++ b/src/comparison/ugbio_comparison/sv_comparison_pipeline.py
@@ -80,7 +80,7 @@ class SVComparison:
         -------
         None
         """
-        removed_vcf_path = pjoin(dirname(output_vcf), "removed.vcf")
+        removed_vcf_path = pjoin(dirname(output_vcf), "tmp.vcf")
         truvari_cmd = ["truvari", "collapse", "-i", vcf, "-t", "-c", removed_vcf_path]
 
         if not ignore_filter:
@@ -260,7 +260,7 @@ class SVComparison:
 
         if dirname(output_file_name) == outdir:
             raise ValueError(
-                "output_file_name must not be under outdr to avoid conflicts (with running truvari bench)."
+                "output_file_name must not be under outdir to avoid conflicts (with running truvari bench)."
             )
         with tempfile.TemporaryDirectory(dir=dirname(output_file_name)) as workdir:
             self.logger.info(f"Running truvari pipeline with calls: {calls} and gt: {gt}")


### PR DESCRIPTION
For consistency with subsequent filtering and training of models, SVLEN column in concordance dataframe of sv comparison pipeline remains tuple. 

New column that is an int is generated