### PR TITLE
Add terminated mode to generate_key_from_sequence

### DIFF
--- a/src/core/tests/unit/flow_format/test_flow_based_read.py
+++ b/src/core/tests/unit/flow_format/test_flow_based_read.py
@@ -95,6 +95,23 @@ def test_generate_key_from_sequence_empty_sequence(flow_order):
     assert np.array_equal(result, expected)
 
 
+def test_generate_key_from_sequence_terminated(flow_order):
+    sequence = "AAGGTTCC"
+    result = fbr.generate_key_from_sequence(sequence, flow_order, terminated=True)
+
+    assert set(np.unique(result)).issubset({0, 1})
+    assert result.sum() == len(sequence)
+
+    expected = np.array([1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0])
+    assert np.array_equal(result, expected)
+
+
+def test_generate_key_from_sequence_terminated_and_truncate_raises(flow_order):
+    sequence = "AAGGTTCC"
+    with pytest.raises(ValueError):
+        fbr.generate_key_from_sequence(sequence, flow_order, truncate=1, terminated=True)
+
+
 def test_get_flow_matrix_column_for_base(resources_dir):
     data = list(pysam.AlignmentFile(pjoin(resources_dir, "chr9.sample.bam")))
     fbrs = [

--- a/src/core/ugbio_core/flow_format/flow_based_read.py
+++ b/src/core/ugbio_core/flow_format/flow_based_read.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import re
 from enum import Enum
+from itertools import cycle
 
 import numpy as np
 import pandas as pd
@@ -53,7 +54,12 @@ def key2base(key: np.ndarray) -> np.ndarray:
 
 
 def generate_key_from_sequence(
-    sequence: str, flow_order: str, truncate: int | None = None, *, non_standard_as_a: bool = False
+    sequence: str,
+    flow_order: str,
+    truncate: int | None = None,
+    *,
+    non_standard_as_a: bool = False,
+    terminated: bool = False,
 ) -> np.ndarray:
     """Converts bases to flow order
 
@@ -67,6 +73,9 @@ def generate_key_from_sequence(
         maximal hmer to read
     non_standard_as_a: bool, optional
         Replace non-standard nucleotides with A (default: false)
+    terminated: bool, optional
+        If True, stop counting each hmer after the first base so that the
+        maximal value in the output key is 1 (default: false).
 
     Returns
     -------
@@ -76,8 +85,12 @@ def generate_key_from_sequence(
     Raises
     ------
     ValueError
-        When  there are non-standard nucleotides
+        When  there are non-standard nucleotides, or when both ``truncate`` and
+        ``terminated`` are provided.
     """
+    if terminated and truncate:
+        raise ValueError("`terminated` and `truncate` cannot both be set")
+
     # sanitize input
     sequence = sequence.upper()
     if bool(re.compile(r"[^ACGT]").search(sequence)):
@@ -89,15 +102,17 @@ def generate_key_from_sequence(
             )
 
     # process
-    flow = flow_order * len(sequence)
-
-    key = []
+    key: list[int] = []
+    if not sequence:
+        return np.array(key)
     pos = 0
-    for base in flow:
+    for base in cycle(flow_order):
         hcount = 0
         for i in range(pos, len(sequence)):
             if sequence[i] == base:
                 hcount += 1
+                if terminated:
+                    break
             else:
                 break
         else:


### PR DESCRIPTION
## Summary
- Add a `terminated` kwarg to `generate_key_from_sequence` that caps each hmer count at 1, producing a binary (0/1) key whose sum equals the sequence length. Mutually exclusive with `truncate` — raises `ValueError` if both are set.
- Small style improvement: replace the redundant `flow = flow_order * len(sequence)` buffer with `itertools.cycle(flow_order)`.

## Test plan
- [x] Existing unit tests in `src/core/tests/unit/flow_format/test_flow_based_read.py` still pass (9/9).
- [x] New `test_generate_key_from_sequence_terminated` verifies the key contains only 0s/1s, that `key.sum() == len(sequence)`, and checks an explicit expected array.
- [x] New `test_generate_key_from_sequence_terminated_and_truncate_raises` verifies the mutual-exclusion error.
- [x] Pre-commit (ruff lint + format) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is additive behind a default-off flag and only affects callers that opt into `terminated` (or incorrectly combine it with `truncate`). Main risk is subtle differences in key generation edge cases due to the new cycling implementation and termination behavior.
> 
> **Overview**
> Adds a `terminated` kwarg to `generate_key_from_sequence` that caps each homopolymer count at 1 (producing a binary key) and raises `ValueError` when used together with `truncate`.
> 
> Refactors key generation to iterate flows via `itertools.cycle` (and returns early on empty input), and adds unit tests covering the new terminated output and the mutual-exclusion error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eedad28c7acc12141a37a3a1500d18146abbba70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->