### PR TITLE
make gpus visible in srsnv docker wehn using miniwdl

### DIFF
--- a/src/srsnv/Dockerfile
+++ b/src/srsnv/Dockerfile
@@ -18,6 +18,9 @@ RUN python -m build --outdir $OUT_DIR --wheel ./src/$MODULE_DIR
 ##################################################################
 FROM $BASE_IMAGE
 
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
 ARG OUT_DIR
 
 RUN groupadd ugbio && useradd -m ugbio -g ugbio


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Docker runtime change that only sets NVIDIA visibility/capabilities env vars; main risk is altered behavior on non-GPU hosts or different container runtimes.
> 
> **Overview**
> Ensures the `srsnv` runtime container advertises GPU availability by setting `NVIDIA_VISIBLE_DEVICES=all` and `NVIDIA_DRIVER_CAPABILITIES=compute,utility` in the final image stage.
> 
> This is intended to make GPUs visible when running under `miniwdl`/NVIDIA container runtimes without changing the build or Python packaging steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9aac7cd581a44c00c8ae001250a151a6f4fcde0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->