### PR TITLE
Bioin 2518 prepare raw feature map memory issues

### DIFF
--- a/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
@@ -65,7 +65,7 @@ log = logging.getLogger(__name__)
 
 # Configuration constants
 DEFAULT_JOBS = 0  # 0 means auto-detect CPU cores
-CHUNK_BP_DEFAULT = 100_000_000  # 100 Mbp per processing chunk
+CHUNK_BP_DEFAULT = 10_000_000  # 10 Mbp per processing chunk
 
 
 @dataclass


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Optimizes and hardens region-based VCF→Parquet conversion.
> 
> - Extracts `_run_region_jobs` to manage parallel region processing with `ProcessPoolExecutor` (spawn context), aggregates worker failures, and raises on any region error; only retains successfully created part files
> - Lowers `CHUNK_BP_DEFAULT` to `10_000_000` to create smaller processing windows
> - CLI: updates `--drop-format` default to `GT, AD, X_TCM`; improves `--chunk-bp` help to reflect dynamic default
> - Minor imports/typing adjustments (`Future`), and clearer error logging with full worker tracebacks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1676227ee66766fa8c18228d4225fdb5f395b72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->