### PR TITLE
[BIOIN-2482] fixup for collapse

### DIFF
--- a/src/core/tests/unit/test_vcf_utils.py
+++ b/src/core/tests/unit/test_vcf_utils.py
@@ -396,7 +396,6 @@ class TestVcfUtils:
         assert "--keep maxqual" in call_args
         assert "--keep first" not in call_args
         assert "truvari collapse" in call_args
-        assert "bcftools view" in call_args
 
         # Verify temporary file cleanup
         mock_unlink.assert_called_once_with(removed_vcf_path)

--- a/src/core/ugbio_core/vcf_utils.py
+++ b/src/core/ugbio_core/vcf_utils.py
@@ -346,13 +346,9 @@ class VcfUtils:
         truvari_cmd.extend(["--pctseq", str(pctseq)])
         truvari_cmd.extend(["--pctsize", str(pctsize)])
         truvari_cmd.extend(["--refdist", str(int(refdist))])
-
+        truvari_cmd.extend(["-o", output_vcf])
         self.logger.info(f"truvari command: {' '.join(truvari_cmd)}")
-
-        bcftools_cmd = ["bcftools", "view", "-Oz", "-o", output_vcf]
-        complete_command = f"{' '.join(truvari_cmd)} | {' '.join(bcftools_cmd)}"
-        self.logger.info(f"Complete command: {complete_command}")
-        self.__execute(complete_command)
+        self.__execute(" ".join(truvari_cmd))
 
         # Parameterize the file path
         if erase_removed:


### PR DESCRIPTION
Fixing vcf_utils.collapse_vcf that does not work on cromwell for unclear reason

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route collapse output directly through `truvari -o` instead of piping to `bcftools`, and update tests to match.
> 
> - **Core (`vcf_utils.collapse_vcf`)**:
>   - Write output directly via `truvari collapse -o {output_vcf}`; remove `bcftools view` pipe and related logging.
>   - Preserve existing options (e.g., `--keep` handling, `--passonly`, `-t`, `--pctseq`, `--pctsize`, `--refdist`) and temporary removed-variants file cleanup.
> - **Tests (`test_vcf_utils.py`)**:
>   - Update collapse tests to align with direct `truvari` output; drop expectation of `bcftools view` in the command.
>   - Keep assertions for `--keep` modes and temporary file cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7736b77e93fc9cbe04f9928b2684deb461e5afe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->