### PR TITLE
Import logger from ugbio_core instead of using logging

### DIFF
--- a/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
@@ -90,7 +90,7 @@ def _configure_logging(log_level: int, *, check_worker_cache: bool = False) -> N
     if check_worker_cache and _configure_logging._worker_log_level == log_level:  # type: ignore[attr-defined]
         return
 
-    # Clear any existing handlers and reconfigure
+    # Reconfigure the root logger for this process.
     root_logger = logging.getLogger()
     root_logger.handlers.clear()
     logging.basicConfig(
@@ -100,6 +100,11 @@ def _configure_logging(log_level: int, *, check_worker_cache: bool = False) -> N
     )
     root_logger.setLevel(log_level)
     log.setLevel(log_level)
+    if log.handlers:
+        # Avoid double logging when the shared logger already has handlers.
+        log.propagate = False
+        for handler in log.handlers:
+            handler.setLevel(log_level)
 
     # Track configured level for worker processes
     if check_worker_cache:


### PR DESCRIPTION
Replaced the logger setup with a logger import from ugbio_core.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: logging-only changes that adjust handler/propagation behavior; main risk is altered log output (duplication or missing logs) especially in multiprocessing workers.
> 
> **Overview**
> `featuremap_to_dataframe.py` now imports `logger` from `ugbio_core` instead of creating a module-local logger.
> 
> `_configure_logging` was updated to reconfigure the root logger without clearing the shared logger’s handlers, and to disable `log` propagation / align handler levels when the shared logger already has handlers to prevent double-logging (notably in worker processes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8a8bd217b6a9f44685937b341880d5985c0edea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->