### PR TITLE
Fix numeric instability in cnvpytor test. 

### DIFF
--- a/src/cnv/tests/system/test_run_cnvpytor.py
+++ b/src/cnv/tests/system/test_run_cnvpytor.py
@@ -41,7 +41,8 @@ class TestRunCNVpytor:
         expected_out_cnvs_file = os.path.join(resources_dir, "HG002.pytor.bin500.CNVs.tsv")
 
         # Read both files into dataframes and compare with tolerance for floats
-        df_actual = pd.read_csv(out_cnvs_file, sep="\t")
-        df_expected = pd.read_csv(expected_out_cnvs_file, sep="\t")
+        # Files are space-separated (multiple spaces), not tab-separated despite .tsv extension
+        df_actual = pd.read_csv(out_cnvs_file, sep=r"\s+", header=None)
+        df_expected = pd.read_csv(expected_out_cnvs_file, sep=r"\s+", header=None)
 
         pd.testing.assert_frame_equal(df_actual, df_expected, rtol=1e-5, atol=1e-8)


### PR DESCRIPTION
CI crashes in the last few days due to some numerical instability in cnvpytor. 
I made the test less conservative. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the `run_cnvpytor` system test by tolerating minor numeric differences in CNV outputs.
> 
> - Replaces exact file comparison with pandas-based DataFrame comparison using `assert_frame_equal` with float tolerances (`rtol=1e-5`, `atol=1e-8`)
> - Parses space-separated `.tsv` files via `pd.read_csv(..., sep=r"\s+", header=None)`
> - Adds `pandas` import and removes unused `filecmp` import
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e15633fde48cdbea6d64b68dc93e5733b6f443b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->