### PR TITLE
BIOIN-2503 replace large df_file.parquet with a subsampled one

### DIFF
--- a/src/mrd/tests/resources/report/Pa_46_333_LuNgs_08.featuremap_df.parquet
+++ b/src/mrd/tests/resources/report/Pa_46_333_LuNgs_08.featuremap_df.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:288232b36041ca300a34be51a35214ef01838501545935f183dc8c6a4a078fba
-size 257195759

--- a/src/mrd/tests/resources/report/Pa_46_333_LuNgs_08.featuremap_df.subsampled.parquet
+++ b/src/mrd/tests/resources/report/Pa_46_333_LuNgs_08.featuremap_df.subsampled.parquet
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b3106bf552c89772f0897c58a4bd8600abb049f3066651fec0c1f6d01ebd0fb
+size 697787

--- a/src/mrd/tests/resources/report/test_report.ctdna_vaf.expected_output.h5
+++ b/src/mrd/tests/resources/report/test_report.ctdna_vaf.expected_output.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c76a4fc50dffbfd1ae0bd60c8113ec9dcc4bbd30ca45226fbbc6f387e6e8af7e
+oid sha256:d0cf1b5c51f97506dacd10f3404ada06f2cc7f196d31f41b009325262dda76db
 size 3223392

--- a/src/mrd/tests/unit/test_generate_mrd_report.py
+++ b/src/mrd/tests/unit/test_generate_mrd_report.py
@@ -39,7 +39,7 @@ def test_generate_mrd_report(output_path, resources_dir):
         # tumor_sample=args_in.tumor_sample,
         output_dir=output_path,
         output_basename="test_report",
-        featuremap_file=str(resources_dir / "Pa_46_333_LuNgs_08.featuremap_df.parquet"),
+        featuremap_file=str(resources_dir / "Pa_46_333_LuNgs_08.featuremap_df.subsampled.parquet"),
         signature_filter_query="(norm_coverage <= 2.5) and (norm_coverage >= 0.6)",
         read_filter_query="filt>0 and snvq>60 and mapq>=60",
         srsnv_metadata_json=str(resources_dir / "Pa_46_333_LuNgs_08.srsnv_metadata.json"),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace large featuremap parquet with a subsampled version and update tests/expected h5 accordingly.
> 
> - **Tests**:
>   - Update `src/mrd/tests/unit/test_generate_mrd_report.py` to use `Pa_46_333_LuNgs_08.featuremap_df.subsampled.parquet` instead of `...featuremap_df.parquet`.
>   - Refresh `src/mrd/tests/resources/report/test_report.ctdna_vaf.expected_output.h5` (LFS pointer) to new object hash.
> - **Test resources**:
>   - Add `src/mrd/tests/resources/report/Pa_46_333_LuNgs_08.featuremap_df.subsampled.parquet` (LFS).
>   - Remove `src/mrd/tests/resources/report/Pa_46_333_LuNgs_08.featuremap_df.parquet` (LFS).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99366f5f018940063a9592bd841a5932aa8850aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->