### PR TITLE
use self hosted runner to prevent disk issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
   ugbio-utils-CI:
-    runs-on: ubuntu-latest
+    runs-on: build-docker-4
     needs: [get-members]
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches `ugbio-utils-CI` job to run on self-hosted runner `build-docker-4` instead of `ubuntu-latest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 545a2274fbb0777deca15f8b2e27261dd7a3ca3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

These should solve [last days](https://github.com/Ultimagen/ugbio-utils/actions/workflows/ci.yml?query=branch%3Amain) CI failures
