### PR TITLE
BIOIN-2570 Fixing small error in ground truth files when moving to NIST hg38

### DIFF
--- a/src/comparison/ugbio_comparison/vcf_comparison_utils.py
+++ b/src/comparison/ugbio_comparison/vcf_comparison_utils.py
@@ -258,7 +258,7 @@ class VcfComparisonUtils:
 
         # Step1 - bcftools norm
 
-        self.__execute(f"bcftools norm -c s -f {ref} -m+any -o {tempdir}/step1.vcf.gz -O z {input_vcf}")
+        self.__execute(f"bcftools norm -c x -f {ref} -m+any -o {tempdir}/step1.vcf.gz -O z {input_vcf}")
         self.vu.index_vcf(f"{tempdir}/step1.vcf.gz")
         self.__execute(
             f"bcftools annotate -a {input_vcf} -c CHROM,POS,CALL,BASE -Oz \


### PR DESCRIPTION
There is a small discrepancy in the NIST truth set that manifests when switching the the NIST version of the genome. The reference allele in few location is different from the reference sequence. 
I remove these variants from the evaluation. 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts normalization of vcfeval outputs.
> 
> - Updates `normalize_vcfeval_vcf` to run `bcftools norm -c x -f {ref} -m+any` when generating `step1.vcf.gz`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f90ffd1546816454a16b08c986db61e5c9ef0fac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->