### PR TITLE
BIOIN-2665 add Neutral ploidy value for cnv plots

### DIFF
--- a/src/cnv/ugbio_cnv/plot_cnv_results.py
+++ b/src/cnv/ugbio_cnv/plot_cnv_results.py
@@ -235,6 +235,7 @@ def run(argv):  # noqa: C901, PLR0912, PLR0915 # TODO: refactor
         <chr><start><end><copy-number>
     --out_directory: output directory
     --sample_name: sample name
+    --neutral_ploidy: neutral ploidy value for plotting the reference line in copy number plot
     output files:
     coverage plot: <sample_name>.CNV.coverage.jpeg
         shows normalized (log scale) coverage along the genome for the germline (and tumor) samples.


### PR DESCRIPTION
adding an argument for neutral ploidy value in cnv plotting script. 
This value will draw the reference line in copy number plot. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, plotting-only change that just parameterizes the reference ploidy line; main risk is minor CLI/backwards-compat usage differences for callers expecting the old hardcoded value.
> 
> **Overview**
> Adds a `--neutral_ploidy` CLI argument (default `2`) to `plot_cnv_results.py` and threads it into `plot_cnv_calls`.
> 
> The copy-number plot’s horizontal reference line is no longer hardcoded and is drawn at the provided neutral ploidy value instead; help text/docs and the call site are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1f42a58a43a66ff0167e7b008dd35b1e15a6cde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->