### PR TITLE
make_sure_s3_file_exists cloud helper function

### DIFF
--- a/src/cloud_utils/ugbio_cloud_utils/file_handler_s3.py
+++ b/src/cloud_utils/ugbio_cloud_utils/file_handler_s3.py
@@ -222,5 +222,5 @@ def make_sure_s3_file_exists(s3_path, s3_client: str | None = None, profile: str
         s3_client.head_object(Bucket=bucket, Key=key)
         return s3_path
     except botocore.exceptions.ClientError:
-        logger.error(f"S3 file does not exist: {s3_path}")
+        logger.error(f"S3 file could not be found: {s3_path}")
         raise


### PR DESCRIPTION
Useful for making sure cloud paths used, particularly when setting up WDL jsons. Example usage:

> from ugbio_cloud_utils.file_handler_s3 import make_sure_s3_file_exists
> print(make_sure_s3_file_exists("s3://ultimagen-pipelines-380827583499-us-east-1-runs-data/users-data/itai/502106/1004502106001-L10740-Z0234-CATCGCACCAGAGAT.op1.cram"))
> make_sure_s3_file_exists("s3://ultimagen-pipelines-380827583499-us-east-1-runs-data/bogus_file.ext")


Output:

> s3://ultimagen-pipelines-380827583499-us-east-1-runs-data/users-data/itai/502106/1004502106001-L10740-Z0234-CATCGCACCAGAGAT.op1.cram
> S3 file does not exist: s3://ultimagen-pipelines-380827583499-us-east-1-runs-data/bogus_file.ext
> ---------------------------------------------------------------------------
> ClientError                               Traceback (most recent call last)
> Cell In[24], [line 3](vscode-notebook-cell:?execution_count=24&line=3)
>       1 from ugbio_cloud_utils.file_handler_s3 import make_sure_s3_file_exists
>       2 print(make_sure_s3_file_exists("s3://ultimagen-pipelines-380827583499-us-east-1-runs-data/users-data/itai/502106/1004502106001-L10740-Z0234-CATCGCACCAGAGAT.op1.cram"))
> ----> [3](vscode-notebook-cell:?execution_count=24&line=3) make_sure_s3_file_exists("s3://ultimagen-pipelines-380827583499-us-east-1-runs-data/bogus_file.ext")
> 
> File ~/ugbio-utils/src/cloud_utils/ugbio_cloud_utils/file_handler_s3.py:21, in make_sure_s3_file_exists(s3_path, s3_client, profile)
>       0 <Error retrieving source code with stack_data see ipython/ipython#13598>
> 
> File ~/ugbio-utils/.venv/lib/python3.11/site-packages/botocore/client.py:602, in _api_call(self, *args, **kwargs)
> 
> File ~/ugbio-utils/.venv/lib/python3.11/site-packages/botocore/context.py:123, in wrapper(*args, **kwargs)
> 
> File ~/ugbio-utils/.venv/lib/python3.11/site-packages/botocore/client.py:1078, in _make_api_call(self, operation_name, api_params)
> 
> ClientError: An error occurred (404) when calling the HeadObject operation: Not Found



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a small utility to confirm S3 object existence.
> 
> - New `make_sure_s3_file_exists(s3_path, s3_client=None, profile=None)` validates `s3://` path format, sets up credentials via `_setup_aws_credentials`, and uses `boto3` `head_object` to check existence; returns the path or raises on errors
> - Adds `boto3`/`botocore` imports to support the HEAD check
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 583fccbf43c1263094c70c69075ca255323cf17c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->