### PR TITLE
BIOIN-2781: Use Ultimagen MethylDackel fork with --reversed and --methylated-cytosine-converted

### DIFF
--- a/src/methylation/Dockerfile
+++ b/src/methylation/Dockerfile
@@ -36,7 +36,7 @@ RUN git clone https://github.com/dpryan79/libBigWig.git && \
     make install && \
     cp libBigWig.a /usr/local/lib/
 
-RUN git clone -b feature/reversed-strand-flag https://github.com/Ultimagen/MethylDackel.git && \
+RUN git clone https://github.com/Ultimagen/MethylDackel.git && \
     cd MethylDackel && \
     make LIBBIGWIG="/usr/local/lib/libBigWig.a" && \
     mkdir -p /app/bin && \

--- a/src/methylation/Dockerfile
+++ b/src/methylation/Dockerfile
@@ -36,7 +36,7 @@ RUN git clone https://github.com/dpryan79/libBigWig.git && \
     make install && \
     cp libBigWig.a /usr/local/lib/
 
-RUN git clone https://github.com/dpryan79/MethylDackel.git && \
+RUN git clone -b feature/reversed-strand-flag https://github.com/Ultimagen/MethylDackel.git && \
     cd MethylDackel && \
     make LIBBIGWIG="/usr/local/lib/libBigWig.a" && \
     mkdir -p /app/bin && \

--- a/src/methylation/tests/system/test_methyldackel_qc_parsing.py
+++ b/src/methylation/tests/system/test_methyldackel_qc_parsing.py
@@ -48,28 +48,6 @@ class TestParsers:
         pd.testing.assert_frame_equal(result_csv, ref_csv)
 
     # ------------------------------------------------------
-    def test_process_mbias_taps(self, tmpdir, resources_dir):
-        output_prefix = f"{tmpdir}/output_Mbias_TAPS"
-        output_file = output_prefix + ".csv"
-        os.makedirs(os.path.dirname(output_file), exist_ok=True)
-
-        process_mbias.run(
-            [
-                "process_Mbias",
-                "--input",
-                f"{resources_dir}/input_Mbias.bedGraph",
-                "--output",
-                f"{output_prefix}",
-                "--taps",
-            ]
-        )
-
-        result_csv = pd.read_csv(output_file)
-        ref_csv = pd.read_csv(open(f"{resources_dir}/ProcessMethylDackelMbias.TAPS.csv"))
-
-        pd.testing.assert_frame_equal(result_csv, ref_csv)
-
-    # ------------------------------------------------------
 
     def test_process_per_read(self, tmpdir, resources_dir):
         output_prefix = f"{tmpdir}/output_perRead"
@@ -88,29 +66,6 @@ class TestParsers:
 
         result_csv = pd.read_csv(output_file)
         ref_csv = pd.read_csv(open(f"{resources_dir}/ProcessMethylDackelPerRead.csv"))
-
-        pd.testing.assert_frame_equal(result_csv, ref_csv)
-
-    # ------------------------------------------------------
-
-    def test_process_per_read_taps(self, tmpdir, resources_dir):
-        output_prefix = f"{tmpdir}/output_perRead_TAPS"
-        output_file = output_prefix + ".csv"
-        os.makedirs(os.path.dirname(output_file), exist_ok=True)
-
-        process_per_read.run(
-            [
-                "process_perRead",
-                "--input",
-                f"{resources_dir}/input_perRead.bedGraph",
-                "--output",
-                f"{output_prefix}",
-                "--taps",
-            ]
-        )
-
-        result_csv = pd.read_csv(output_file)
-        ref_csv = pd.read_csv(open(f"{resources_dir}/ProcessMethylDackelPerRead.TAPS.csv"))
 
         pd.testing.assert_frame_equal(result_csv, ref_csv)
 
@@ -140,31 +95,6 @@ class TestParsers:
 
     # ------------------------------------------------------
 
-    def test_process_merge_context_no_cpg_taps(self, tmpdir, resources_dir):
-        output_prefix = f"{tmpdir}/output_mergeContextNoCpG_TAPS"
-        output_file = output_prefix + ".csv"
-        os.makedirs(os.path.dirname(output_file), exist_ok=True)
-
-        process_merge_context_no_cp_g.run(
-            [
-                "process_mergeContextNoCpG",
-                "--input_chg",
-                f"{resources_dir}/input_mergeContextNoCpG_CHG.bedGraph",
-                "--input_chh",
-                f"{resources_dir}/input_mergeContextNoCpG_CHH.bedGraph",
-                "--output",
-                f"{output_prefix}",
-                "--taps",
-            ]
-        )
-
-        result_csv = pd.read_csv(output_file)
-        ref_csv = pd.read_csv(open(f"{resources_dir}/ProcessMethylDackelMergeContextNoCpG.TAPS.csv"))
-
-        pd.testing.assert_frame_equal(result_csv, ref_csv)
-
-    # ------------------------------------------------------
-
     def test_process_merge_context(self, tmpdir, resources_dir):
         output_prefix = f"{tmpdir}/output_mergeContext"
         output_file = output_prefix + ".csv"
@@ -187,46 +117,6 @@ class TestParsers:
             result_csv_sub = result_csv.loc[idx, :].copy()
 
         ref_csv = pd.read_csv(open(f"{resources_dir}/ProcessConcatMethylDackelMergeContext.csv"))
-        idx = ref_csv.detail.str.contains(pat)
-        if idx.any(axis=None):
-            ref_csv_sub = ref_csv.loc[idx, :].copy()
-
-        pat = r"^PercentMethylation_"
-        idx = result_csv_sub.metric.str.contains(pat)
-        if idx.any(axis=None):
-            result_output = result_csv_sub.loc[idx, :].copy()
-
-        idx = ref_csv_sub.metric.str.contains(pat)
-        if idx.any(axis=None):
-            ref_output = ref_csv_sub.loc[idx, :].copy()
-
-        assert np.all(np.sum(result_output.value) == np.sum(ref_output.value))
-
-    # ------------------------------------------------------
-
-    def test_process_merge_context_taps(self, tmpdir, resources_dir):
-        output_prefix = f"{tmpdir}/output_mergeContext_TAPS"
-        output_file = output_prefix + ".csv"
-        os.makedirs(os.path.dirname(output_file), exist_ok=True)
-
-        process_merge_context.run(
-            [
-                "process_mergeContext",
-                "--input",
-                f"{resources_dir}/input_mergeContext.bedGraph",
-                "--output",
-                f"{output_prefix}",
-                "--taps",
-            ]
-        )
-
-        result_csv = pd.read_csv(output_file)
-        pat = r"^hg"
-        idx = result_csv.detail.str.contains(pat)
-        if idx.any(axis=None):
-            result_csv_sub = result_csv.loc[idx, :].copy()
-
-        ref_csv = pd.read_csv(open(f"{resources_dir}/ProcessConcatMethylDackelMergeContext.TAPS.csv"))
         idx = ref_csv.detail.str.contains(pat)
         if idx.any(axis=None):
             ref_csv_sub = ref_csv.loc[idx, :].copy()

--- a/src/methylation/ugbio_methylation/methyldackel_utils.py
+++ b/src/methylation/ugbio_methylation/methyldackel_utils.py
@@ -365,7 +365,7 @@ def calc_distrib_per_strand(data_frame: pd.DataFrame):
     return df_distrib
 
 
-def read_merge_context_file(in_file_name: str, is_taps: bool = False) -> pd.DataFrame:  # noqa: FBT001, FBT002
+def read_merge_context_file(in_file_name: str) -> pd.DataFrame:
     """
     Goal: Function for reading MethylDackel mergeContext file
 
@@ -373,8 +373,6 @@ def read_merge_context_file(in_file_name: str, is_taps: bool = False) -> pd.Data
     ----------
     in_file_name: str
         Input MethylDackel mergeContext file name
-    is_taps: bool
-        Indicate if input is TAPS data
 
     Returns
     -------
@@ -384,11 +382,5 @@ def read_merge_context_file(in_file_name: str, is_taps: bool = False) -> pd.Data
     """
     col_names = ["chr", "start", "end", "PercentMethylation", "coverage_methylated", "coverage_unmethylated"]
     df_in_report = pd.read_csv(in_file_name, sep="\t", header=0, names=col_names)
-    if is_taps:
-        df_in_report["PercentMethylation"] = 100 - df_in_report["PercentMethylation"]
-        df_in_report["coverage_methylated"], df_in_report["coverage_unmethylated"] = (
-            df_in_report["coverage_unmethylated"],
-            df_in_report["coverage_methylated"],
-        )
     df_in_report["Coverage"] = df_in_report["coverage_methylated"] + df_in_report["coverage_unmethylated"]
     return df_in_report

--- a/src/methylation/ugbio_methylation/process_mbias.py
+++ b/src/methylation/ugbio_methylation/process_mbias.py
@@ -58,7 +58,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     ap_var.add_argument(
         "--noCpG", help="use this flag to tag Mbias call on no-CpG cytosines", action="store_true", default=False
     )
-    ap_var.add_argument("--taps", help="Indicate if input is TAPS data", action="store_true", default=False)
 
     return ap_var.parse_args(argv[1:])
 
@@ -79,11 +78,6 @@ def run(argv: list[str] | None = None):
         # import Mbais file
         in_file_name = args.input
         df_mbias_input = pd.read_csv(in_file_name, sep="\t")
-        if args.taps:
-            df_mbias_input["nMethylated"], df_mbias_input["nUnmethylated"] = (
-                df_mbias_input["nUnmethylated"],
-                df_mbias_input["nMethylated"],
-            )
         df_mbias_input["PercentMethylation"] = df_mbias_input["nMethylated"] / (
             df_mbias_input["nMethylated"] + df_mbias_input["nUnmethylated"]
         )

--- a/src/methylation/ugbio_methylation/process_merge_context.py
+++ b/src/methylation/ugbio_methylation/process_merge_context.py
@@ -66,7 +66,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     ap_var.add_argument("--input", help="MethylDackel mergeContext file", type=str, required=True)
     ap_var.add_argument("--output", help="Output file basename", type=str, required=True)
-    ap_var.add_argument("--taps", help="Indicate if input is TAPS data", action="store_true", default=False)
 
     return ap_var.parse_args(argv[1:])
 
@@ -86,7 +85,7 @@ def run(argv: list[str] | None = None):
         # import input files
         # ============================================================================
         in_file_name = args.input
-        df_in_report = read_merge_context_file(in_file_name, is_taps=args.taps)
+        df_in_report = read_merge_context_file(in_file_name)
 
         # Get chromosomes and genomes from MethylDackel mergeContext file
         # ===================================================================

--- a/src/methylation/ugbio_methylation/process_merge_context_no_cp_g.py
+++ b/src/methylation/ugbio_methylation/process_merge_context_no_cp_g.py
@@ -63,7 +63,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     ap_var.add_argument("--input_chg", help="MethylDackel mergeContext CHG context file", type=str, required=True)
     ap_var.add_argument("--input_chh", help="MethylDackel mergeContext CHH context file", type=str, required=True)
     ap_var.add_argument("--output", help="Output file basename", type=str, required=True)
-    ap_var.add_argument("--taps", help="Indicate if input is TAPS data", action="store_true", default=False)
 
     return ap_var.parse_args(argv[1:])
 
@@ -84,10 +83,10 @@ def run(argv: list[str] | None = None):
         # import input files
         # ====================================================================
         # import CHG file
-        df_chg_input = read_merge_context_file(args.input_chg, is_taps=args.taps)
+        df_chg_input = read_merge_context_file(args.input_chg)
 
         # import CHG file
-        df_chh_input = read_merge_context_file(args.input_chh, is_taps=args.taps)
+        df_chh_input = read_merge_context_file(args.input_chh)
 
         pat = r"[^Lambda_NEB|pUC19]"  # limit to the human genome chromosomes
         idx_chg = df_chg_input.chr.str.contains(pat)

--- a/src/methylation/ugbio_methylation/process_per_read.py
+++ b/src/methylation/ugbio_methylation/process_per_read.py
@@ -56,7 +56,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     ap_var.add_argument("--input", help="MethylDackel perRead file", type=str, required=True)
     ap_var.add_argument("--output", help="Output file basename", type=str, required=True)
-    ap_var.add_argument("--taps", help="Indicate if input is TAPS data", action="store_true", default=False)
 
     return ap_var.parse_args(argv[1:])
 
@@ -77,8 +76,6 @@ def run(argv: list[str] | None = None):
         in_file_name = args.input
         col_names = ["read_name", "chr", "start", "PercentMethylation", "TotalCpGs"]
         df_per_read = pd.read_csv(in_file_name, sep="\t", header=0, names=col_names)
-        if args.taps:
-            df_per_read["PercentMethylation"] = 100 - df_per_read["PercentMethylation"]
         df_per_read = df_per_read.drop(columns="read_name")
         df_per_read = df_per_read.dropna()
 


### PR DESCRIPTION
## Summary

Moves methylation post-processing to use the Ultimagen MethylDackel fork ([Ultimagen/MethylDackel PR #1](https://github.com/Ultimagen/MethylDackel/pull/1)), which adds two new flags:

- [`--reversed`](https://github.com/Ultimagen/MethylDackel/pull/1) — swaps OT↔OB / CTOT↔CTOB strand assignment for TAPS + linear amplification libraries where the strand direction is flipped.
- [`--methylated-cytosine-converted`](https://github.com/Ultimagen/MethylDackel/commit/430c1f3) — treats C→T (OT/CTOT) and G→A (OB/CTOB) as **methylated** rather than unmethylated, matching TAPS chemistry at the decision point inside MethylDackel.

With `--methylated-cytosine-converted` available, the Python post-processors no longer need to flip methylation counts after the fact. This PR ([`d17e8eeb`](https://github.com/Ultimagen/ugbio-utils/commit/d17e8eeb)) removes the `--taps` CLI flag from all four post-processors:

- `process_merge_context`
- `process_merge_context_no_cp_g`
- `process_mbias`
- `process_per_read`

And drops the `is_taps=` parameter from `read_merge_context_file()` in `methyldackel_utils.py`.

## Why move the inversion to MethylDackel

Previously, the Python post-processors received bedGraphs with methylation calls made under a bisulfite assumption and reinterpreted them for TAPS (`PercentMethylation = 100 - PercentMethylation` and swap methylated/unmethylated coverage columns). That had two problems:

1. **Double-rounding.** MethylDackel writes `PercentMethylation` as `(int)(100.0 * nmeth / (nmeth+nunmeth))` — a floor-truncation. Flipping via `100 - x` in Python introduces a second rounding step, so sites near bin boundaries end up in a different histogram bucket than they should (by 1 percentage point). Doing the swap inside `updateMetrics` / `getMethylState` removes the second rounding.
2. **Incomplete coverage.** The Python flip only corrected CSV/JSON outputs. Raw bedGraph, `.mbias.tsv`, perRead bedGraph, and SVGs carried bisulfite semantics forever. With the flag in MethylDackel, every output is directly correct for TAPS.

## Files changed

- [`src/methylation/Dockerfile`](../blob/BIOIN-2781-methyldackel-reversed-strand/src/methylation/Dockerfile) — clones MethylDackel from the `feature/reversed-strand-flag` branch.
- `src/methylation/ugbio_methylation/process_merge_context.py` — drop `--taps` arg and `is_taps=args.taps` call.
- `src/methylation/ugbio_methylation/process_merge_context_no_cp_g.py` — drop `--taps` arg and both `is_taps=args.taps` calls.
- `src/methylation/ugbio_methylation/process_mbias.py` — drop `--taps` arg and nMethylated/nUnmethylated swap block.
- `src/methylation/ugbio_methylation/process_per_read.py` — drop `--taps` arg and `PercentMethylation = 100 - PercentMethylation` block.
- `src/methylation/ugbio_methylation/methyldackel_utils.py` — simplify `read_merge_context_file(in_file_name)`, drop `is_taps` parameter and swap logic.
- `src/methylation/tests/system/test_methyldackel_qc_parsing.py` — delete four stale `_taps` test methods.

## Dependent PRs

- MethylDackel flag implementation: https://github.com/Ultimagen/MethylDackel/pull/1
- terra_pipeline WDL wiring & end-to-end test: https://github.com/Ultimagen/terra_pipeline/pull/2116

## Test plan

- [x] `uv run pytest src/methylation/tests/` — 10/10 pass locally after removals.
- [x] Docker build succeeds via [Build ugbio docker GH Action run 24831084627](https://github.com/Ultimagen/ugbio-utils/actions/runs/24831084627) — image `ugbio_methylation:test_mcc_430c1f3` pushed to ECR.
- [x] End-to-end regression in [terra_pipeline PR #2116](https://github.com/Ultimagen/terra_pipeline/pull/2116) — Omics run [`9155201`](https://proxy.ultimagen.dev/s3/ultimagen-pipelines-380827583499-us-east-1-outputs/MethylDackelQC/BIOIN-2781-methyldackel-reversed-strand-0d19bb-055451-nightly-long/9155201/out/report_html/6010600705-CL35301-Z0245-CATGCAGAGCGCCTGAT_rd1_500M.methyl_seq.applicationQC.html) COMPLETED.
- [x] Numerical comparison vs. baseline Omics run [`4822060`](https://proxy.ultimagen.dev/s3/ultimagen-pipelines-380827583499-us-east-1-outputs/MethylDackelQC/BIOIN-2781-methyldackel-reversed-strand-fa101f-709f16-long/4822060/out/report_html/6010600705-CL35301-Z0245-CATGCAGAGCGCCTGAT_rd1_500M.methyl_seq.applicationQC.html) (reversed + Python `--taps`): identical `TotalCpGs`, `Coverage_*`, and `PercentMethylation_median`; sub-percent shifts in mean/histogram attributable to removed double-rounding (see PR #2116 description for details).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 31fcf9f4d6a15b594b6fe3c85e3a220729f577ce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->