### PR TITLE
Expose RTG_MEM

### DIFF
--- a/src/comparison/ugbio_comparison/run_comparison_pipeline.py
+++ b/src/comparison/ugbio_comparison/run_comparison_pipeline.py
@@ -199,6 +199,13 @@ def get_parser() -> argparse.ArgumentParser:
         required=False,
         default="INFO",
     )
+    ap_var.add_argument(
+        "--rtg_mem",
+        help='Memory for RTG Tools via RTG_MEM (e.g. "12G", "24G")',
+        required=False,
+        default="12G",
+        type=str,
+    )
     return ap_var
 
 
@@ -206,7 +213,7 @@ def _setup_pipeline_and_utilities(args) -> tuple[SimplePipeline, VcfComparisonUt
     """Setup pipeline and utility objects."""
     logger.setLevel(getattr(logging, args.verbosity))
     sp = SimplePipeline(args.fc, args.lc, debug=args.d, print_timing=True)
-    vcu = VcfComparisonUtils(sp)
+    vcu = VcfComparisonUtils(sp, rtg_mem=args.rtg_mem)
     vu = VcfUtils(sp)
     return sp, vcu, vu
 

--- a/src/comparison/ugbio_comparison/vcf_comparison_utils.py
+++ b/src/comparison/ugbio_comparison/vcf_comparison_utils.py
@@ -19,16 +19,19 @@ class VcfComparisonUtils:
         Simple pipeline object
     """
 
-    def __init__(self, simple_pipeline: SimplePipeline | None = None):
+    def __init__(self, simple_pipeline: SimplePipeline | None = None, rtg_mem: str = "12G"):
         """Combines VCF in parts from GATK and indices the result
 
         Parameters
         ----------
         simple_pipeline : SimplePipeline, optional
             Optional SimplePipeline object for executing shell commands
+        rtg_mem : str, optional
+            Memory passed to RTG Tools via the RTG_MEM environment variable (default: "12G")
         """
         self.sp = simple_pipeline
         self.vu = VcfUtils()
+        self.rtg_mem = rtg_mem
 
     def __execute(self, command: str, output_file: str | None = None):
         """Summary
@@ -91,7 +94,7 @@ class VcfComparisonUtils:
             shutil.rmtree(outdir)
         cmd = [
             "rtg",
-            "RTG_MEM=12G",
+            f"RTG_MEM={self.rtg_mem}",
             "vcfeval",
             "-b",
             gt,


### PR DESCRIPTION
Abilitt to change RTG_MEM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI/config parameter and threads it into the RTG vcfeval invocation without changing comparison logic or outputs beyond resource settings.
> 
> **Overview**
> Exposes RTG Tools memory configuration by adding a new `--rtg_mem` CLI flag to `run_comparison_pipeline.py` and wiring it into `VcfComparisonUtils`.
> 
> `VcfComparisonUtils.run_vcfeval` now uses the instance-provided `rtg_mem` value (defaulting to `12G`) instead of a hardcoded `RTG_MEM=12G`, allowing callers to tune vcfeval resource usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b4272154e0eda7f2a119efdb5dde43ab7244c0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->