### PR TITLE
BIOIN-2572 Fix saving srsnv_metadata.json with null values

### DIFF
--- a/src/srsnv/ugbio_srsnv/srsnv_training.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_training.py
@@ -74,6 +74,16 @@ EDIT_DIST_FEATURES = [
 pl.enable_string_cache()
 
 
+# ───────────────────────── JSON encoder ───────────────────────────
+class NaNToNullEncoder(json.JSONEncoder):
+    """Custom JSON encoder that converts NaN values to null."""
+
+    def iterencode(self, obj, *, _one_shot=False):
+        """Encode recursively, handling NaN in nested structures."""
+        for chunk in super().iterencode(obj, _one_shot=_one_shot):
+            yield chunk.replace("NaN", "null")
+
+
 # ───────────────────────── parsers ────────────────────────────
 def _parse_interval_list_tabix(path: str) -> tuple[dict[str, int], list[str]]:
     # Parse headers for chrom_sizes (must still scan file start)
@@ -960,7 +970,7 @@ class SRSNVTrainer:
         }
 
         with metadata_path.open("w") as fh:
-            json.dump(metadata, fh, indent=2)
+            json.dump(metadata, fh, indent=2, cls=NaNToNullEncoder)
         logger.info(f"Saved metadata → {metadata_path}")
         logger.info(
             "Metadata includes %d chromosome to model mappings and %d features",


### PR DESCRIPTION
When there are NaN values in the srsnv metadata saved to json by srsnv_training.py, then these NaNs are saved as NaN rather than null (as they should be for the json to be properly formatted). This PR fixes this issue. 

Null values may arise in the “training_results” field when one of the metrics is auc and the evaluation set only has TP (or only FP) SNVs. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `srsnv_metadata.json` is valid JSON by converting NaN values to null during serialization.
> 
> - Add `NaNToNullEncoder` in `srsnv_training.py` and use it in `json.dump` for metadata
> - New unit tests verify NaN→null conversion for nested structures and NumPy NaNs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 079d09db61e040896e28f9b87ad2dfd6e3258b43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->