### PR TITLE
Add is_null/is_not_null/any_not_null filter operators and Flag field support

### DIFF
--- a/src/featuremap/pyproject.toml
+++ b/src/featuremap/pyproject.toml
@@ -24,6 +24,7 @@ run_tests = "pytest:main"
 featuremap_to_dataframe = "ugbio_featuremap.featuremap_to_dataframe:main"
 filter_featuremap = "ugbio_featuremap.filter_dataframe:main"
 somatic_snvfind_classifier = "ugbio_featuremap.somatic_snvfind_classifier:main"
+prepare_annotation_vcfs = "ugbio_featuremap.prepare_annotation_vcfs:main"
 
 [tool.uv.sources.ugbio_core]
 workspace = true

--- a/src/featuremap/tests/unit/test_annotation_filtering.py
+++ b/src/featuremap/tests/unit/test_annotation_filtering.py
@@ -1,19 +1,5 @@
 import polars as pl
-from ugbio_featuremap.featuremap_to_dataframe import VCFJobConfig, _apply_annotation_filters
-
-
-def _make_job_cfg(**kwargs) -> VCFJobConfig:
-    defaults = {
-        "bcftools_path": "bcftools",
-        "awk_script": "",
-        "columns": [],
-        "schema": {},
-        "column_config": None,
-        "sample_list": ["S1"],
-        "log_level": 20,
-    }
-    defaults.update(kwargs)
-    return VCFJobConfig(**defaults)
+from ugbio_featuremap.filter_dataframe import _create_filter_columns, _create_final_filter_column, _mask_for_rule
 
 
 def _sample_frame() -> pl.DataFrame:
@@ -28,73 +14,94 @@ def _sample_frame() -> pl.DataFrame:
     )
 
 
-def test_exclude_single_field():
-    cfg = _make_job_cfg(exclude_if_annotated=["PCAWG"])
-    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
+def _apply_filters(frame: pl.DataFrame, filters: list[dict]) -> pl.DataFrame:
+    lazy = frame.lazy()
+    lazy, filter_cols = _create_filter_columns(lazy, filters)
+    lazy = _create_final_filter_column(lazy, filter_cols, None)
+    result = lazy.collect()
+    return result.filter(pl.col("__filter_final")).select(pl.exclude("^__filter_.*$"))
+
+
+def test_is_null_excludes_annotated():
+    filters = [{"name": "not_pcawg", "type": "region", "field": "PCAWG", "op": "is_null"}]
+    result = _apply_filters(_sample_frame(), filters)
     assert result.height == 2
     assert result["POS"].to_list() == [200, 400]
 
 
-def test_exclude_multiple_fields():
-    cfg = _make_job_cfg(exclude_if_annotated=["PCAWG", "EXCLUDE_TRAINING"])
-    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
-    assert result.height == 0
-
-
-def test_include_single_field():
-    cfg = _make_job_cfg(include_only_annotated=["INCLUDE_INFERENCE"])
-    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
+def test_is_not_null_includes_annotated():
+    filters = [{"name": "has_include", "type": "region", "field": "INCLUDE_INFERENCE", "op": "is_not_null"}]
+    result = _apply_filters(_sample_frame(), filters)
     assert result.height == 2
     assert result["POS"].to_list() == [100, 500]
 
 
-def test_include_multiple_fields_or_logic():
-    cfg = _make_job_cfg(include_only_annotated=["INCLUDE_INFERENCE", "PCAWG"])
-    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
+def test_is_null_multiple_fields_and_logic():
+    filters = [
+        {"name": "not_pcawg", "type": "region", "field": "PCAWG", "op": "is_null"},
+        {"name": "not_excluded", "type": "region", "field": "EXCLUDE_TRAINING", "op": "is_null"},
+    ]
+    result = _apply_filters(_sample_frame(), filters)
+    assert result.height == 0
+
+
+def test_any_not_null_or_logic():
+    filters = [
+        {"name": "in_inference", "type": "region", "op": "any_not_null", "fields": ["INCLUDE_INFERENCE", "PCAWG"]}
+    ]
+    result = _apply_filters(_sample_frame(), filters)
     assert result.height == 3
     assert result["POS"].to_list() == [100, 300, 500]
 
 
-def test_missing_column_no_op():
-    cfg = _make_job_cfg(exclude_if_annotated=["NONEXISTENT_FIELD"])
-    frame = _sample_frame()
-    result = _apply_annotation_filters(frame, cfg, "test")
-    assert result.height == frame.height
-
-
-def test_include_missing_column_no_op():
-    cfg = _make_job_cfg(include_only_annotated=["NONEXISTENT_FIELD"])
-    frame = _sample_frame()
-    result = _apply_annotation_filters(frame, cfg, "test")
-    assert result.height == frame.height
-
-
-def test_no_filters_no_op():
-    cfg = _make_job_cfg()
-    frame = _sample_frame()
-    result = _apply_annotation_filters(frame, cfg, "test")
-    assert result.height == frame.height
-
-
-def test_exclude_and_include_combined():
-    cfg = _make_job_cfg(
-        exclude_if_annotated=["EXCLUDE_TRAINING"],
-        include_only_annotated=["PCAWG"],
-    )
-    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
+def test_any_not_null_single_field():
+    filters = [{"name": "has_pcawg", "type": "region", "op": "any_not_null", "fields": ["PCAWG"]}]
+    result = _apply_filters(_sample_frame(), filters)
     assert result.height == 3
     assert result["POS"].to_list() == [100, 300, 500]
 
 
-def test_exclude_all_rows():
-    frame = pl.DataFrame({"CHROM": ["chr1", "chr1"], "POS": [1, 2], "PCAWG": ["a", "b"]})
-    cfg = _make_job_cfg(exclude_if_annotated=["PCAWG"])
-    result = _apply_annotation_filters(frame, cfg, "test")
+def test_is_null_combined_with_any_not_null():
+    filters = [
+        {"name": "not_excluded", "type": "region", "field": "EXCLUDE_TRAINING", "op": "is_null"},
+        {"name": "in_inference", "type": "region", "op": "any_not_null", "fields": ["INCLUDE_INFERENCE", "PCAWG"]},
+    ]
+    result = _apply_filters(_sample_frame(), filters)
+    assert result.height == 3
+    assert result["POS"].to_list() == [100, 300, 500]
+
+
+def test_no_filters_returns_all():
+    frame = _sample_frame()
+    lazy = frame.lazy()
+    lazy, filter_cols = _create_filter_columns(lazy, [])
+    assert filter_cols == []
+    assert lazy.collect().height == 5
+
+
+def test_is_null_all_null_column():
+    frame = pl.DataFrame({"POS": [1, 2], "FIELD": [None, None]})
+    filters = [{"name": "test", "type": "region", "field": "FIELD", "op": "is_null"}]
+    result = _apply_filters(frame, filters)
+    assert result.height == 2
+
+
+def test_is_not_null_all_null_column():
+    frame = pl.DataFrame({"POS": [1, 2], "FIELD": [None, None]})
+    filters = [{"name": "test", "type": "region", "field": "FIELD", "op": "is_not_null"}]
+    result = _apply_filters(frame, filters)
     assert result.height == 0
 
 
-def test_include_filters_empty_when_no_match():
-    frame = pl.DataFrame({"CHROM": ["chr1", "chr1"], "POS": [1, 2], "PCAWG": [None, None]})
-    cfg = _make_job_cfg(include_only_annotated=["PCAWG"])
-    result = _apply_annotation_filters(frame, cfg, "test")
-    assert result.height == 0
+def test_mask_for_rule_is_null():
+    expr = _mask_for_rule({"field": "X", "op": "is_null", "type": "region"})
+    frame = pl.DataFrame({"X": ["a", None, "b"]})
+    result = frame.select(expr.alias("mask"))["mask"].to_list()
+    assert result == [False, True, False]
+
+
+def test_mask_for_rule_any_not_null():
+    expr = _mask_for_rule({"op": "any_not_null", "type": "region", "fields": ["A", "B"]})
+    frame = pl.DataFrame({"A": [None, "x", None], "B": [None, None, "y"]})
+    result = frame.select(expr.alias("mask"))["mask"].to_list()
+    assert result == [False, True, True]

--- a/src/featuremap/tests/unit/test_annotation_filtering.py
+++ b/src/featuremap/tests/unit/test_annotation_filtering.py
@@ -1,0 +1,100 @@
+import polars as pl
+from ugbio_featuremap.featuremap_to_dataframe import VCFJobConfig, _apply_annotation_filters
+
+
+def _make_job_cfg(**kwargs) -> VCFJobConfig:
+    defaults = {
+        "bcftools_path": "bcftools",
+        "awk_script": "",
+        "columns": [],
+        "schema": {},
+        "column_config": None,
+        "sample_list": ["S1"],
+        "log_level": 20,
+    }
+    defaults.update(kwargs)
+    return VCFJobConfig(**defaults)
+
+
+def _sample_frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "CHROM": ["chr1", "chr1", "chr1", "chr2", "chr2"],
+            "POS": [100, 200, 300, 400, 500],
+            "PCAWG": ["rs1", None, "rs3", None, "rs5"],
+            "EXCLUDE_TRAINING": [None, "ex1", None, "ex2", None],
+            "INCLUDE_INFERENCE": ["inc1", None, None, None, "inc5"],
+        }
+    )
+
+
+def test_exclude_single_field():
+    cfg = _make_job_cfg(exclude_if_annotated=["PCAWG"])
+    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
+    assert result.height == 2
+    assert result["POS"].to_list() == [200, 400]
+
+
+def test_exclude_multiple_fields():
+    cfg = _make_job_cfg(exclude_if_annotated=["PCAWG", "EXCLUDE_TRAINING"])
+    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
+    assert result.height == 0
+
+
+def test_include_single_field():
+    cfg = _make_job_cfg(include_only_annotated=["INCLUDE_INFERENCE"])
+    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
+    assert result.height == 2
+    assert result["POS"].to_list() == [100, 500]
+
+
+def test_include_multiple_fields_or_logic():
+    cfg = _make_job_cfg(include_only_annotated=["INCLUDE_INFERENCE", "PCAWG"])
+    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
+    assert result.height == 3
+    assert result["POS"].to_list() == [100, 300, 500]
+
+
+def test_missing_column_no_op():
+    cfg = _make_job_cfg(exclude_if_annotated=["NONEXISTENT_FIELD"])
+    frame = _sample_frame()
+    result = _apply_annotation_filters(frame, cfg, "test")
+    assert result.height == frame.height
+
+
+def test_include_missing_column_no_op():
+    cfg = _make_job_cfg(include_only_annotated=["NONEXISTENT_FIELD"])
+    frame = _sample_frame()
+    result = _apply_annotation_filters(frame, cfg, "test")
+    assert result.height == frame.height
+
+
+def test_no_filters_no_op():
+    cfg = _make_job_cfg()
+    frame = _sample_frame()
+    result = _apply_annotation_filters(frame, cfg, "test")
+    assert result.height == frame.height
+
+
+def test_exclude_and_include_combined():
+    cfg = _make_job_cfg(
+        exclude_if_annotated=["EXCLUDE_TRAINING"],
+        include_only_annotated=["PCAWG"],
+    )
+    result = _apply_annotation_filters(_sample_frame(), cfg, "test")
+    assert result.height == 3
+    assert result["POS"].to_list() == [100, 300, 500]
+
+
+def test_exclude_all_rows():
+    frame = pl.DataFrame({"CHROM": ["chr1", "chr1"], "POS": [1, 2], "PCAWG": ["a", "b"]})
+    cfg = _make_job_cfg(exclude_if_annotated=["PCAWG"])
+    result = _apply_annotation_filters(frame, cfg, "test")
+    assert result.height == 0
+
+
+def test_include_filters_empty_when_no_match():
+    frame = pl.DataFrame({"CHROM": ["chr1", "chr1"], "POS": [1, 2], "PCAWG": [None, None]})
+    cfg = _make_job_cfg(include_only_annotated=["PCAWG"])
+    result = _apply_annotation_filters(frame, cfg, "test")
+    assert result.height == 0

--- a/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
@@ -1386,7 +1386,13 @@ def _process_region_to_parquet(
                     log.debug(f"Region {region}: all rows filtered out")
                     return ""
 
+            rows_before_annot = frame.height
             frame = _apply_annotation_filters(frame, job_cfg, region)
+            if frame.height < rows_before_annot:
+                log.info(
+                    f"Region {region}: annotation filter removed {rows_before_annot - frame.height:,} "
+                    f"additional rows ({rows_before_annot:,} -> {frame.height:,})"
+                )
             if frame.is_empty():
                 return ""
 
@@ -1557,8 +1563,8 @@ def _convert_sample_frames_to_polars(
                 rows_before = frame.height
                 frame = _apply_read_filters(frame, job_cfg.read_filters)
                 log.debug(f"Sample {sample}, region {region}: {rows_before:,} -> {frame.height:,} rows after filtering")
-            if not frame.is_empty():
-                frame = _apply_annotation_filters(frame, job_cfg, region)
+                if not frame.is_empty():
+                    frame = _apply_annotation_filters(frame, job_cfg, region)
             if not frame.is_empty():
                 frames[sample] = frame
 

--- a/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
@@ -176,6 +176,8 @@ _QUOTED_VALUE = r'"((?:[^"\\]|\\.)*)'
 INFO_RE = re.compile(rf"##INFO=<ID=([^,]+),Number=([^,]+),Type=([^,]+),Description={_QUOTED_VALUE}")
 FORMAT_RE = re.compile(rf"##FORMAT=<ID=([^,]+),Number=([^,]+),Type=([^,]+),Description={_QUOTED_VALUE}")
 
+# Flag→Utf8: bcftools query outputs "1"/"."; Polars can't parse "1" as Boolean.
+# With Utf8, "." becomes null (via null_values) and "1" is non-null — is_null()/is_not_null() works.
 _POLARS_DTYPE = {"Integer": pl.Int64, "Float": pl.Float64, "Flag": pl.Utf8}
 # VCF column names – imported from FeatureMapFields for consistency
 CHROM = FeatureMapFields.CHROM.value

--- a/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
@@ -167,6 +167,8 @@ class VCFJobConfig:
     sample_list: list[str]
     log_level: int
     read_filters: dict | None = None
+    exclude_if_annotated: list[str] | None = None
+    include_only_annotated: list[str] | None = None
 
 
 # ───────────────── header helpers ────────────────────────────────────────────
@@ -1067,6 +1069,8 @@ def vcf_to_parquet(  # noqa: PLR0915, C901, PLR0912, PLR0913
     read_filter_json_key: str | None = None,
     downsample_reads: int | None = None,
     downsample_seed: int | None = None,
+    exclude_if_annotated: list[str] | None = None,
+    include_only_annotated: list[str] | None = None,
 ) -> None:
     """
     Convert VCF to Parquet using region-based parallel processing.
@@ -1113,6 +1117,10 @@ def vcf_to_parquet(  # noqa: PLR0915, C901, PLR0912, PLR0913
     log.info(f"Input: {vcf}")
     log.info(f"Output: {out}")
     log.info(f"List mode: {list_mode}")
+    if exclude_if_annotated:
+        log.info(f"Exclude-if-annotated fields: {exclude_if_annotated}")
+    if include_only_annotated:
+        log.info(f"Include-only-annotated fields: {include_only_annotated}")
 
     _assert_vcf_index_exists(vcf)
     log.debug("VCF index found")
@@ -1240,6 +1248,8 @@ def vcf_to_parquet(  # noqa: PLR0915, C901, PLR0912, PLR0913
             sample_list=sample_list,
             log_level=log_level,
             read_filters=read_filters,
+            exclude_if_annotated=exclude_if_annotated,
+            include_only_annotated=include_only_annotated,
         )
 
         # Temporary directory for ordered part-files
@@ -1279,7 +1289,37 @@ def vcf_to_parquet(  # noqa: PLR0915, C901, PLR0912, PLR0913
 
             _merge_parquet_files_lazy(part_files, out, downsample_reads, downsample_seed)
 
-        log.info(f"Conversion completed: {out}")
+        final_row_count = pl.scan_parquet(out).select(pl.len()).collect().item()
+        log.info(f"Conversion completed: {out} ({final_row_count:,} rows)")
+        if exclude_if_annotated:
+            log.info(f"Annotation exclude filter was active for fields: {exclude_if_annotated}")
+        if include_only_annotated:
+            log.info(f"Annotation include filter was active for fields: {include_only_annotated}")
+
+
+def _apply_annotation_filters(frame: pl.DataFrame, job_cfg: VCFJobConfig, region: str) -> pl.DataFrame:
+    """Apply annotation-based exclude/include filters to a DataFrame."""
+    if job_cfg.exclude_if_annotated:
+        for field_name in job_cfg.exclude_if_annotated:
+            if field_name in frame.columns:
+                before = frame.height
+                frame = frame.filter(pl.col(field_name).is_null())
+                log.info(f"Region {region}: exclude filter '{field_name}': {before:,} -> {frame.height:,}")
+            else:
+                log.warning(f"Region {region}: exclude field '{field_name}' not found in columns, skipping")
+    if job_cfg.include_only_annotated:
+        present_fields = [f for f in job_cfg.include_only_annotated if f in frame.columns]
+        missing_fields = [f for f in job_cfg.include_only_annotated if f not in frame.columns]
+        if missing_fields:
+            log.warning(f"Region {region}: include fields {missing_fields} not found in columns, skipping them")
+        if present_fields:
+            include_mask = pl.col(present_fields[0]).is_not_null()
+            for field_name in present_fields[1:]:
+                include_mask = include_mask | pl.col(field_name).is_not_null()
+            before = frame.height
+            frame = frame.filter(include_mask)
+            log.info(f"Region {region}: include filter {present_fields}: {before:,} -> {frame.height:,}")
+    return frame
 
 
 def _process_region_to_parquet(
@@ -1345,6 +1385,10 @@ def _process_region_to_parquet(
                 if frame.is_empty():
                     log.debug(f"Region {region}: all rows filtered out")
                     return ""
+
+            frame = _apply_annotation_filters(frame, job_cfg, region)
+            if frame.is_empty():
+                return ""
 
             log.debug(f"Region {region}: writing {frame.height} rows to {output_file}")
             frame.write_parquet(output_file)
@@ -1513,6 +1557,8 @@ def _convert_sample_frames_to_polars(
                 rows_before = frame.height
                 frame = _apply_read_filters(frame, job_cfg.read_filters)
                 log.debug(f"Sample {sample}, region {region}: {rows_before:,} -> {frame.height:,} rows after filtering")
+            if not frame.is_empty():
+                frame = _apply_annotation_filters(frame, job_cfg, region)
             if not frame.is_empty():
                 frames[sample] = frame
 
@@ -1694,6 +1740,18 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Random seed for reproducible downsampling",
     )
+    parser.add_argument(
+        "--exclude-if-annotated",
+        nargs="*",
+        default=None,
+        help="Exclude rows where any of these INFO fields has a non-null value",
+    )
+    parser.add_argument(
+        "--include-only-annotated",
+        nargs="*",
+        default=None,
+        help="Include only rows where at least one of these INFO fields has a non-null value",
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args(argv)
 
@@ -1728,6 +1786,8 @@ def main(argv: list[str] | None = None) -> None:
         read_filter_json_key=args.read_filter_json_key,
         downsample_reads=args.downsample_reads,
         downsample_seed=args.downsample_seed,
+        exclude_if_annotated=args.exclude_if_annotated,
+        include_only_annotated=args.include_only_annotated,
     )
 
 

--- a/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
@@ -1313,12 +1313,15 @@ def _apply_annotation_filters(frame: pl.DataFrame, job_cfg: VCFJobConfig, region
         if missing_fields:
             log.warning(f"Region {region}: include fields {missing_fields} not found in columns, skipping them")
         if present_fields:
+            before = frame.height
+            for field_name in present_fields:
+                count = frame.filter(pl.col(field_name).is_not_null()).height
+                log.info(f"Region {region}: include field '{field_name}' matches {count:,} / {before:,} rows")
             include_mask = pl.col(present_fields[0]).is_not_null()
             for field_name in present_fields[1:]:
                 include_mask = include_mask | pl.col(field_name).is_not_null()
-            before = frame.height
             frame = frame.filter(include_mask)
-            log.info(f"Region {region}: include filter {present_fields}: {before:,} -> {frame.height:,}")
+            log.info(f"Region {region}: include filter (union): {before:,} -> {frame.height:,}")
     return frame
 
 

--- a/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
@@ -167,8 +167,6 @@ class VCFJobConfig:
     sample_list: list[str]
     log_level: int
     read_filters: dict | None = None
-    exclude_if_annotated: list[str] | None = None
-    include_only_annotated: list[str] | None = None
 
 
 # ───────────────── header helpers ────────────────────────────────────────────
@@ -1069,8 +1067,6 @@ def vcf_to_parquet(  # noqa: PLR0915, C901, PLR0912, PLR0913
     read_filter_json_key: str | None = None,
     downsample_reads: int | None = None,
     downsample_seed: int | None = None,
-    exclude_if_annotated: list[str] | None = None,
-    include_only_annotated: list[str] | None = None,
 ) -> None:
     """
     Convert VCF to Parquet using region-based parallel processing.
@@ -1117,10 +1113,6 @@ def vcf_to_parquet(  # noqa: PLR0915, C901, PLR0912, PLR0913
     log.info(f"Input: {vcf}")
     log.info(f"Output: {out}")
     log.info(f"List mode: {list_mode}")
-    if exclude_if_annotated:
-        log.info(f"Exclude-if-annotated fields: {exclude_if_annotated}")
-    if include_only_annotated:
-        log.info(f"Include-only-annotated fields: {include_only_annotated}")
 
     _assert_vcf_index_exists(vcf)
     log.debug("VCF index found")
@@ -1248,8 +1240,6 @@ def vcf_to_parquet(  # noqa: PLR0915, C901, PLR0912, PLR0913
             sample_list=sample_list,
             log_level=log_level,
             read_filters=read_filters,
-            exclude_if_annotated=exclude_if_annotated,
-            include_only_annotated=include_only_annotated,
         )
 
         # Temporary directory for ordered part-files
@@ -1291,38 +1281,6 @@ def vcf_to_parquet(  # noqa: PLR0915, C901, PLR0912, PLR0913
 
         final_row_count = pl.scan_parquet(out).select(pl.len()).collect().item()
         log.info(f"Conversion completed: {out} ({final_row_count:,} rows)")
-        if exclude_if_annotated:
-            log.info(f"Annotation exclude filter was active for fields: {exclude_if_annotated}")
-        if include_only_annotated:
-            log.info(f"Annotation include filter was active for fields: {include_only_annotated}")
-
-
-def _apply_annotation_filters(frame: pl.DataFrame, job_cfg: VCFJobConfig, region: str) -> pl.DataFrame:
-    """Apply annotation-based exclude/include filters to a DataFrame."""
-    if job_cfg.exclude_if_annotated:
-        for field_name in job_cfg.exclude_if_annotated:
-            if field_name in frame.columns:
-                before = frame.height
-                frame = frame.filter(pl.col(field_name).is_null())
-                log.info(f"Region {region}: exclude filter '{field_name}': {before:,} -> {frame.height:,}")
-            else:
-                log.warning(f"Region {region}: exclude field '{field_name}' not found in columns, skipping")
-    if job_cfg.include_only_annotated:
-        present_fields = [f for f in job_cfg.include_only_annotated if f in frame.columns]
-        missing_fields = [f for f in job_cfg.include_only_annotated if f not in frame.columns]
-        if missing_fields:
-            log.warning(f"Region {region}: include fields {missing_fields} not found in columns, skipping them")
-        if present_fields:
-            before = frame.height
-            for field_name in present_fields:
-                count = frame.filter(pl.col(field_name).is_not_null()).height
-                log.info(f"Region {region}: include field '{field_name}' matches {count:,} / {before:,} rows")
-            include_mask = pl.col(present_fields[0]).is_not_null()
-            for field_name in present_fields[1:]:
-                include_mask = include_mask | pl.col(field_name).is_not_null()
-            frame = frame.filter(include_mask)
-            log.info(f"Region {region}: include filter (union): {before:,} -> {frame.height:,}")
-    return frame
 
 
 def _process_region_to_parquet(
@@ -1388,16 +1346,6 @@ def _process_region_to_parquet(
                 if frame.is_empty():
                     log.debug(f"Region {region}: all rows filtered out")
                     return ""
-
-            rows_before_annot = frame.height
-            frame = _apply_annotation_filters(frame, job_cfg, region)
-            if frame.height < rows_before_annot:
-                log.info(
-                    f"Region {region}: annotation filter removed {rows_before_annot - frame.height:,} "
-                    f"additional rows ({rows_before_annot:,} -> {frame.height:,})"
-                )
-            if frame.is_empty():
-                return ""
 
             log.debug(f"Region {region}: writing {frame.height} rows to {output_file}")
             frame.write_parquet(output_file)
@@ -1566,8 +1514,6 @@ def _convert_sample_frames_to_polars(
                 rows_before = frame.height
                 frame = _apply_read_filters(frame, job_cfg.read_filters)
                 log.debug(f"Sample {sample}, region {region}: {rows_before:,} -> {frame.height:,} rows after filtering")
-                if not frame.is_empty():
-                    frame = _apply_annotation_filters(frame, job_cfg, region)
             if not frame.is_empty():
                 frames[sample] = frame
 
@@ -1749,18 +1695,6 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Random seed for reproducible downsampling",
     )
-    parser.add_argument(
-        "--exclude-if-annotated",
-        nargs="*",
-        default=None,
-        help="Exclude rows where any of these INFO fields has a non-null value",
-    )
-    parser.add_argument(
-        "--include-only-annotated",
-        nargs="*",
-        default=None,
-        help="Include only rows where at least one of these INFO fields has a non-null value",
-    )
     parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
     args = parser.parse_args(argv)
 
@@ -1795,8 +1729,6 @@ def main(argv: list[str] | None = None) -> None:
         read_filter_json_key=args.read_filter_json_key,
         downsample_reads=args.downsample_reads,
         downsample_seed=args.downsample_seed,
-        exclude_if_annotated=args.exclude_if_annotated,
-        include_only_annotated=args.include_only_annotated,
     )
 
 

--- a/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_to_dataframe.py
@@ -178,7 +178,7 @@ _QUOTED_VALUE = r'"((?:[^"\\]|\\.)*)'
 INFO_RE = re.compile(rf"##INFO=<ID=([^,]+),Number=([^,]+),Type=([^,]+),Description={_QUOTED_VALUE}")
 FORMAT_RE = re.compile(rf"##FORMAT=<ID=([^,]+),Number=([^,]+),Type=([^,]+),Description={_QUOTED_VALUE}")
 
-_POLARS_DTYPE = {"Integer": pl.Int64, "Float": pl.Float64, "Flag": pl.Boolean}
+_POLARS_DTYPE = {"Integer": pl.Int64, "Float": pl.Float64, "Flag": pl.Utf8}
 # VCF column names – imported from FeatureMapFields for consistency
 CHROM = FeatureMapFields.CHROM.value
 POS = FeatureMapFields.POS.value
@@ -534,7 +534,7 @@ def _cast_expr(col: str, meta: dict) -> pl.Expr:
         cats = meta["cat"] + ([] if "" in meta["cat"] else [""])
         return base.fill_null(value="").str.to_uppercase().cast(pl.Enum(cats), strict=True).alias(col)
     elif meta["type"] == "Flag":
-        return base.fill_null(value=False).cast(pl.Boolean, strict=True).alias(col)
+        return base.alias(col)
     elif meta["type"] in _POLARS_DTYPE:
         return base.fill_null(value=0).cast(_POLARS_DTYPE[meta["type"]], strict=True).alias(col)
 

--- a/src/featuremap/ugbio_featuremap/filter_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/filter_dataframe.py
@@ -122,8 +122,8 @@ def _validate_filter(rule: dict[str, Any], index: int) -> None:
         raise ValueError(f"Filter {index} has invalid type '{rule[KEY_TYPE]}'. Must be one of: {valid_types}")
 
     if rule[KEY_OP] == OP_ANY_NOT_NULL:
-        if KEY_FIELDS not in rule or not isinstance(rule[KEY_FIELDS], list):
-            raise ValueError(f"Filter {index} with '{OP_ANY_NOT_NULL}' op requires a '{KEY_FIELDS}' list")
+        if KEY_FIELDS not in rule or not isinstance(rule[KEY_FIELDS], list) or len(rule[KEY_FIELDS]) == 0:
+            raise ValueError(f"Filter {index} with '{OP_ANY_NOT_NULL}' op requires a non-empty '{KEY_FIELDS}' list")
     elif KEY_FIELD not in rule:
         raise ValueError(f"Filter {index} missing required '{KEY_FIELD}' key")
 

--- a/src/featuremap/ugbio_featuremap/filter_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/filter_dataframe.py
@@ -29,6 +29,12 @@ KEY_SIZE = "size"
 KEY_METHOD = "method"
 KEY_SEED = "seed"
 KEY_NULL_VALUE = "null_value"
+KEY_FIELDS = "fields"
+
+# Operators
+OP_IS_NULL = "is_null"
+OP_IS_NOT_NULL = "is_not_null"
+OP_ANY_NOT_NULL = "any_not_null"
 
 # Filter types
 TYPE_QUALITY = "quality"
@@ -84,11 +90,11 @@ _OPS = {
     "ge": lambda c, v: c >= v,
     "in": lambda c, v: c.is_in(v),
     "not_in": lambda c, v: ~c.is_in(v),
-    "is_null": lambda c, v: c.is_null(),
-    "is_not_null": lambda c, v: c.is_not_null(),
+    OP_IS_NULL: lambda c, v: c.is_null(),
+    OP_IS_NOT_NULL: lambda c, v: c.is_not_null(),
 }
 
-_UNARY_OPS = {"is_null", "is_not_null", "any_not_null"}
+_UNARY_OPS = {OP_IS_NULL, OP_IS_NOT_NULL, OP_ANY_NOT_NULL}
 
 
 def _validate_filter_op(rule: dict[str, Any], index: int) -> None:
@@ -115,9 +121,9 @@ def _validate_filter(rule: dict[str, Any], index: int) -> None:
     if rule[KEY_TYPE] not in valid_types:
         raise ValueError(f"Filter {index} has invalid type '{rule[KEY_TYPE]}'. Must be one of: {valid_types}")
 
-    if rule[KEY_OP] == "any_not_null":
-        if "fields" not in rule or not isinstance(rule["fields"], list):
-            raise ValueError(f"Filter {index} with 'any_not_null' op requires a 'fields' list")
+    if rule[KEY_OP] == OP_ANY_NOT_NULL:
+        if KEY_FIELDS not in rule or not isinstance(rule[KEY_FIELDS], list):
+            raise ValueError(f"Filter {index} with '{OP_ANY_NOT_NULL}' op requires a '{KEY_FIELDS}' list")
     elif KEY_FIELD not in rule:
         raise ValueError(f"Filter {index} missing required '{KEY_FIELD}' key")
 
@@ -308,8 +314,8 @@ def _mask_for_rule(rule: dict[str, Any]) -> pl.Expr:
     """Return a boolean expression for a single rule."""
     op = rule[KEY_OP]
 
-    if op == "any_not_null":
-        fields = rule["fields"]
+    if op == OP_ANY_NOT_NULL:
+        fields = rule[KEY_FIELDS]
         expr = pl.col(fields[0]).is_not_null()
         for f in fields[1:]:
             expr = expr | pl.col(f).is_not_null()
@@ -354,7 +360,7 @@ def _create_filter_columns(
     logger.debug(f"Creating binary columns for {len(filters)} filters")
 
     for rule in filters:
-        name = rule.get(KEY_NAME) or f"{rule[KEY_FIELD]}_{rule[KEY_OP]}"
+        name = rule.get(KEY_NAME) or f"{rule.get(KEY_FIELD, '_'.join(rule.get(KEY_FIELDS, [])))}_{rule[KEY_OP]}"
         col_name = f"{COL_PREFIX_FILTER}{name}"
         filter_cols.append(col_name)
 
@@ -455,7 +461,7 @@ def _calculate_statistics(
     # Calculate cumulative filter effects
     cumulative_mask = pl.lit(value=True)
     for _i, (col, rule) in enumerate(zip(filter_cols, filters, strict=False)):
-        name = rule.get(KEY_NAME) or f"{rule[KEY_FIELD]}_{rule[KEY_OP]}"
+        name = rule.get(KEY_NAME) or f"{rule.get(KEY_FIELD, '_'.join(rule.get(KEY_FIELDS, [])))}_{rule[KEY_OP]}"
         cumulative_mask = cumulative_mask & pl.col(col)
         count = featuremap_dataframe.select(cumulative_mask.sum()).collect().item()
         funnel.append((name, count))
@@ -471,7 +477,7 @@ def _calculate_statistics(
     # Single effect statistics
     single_effect = {}
     for col, rule in zip(filter_cols, filters, strict=False):
-        name = rule.get(KEY_NAME) or f"{rule[KEY_FIELD]}_{rule[KEY_OP]}"
+        name = rule.get(KEY_NAME) or f"{rule.get(KEY_FIELD, '_'.join(rule.get(KEY_FIELDS, [])))}_{rule[KEY_OP]}"
         count = featuremap_dataframe.select(pl.col(col).sum()).collect().item()
         single_effect[name] = count
 

--- a/src/featuremap/ugbio_featuremap/filter_dataframe.py
+++ b/src/featuremap/ugbio_featuremap/filter_dataframe.py
@@ -84,34 +84,44 @@ _OPS = {
     "ge": lambda c, v: c >= v,
     "in": lambda c, v: c.is_in(v),
     "not_in": lambda c, v: ~c.is_in(v),
+    "is_null": lambda c, v: c.is_null(),
+    "is_not_null": lambda c, v: c.is_not_null(),
 }
+
+_UNARY_OPS = {"is_null", "is_not_null", "any_not_null"}
+
+
+def _validate_filter_op(rule: dict[str, Any], index: int) -> None:
+    """Validate operator and its required value keys."""
+    op = rule[KEY_OP]
+    all_ops = {*_OPS, *_UNARY_OPS}
+    if op not in all_ops:
+        raise ValueError(f"Filter {index} has unsupported operator: {op}")
+    if op not in _UNARY_OPS:
+        if KEY_VALUE not in rule and KEY_VALUES not in rule and KEY_VALUE_FIELD not in rule:
+            raise ValueError(f"Filter {index} must have either '{KEY_VALUE}', '{KEY_VALUES}', or '{KEY_VALUE_FIELD}'")
 
 
 def _validate_filter(rule: dict[str, Any], index: int) -> None:
     """Validate a single filter rule."""
     if not isinstance(rule, dict):
         raise ValueError(f"Filter {index} must be a dictionary")
-
-    # Check required fields
-    if KEY_FIELD not in rule:
-        raise ValueError(f"Filter {index} missing required '{KEY_FIELD}' key")
     if KEY_OP not in rule:
         raise ValueError(f"Filter {index} missing required '{KEY_OP}' key")
     if KEY_TYPE not in rule:
         raise ValueError(f"Filter {index} missing required '{KEY_TYPE}' key")
 
-    # Check operator
-    if rule[KEY_OP] not in _OPS:
-        raise ValueError(f"Filter {index} has unsupported operator: {rule[KEY_OP]}")
-
-    # Check type
     valid_types = {TYPE_QUALITY, TYPE_REGION, TYPE_MAPPING, TYPE_LABEL}
     if rule[KEY_TYPE] not in valid_types:
         raise ValueError(f"Filter {index} has invalid type '{rule[KEY_TYPE]}'. Must be one of: {valid_types}")
 
-    # Check value/value_field
-    if KEY_VALUE not in rule and KEY_VALUES not in rule and KEY_VALUE_FIELD not in rule:
-        raise ValueError(f"Filter {index} must have either '{KEY_VALUE}', '{KEY_VALUES}', or '{KEY_VALUE_FIELD}'")
+    if rule[KEY_OP] == "any_not_null":
+        if "fields" not in rule or not isinstance(rule["fields"], list):
+            raise ValueError(f"Filter {index} with 'any_not_null' op requires a 'fields' list")
+    elif KEY_FIELD not in rule:
+        raise ValueError(f"Filter {index} missing required '{KEY_FIELD}' key")
+
+    _validate_filter_op(rule, index)
 
 
 def _validate_downsample(ds: dict[str, Any]) -> None:
@@ -296,8 +306,20 @@ def validate_filter_config(cfg: dict[str, Any]) -> None:
 
 def _mask_for_rule(rule: dict[str, Any]) -> pl.Expr:
     """Return a boolean expression for a single rule."""
-    field = rule[KEY_FIELD]
     op = rule[KEY_OP]
+
+    if op == "any_not_null":
+        fields = rule["fields"]
+        expr = pl.col(fields[0]).is_not_null()
+        for f in fields[1:]:
+            expr = expr | pl.col(f).is_not_null()
+        return expr
+
+    field = rule[KEY_FIELD]
+
+    if op in _UNARY_OPS:
+        return _OPS[op](pl.col(field), None)
+
     if op not in _OPS:
         raise ValueError(f"Unsupported op: {op}")
 

--- a/src/featuremap/ugbio_featuremap/prepare_annotation_vcfs.py
+++ b/src/featuremap/ugbio_featuremap/prepare_annotation_vcfs.py
@@ -1,0 +1,119 @@
+"""Prepare annotation VCFs for snvfind: add Flag fields, convert to BCF, create filter JSONs.
+
+Usage::
+
+    prepare_annotation_vcfs \
+        --exclude-vcf exclude.vcf.gz --exclude-field EXCLUDE_TRAINING \
+        --include-vcf include.vcf.gz --include-field INCLUDE_INFERENCE \
+        --pcawg-vcf pcawg.vcf.gz --pcawg-field PCAWG \
+        --read-filters read_filters.json \
+        --output-dir .
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from ugbio_core.exec_utils import print_and_execute
+from ugbio_core.logger import logger
+
+
+def _add_flag_and_convert_to_bcf(vcf_path: str, field_name: str, output_bcf: str) -> None:
+    """Add a Flag INFO field to every record in a VCF and convert to indexed BCF."""
+    logger.info(f"Converting {vcf_path} to BCF with Flag field '{field_name}'")
+
+    cmd = (
+        f"(bcftools view -h {vcf_path} | grep -v '^#CHROM';"
+        f" echo '##INFO=<ID={field_name},Number=0,Type=Flag,Description=\"{field_name} annotation flag\">';"
+        f" bcftools view -h {vcf_path} | grep '^#CHROM';"
+        f" bcftools view -H {vcf_path} | awk -F'\\t' -v OFS='\\t'"
+        f' \'{{if($8==".") $8="{field_name}"; else $8=$8";{field_name}"; print}}\''
+        f") | bcftools view -Ob -o {output_bcf}"
+    )
+    print_and_execute(cmd)
+    print_and_execute(f"bcftools index {output_bcf}")
+    logger.info(f"Created {output_bcf}")
+
+
+def _inject_exclusion_filter(filters_json: dict, field_name: str) -> dict:
+    """Add an is_null exclusion filter for the given field to both filter sets."""
+    entry = {"name": f"not_in_{field_name}", "type": "region", "field": field_name, "op": "is_null"}
+    if "filters_full_output" in filters_json:
+        filters_json["filters_full_output"].append(entry)
+    if "filters_random_sample" in filters_json:
+        filters_json["filters_random_sample"].append(entry)
+    logger.info(f"Injected is_null filter for '{field_name}' into read_filters JSON")
+    return filters_json
+
+
+def _create_inference_filters(fields: list[str], output_path: str) -> None:
+    """Create inference_filters.json with any_not_null for the given fields."""
+    filters = {
+        "filters_inference": [{"name": "in_inference_set", "type": "region", "op": "any_not_null", "fields": fields}]
+    }
+    Path(output_path).write_text(json.dumps(filters, indent=2) + "\n")
+    logger.info(f"Created {output_path} with any_not_null on {fields}")
+
+
+def run(argv: list[str] | None = None) -> None:
+    """Main entry point."""
+    args = _parse_args(argv)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    read_filters = None
+    if args.read_filters:
+        with open(args.read_filters) as f:
+            read_filters = json.load(f)
+
+    inference_fields: list[str] = []
+
+    if args.exclude_vcf:
+        bcf_path = str(output_dir / "exclude_annot.bcf")
+        _add_flag_and_convert_to_bcf(args.exclude_vcf, args.exclude_field, bcf_path)
+        if read_filters:
+            read_filters = _inject_exclusion_filter(read_filters, args.exclude_field)
+
+    if args.include_vcf:
+        bcf_path = str(output_dir / "include_annot.bcf")
+        _add_flag_and_convert_to_bcf(args.include_vcf, args.include_field, bcf_path)
+        inference_fields.append(args.include_field)
+
+    if args.pcawg_vcf:
+        bcf_path = str(output_dir / "pcawg_annot.bcf")
+        _add_flag_and_convert_to_bcf(args.pcawg_vcf, args.pcawg_field, bcf_path)
+        if read_filters:
+            read_filters = _inject_exclusion_filter(read_filters, args.pcawg_field)
+        inference_fields.append(args.pcawg_field)
+
+    if read_filters:
+        out_json = str(output_dir / "read_filters_with_max_coverage.json")
+        Path(out_json).write_text(json.dumps(read_filters, indent=2) + "\n")
+        logger.info(f"Written augmented read_filters to {out_json}")
+
+    if inference_fields:
+        _create_inference_filters(inference_fields, str(output_dir / "inference_filters.json"))
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Prepare annotation VCFs for snvfind")
+    parser.add_argument("--exclude-vcf", help="Exclude-from-training annotation VCF")
+    parser.add_argument("--exclude-field", default="EXCLUDE_TRAINING", help="Field name for exclusion flag")
+    parser.add_argument("--include-vcf", help="Include-in-inference annotation VCF")
+    parser.add_argument("--include-field", default="INCLUDE_INFERENCE", help="Field name for inclusion flag")
+    parser.add_argument("--pcawg-vcf", help="PCAWG annotation VCF")
+    parser.add_argument("--pcawg-field", default="PCAWG", help="Field name for PCAWG flag")
+    parser.add_argument("--read-filters", help="Input read_filters JSON to augment with exclusion filters")
+    parser.add_argument("--output-dir", default=".", help="Output directory for BCF files and JSON")
+    return parser.parse_args(argv)
+
+
+def main():
+    run(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/featuremap/ugbio_featuremap/prepare_annotation_vcfs.py
+++ b/src/featuremap/ugbio_featuremap/prepare_annotation_vcfs.py
@@ -58,6 +58,17 @@ def _create_inference_filters(fields: list[str], output_path: str) -> None:
     logger.info(f"Created {output_path} with any_not_null on {fields}")
 
 
+def _update_coverage_threshold(filters_json: dict, coverage_threshold: int) -> dict:
+    """Update coverage_le_max filter value in both filter sets."""
+    for key in ("filters_full_output", "filters_random_sample"):
+        if key in filters_json:
+            for entry in filters_json[key]:
+                if entry.get("name") == "coverage_le_max":
+                    entry["value"] = coverage_threshold
+    logger.info(f"Updated coverage_le_max threshold to {coverage_threshold}")
+    return filters_json
+
+
 def run(argv: list[str] | None = None) -> None:
     """Main entry point."""
     args = _parse_args(argv)
@@ -68,6 +79,8 @@ def run(argv: list[str] | None = None) -> None:
     if args.read_filters:
         with open(args.read_filters) as f:
             read_filters = json.load(f)
+        if args.coverage_threshold is not None:
+            read_filters = _update_coverage_threshold(read_filters, args.coverage_threshold)
 
     inference_fields: list[str] = []
 
@@ -107,6 +120,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--pcawg-vcf", help="PCAWG annotation VCF")
     parser.add_argument("--pcawg-field", default="PCAWG", help="Field name for PCAWG flag")
     parser.add_argument("--read-filters", help="Input read_filters JSON to augment with exclusion filters")
+    parser.add_argument(
+        "--coverage-threshold", type=int, default=None, help="Coverage threshold to update in read_filters"
+    )
     parser.add_argument("--output-dir", default=".", help="Output directory for BCF files and JSON")
     return parser.parse_args(argv)
 

--- a/src/featuremap/ugbio_featuremap/prepare_annotation_vcfs.py
+++ b/src/featuremap/ugbio_featuremap/prepare_annotation_vcfs.py
@@ -57,6 +57,17 @@ def _create_inference_filters(fields: list[str], output_path: str) -> None:
     logger.info(f"Created {output_path} with any_not_null on {fields}")
 
 
+def _build_inference_fields(include_field: str | None, pcawg_field: str | None) -> list[str]:
+    """Build the list of fields for inference inclusion filtering."""
+    fields: list[str] = []
+    if include_field:
+        fields.append(include_field)
+        # PCAWG contributes to inference inclusion only when include VCFs are also provided
+        if pcawg_field:
+            fields.append(pcawg_field)
+    return fields
+
+
 def run(argv: list[str] | None = None) -> None:
     """Main entry point."""
     args = _parse_args(argv)
@@ -70,25 +81,18 @@ def run(argv: list[str] | None = None) -> None:
         if args.coverage_threshold is not None:
             read_filters = _update_coverage_threshold(read_filters, args.coverage_threshold)
 
-    inference_fields: list[str] = []
+    if args.exclude_field and read_filters:
+        read_filters = _inject_exclusion_filter(read_filters, args.exclude_field)
 
-    if args.exclude_field:
-        if read_filters:
-            read_filters = _inject_exclusion_filter(read_filters, args.exclude_field)
-
-    if args.include_field:
-        inference_fields.append(args.include_field)
-
-    if args.pcawg_field:
-        if read_filters:
-            read_filters = _inject_exclusion_filter(read_filters, args.pcawg_field)
-        inference_fields.append(args.pcawg_field)
+    if args.pcawg_field and read_filters:
+        read_filters = _inject_exclusion_filter(read_filters, args.pcawg_field)
 
     if read_filters:
         out_json = str(output_dir / "read_filters_with_max_coverage.json")
         Path(out_json).write_text(json.dumps(read_filters, indent=2) + "\n")
         logger.info(f"Written augmented read_filters to {out_json}")
 
+    inference_fields = _build_inference_fields(args.include_field, args.pcawg_field)
     if inference_fields:
         _create_inference_filters(inference_fields, str(output_dir / "inference_filters.json"))
 

--- a/src/featuremap/ugbio_featuremap/prepare_annotation_vcfs.py
+++ b/src/featuremap/ugbio_featuremap/prepare_annotation_vcfs.py
@@ -1,12 +1,18 @@
-"""Prepare annotation VCFs for snvfind: add Flag fields, convert to BCF, create filter JSONs.
+"""Prepare read_filters JSON and inference_filters JSON for annotation-based filtering.
+
+Handles:
+- Coverage threshold update in read_filters JSON
+- Annotation exclusion filter injection (is_null for EXCLUDE_TRAINING, PCAWG)
+- Inference inclusion filter creation (any_not_null for INCLUDE_INFERENCE, PCAWG)
 
 Usage::
 
     prepare_annotation_vcfs \
-        --exclude-vcf exclude.vcf.gz --exclude-field EXCLUDE_TRAINING \
-        --include-vcf include.vcf.gz --include-field INCLUDE_INFERENCE \
-        --pcawg-vcf pcawg.vcf.gz --pcawg-field PCAWG \
+        --exclude-field EXCLUDE_TRAINING \
+        --include-field INCLUDE_INFERENCE \
+        --pcawg-field PCAWG \
         --read-filters read_filters.json \
+        --coverage-threshold 42 \
         --output-dir .
 """
 
@@ -17,25 +23,18 @@ import json
 import sys
 from pathlib import Path
 
-from ugbio_core.exec_utils import print_and_execute
 from ugbio_core.logger import logger
 
 
-def _add_flag_and_convert_to_bcf(vcf_path: str, field_name: str, output_bcf: str) -> None:
-    """Add a Flag INFO field to every record in a VCF and convert to indexed BCF."""
-    logger.info(f"Converting {vcf_path} to BCF with Flag field '{field_name}'")
-
-    cmd = (
-        f"(bcftools view -h {vcf_path} | grep -v '^#CHROM';"
-        f" echo '##INFO=<ID={field_name},Number=0,Type=Flag,Description=\"{field_name} annotation flag\">';"
-        f" bcftools view -h {vcf_path} | grep '^#CHROM';"
-        f" bcftools view -H {vcf_path} | awk -F'\\t' -v OFS='\\t'"
-        f' \'{{if($8==".") $8="{field_name}"; else $8=$8";{field_name}"; print}}\''
-        f") | bcftools view -Ob -o {output_bcf}"
-    )
-    print_and_execute(cmd)
-    print_and_execute(f"bcftools index {output_bcf}")
-    logger.info(f"Created {output_bcf}")
+def _update_coverage_threshold(filters_json: dict, coverage_threshold: int) -> dict:
+    """Update coverage_le_max filter value in both filter sets."""
+    for key in ("filters_full_output", "filters_random_sample"):
+        if key in filters_json:
+            for entry in filters_json[key]:
+                if entry.get("name") == "coverage_le_max":
+                    entry["value"] = coverage_threshold
+    logger.info(f"Updated coverage_le_max threshold to {coverage_threshold}")
+    return filters_json
 
 
 def _inject_exclusion_filter(filters_json: dict, field_name: str) -> dict:
@@ -58,17 +57,6 @@ def _create_inference_filters(fields: list[str], output_path: str) -> None:
     logger.info(f"Created {output_path} with any_not_null on {fields}")
 
 
-def _update_coverage_threshold(filters_json: dict, coverage_threshold: int) -> dict:
-    """Update coverage_le_max filter value in both filter sets."""
-    for key in ("filters_full_output", "filters_random_sample"):
-        if key in filters_json:
-            for entry in filters_json[key]:
-                if entry.get("name") == "coverage_le_max":
-                    entry["value"] = coverage_threshold
-    logger.info(f"Updated coverage_le_max threshold to {coverage_threshold}")
-    return filters_json
-
-
 def run(argv: list[str] | None = None) -> None:
     """Main entry point."""
     args = _parse_args(argv)
@@ -84,20 +72,14 @@ def run(argv: list[str] | None = None) -> None:
 
     inference_fields: list[str] = []
 
-    if args.exclude_vcf:
-        bcf_path = str(output_dir / "exclude_annot.bcf")
-        _add_flag_and_convert_to_bcf(args.exclude_vcf, args.exclude_field, bcf_path)
+    if args.exclude_field:
         if read_filters:
             read_filters = _inject_exclusion_filter(read_filters, args.exclude_field)
 
-    if args.include_vcf:
-        bcf_path = str(output_dir / "include_annot.bcf")
-        _add_flag_and_convert_to_bcf(args.include_vcf, args.include_field, bcf_path)
+    if args.include_field:
         inference_fields.append(args.include_field)
 
-    if args.pcawg_vcf:
-        bcf_path = str(output_dir / "pcawg_annot.bcf")
-        _add_flag_and_convert_to_bcf(args.pcawg_vcf, args.pcawg_field, bcf_path)
+    if args.pcawg_field:
         if read_filters:
             read_filters = _inject_exclusion_filter(read_filters, args.pcawg_field)
         inference_fields.append(args.pcawg_field)
@@ -112,18 +94,15 @@ def run(argv: list[str] | None = None) -> None:
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Prepare annotation VCFs for snvfind")
-    parser.add_argument("--exclude-vcf", help="Exclude-from-training annotation VCF")
-    parser.add_argument("--exclude-field", default="EXCLUDE_TRAINING", help="Field name for exclusion flag")
-    parser.add_argument("--include-vcf", help="Include-in-inference annotation VCF")
-    parser.add_argument("--include-field", default="INCLUDE_INFERENCE", help="Field name for inclusion flag")
-    parser.add_argument("--pcawg-vcf", help="PCAWG annotation VCF")
-    parser.add_argument("--pcawg-field", default="PCAWG", help="Field name for PCAWG flag")
-    parser.add_argument("--read-filters", help="Input read_filters JSON to augment with exclusion filters")
+    parser = argparse.ArgumentParser(description="Prepare filter JSONs for annotation-based filtering")
+    parser.add_argument("--exclude-field", default=None, help="Field name for training exclusion (inject is_null)")
+    parser.add_argument("--include-field", default=None, help="Field name for inference inclusion")
+    parser.add_argument("--pcawg-field", default=None, help="Field name for PCAWG (exclude + include)")
+    parser.add_argument("--read-filters", help="Input read_filters JSON to augment")
     parser.add_argument(
         "--coverage-threshold", type=int, default=None, help="Coverage threshold to update in read_filters"
     )
-    parser.add_argument("--output-dir", default=".", help="Output directory for BCF files and JSON")
+    parser.add_argument("--output-dir", default=".", help="Output directory for JSON files")
     return parser.parse_args(argv)
 
 

--- a/src/srsnv/ugbio_srsnv/deep_srsnv/inference/dnn_vcf_inference.py
+++ b/src/srsnv/ugbio_srsnv/deep_srsnv/inference/dnn_vcf_inference.py
@@ -55,6 +55,17 @@ from ugbio_srsnv.srsnv_utils import MAX_PHRED, prob_to_phred
 
 ML_QUAL = "ML_QUAL"
 
+# INFO fields added by snvfind for multi-VCF training/inference filtering.
+# Not needed downstream after DNN merge; stripping them prevents BCF
+# dictionary overflow from orphaned rsID keys in the record data.
+_ANNOTATION_INFO_FIELDS_TO_STRIP: frozenset[str] = frozenset(
+    {
+        "EXCLUDE_TRAINING",
+        "INCLUDE_INFERENCE",
+        "PCAWG",
+    }
+)
+
 
 # ---------------------------------------------------------------------------
 # DNNQualAnnotator
@@ -93,6 +104,12 @@ class DNNQualAnnotator(VcfAnnotator):
 
     def process_records(self, records: list[pysam.VariantRecord]) -> list[pysam.VariantRecord]:
         for rec in records:
+            for field in _ANNOTATION_INFO_FIELDS_TO_STRIP:
+                try:
+                    del rec.info[field]
+                except KeyError:
+                    pass
+
             rns = self._extract_rns(rec)
             if not rns:
                 continue
@@ -1462,6 +1479,21 @@ def _parse_merge_args(argv: list[str] | None = None) -> argparse.Namespace:
     return ap.parse_args(argv)
 
 
+def _strip_unwanted_info(
+    rec: pysam.VariantRecord,
+    known_info_keys: frozenset[str],
+    fields_to_strip: frozenset[str],
+) -> None:
+    """Remove annotation and undeclared INFO fields from a record in-place.
+
+    Prevents BCF dictionary overflow when records contain fields not in the
+    output header snapshot (orphaned rsID keys or annotation fields).
+    """
+    keys_to_del = [k for k in rec.info if k in fields_to_strip or k not in known_info_keys]
+    for k in keys_to_del:
+        del rec.info[k]
+
+
 def _merge_contig_worker(  # noqa: PLR0913, PLR0912, PLR0915, C901
     contig: str,
     vcf_in: str,
@@ -1496,12 +1528,14 @@ def _merge_contig_worker(  # noqa: PLR0913, PLR0912, PLR0915, C901
     if not all_pos:
         # No predictions for this contig — copy records through without annotation
         with pysam.VariantFile(vcf_in) as inp:
+            known_info_keys = frozenset(inp.header.info)
             try:
                 inp.header.add_line('##FILTER=<ID=LowQual,Description="SNVQ below quality threshold">')
             except ValueError:
                 pass
             with pysam.VariantFile(vcf_out, "w", header=inp.header) as out:
                 for rec in inp.fetch(contig):
+                    _strip_unwanted_info(rec, known_info_keys, _ANNOTATION_INFO_FIELDS_TO_STRIP)
                     out.write(rec)
         pysam.tabix_index(vcf_out, preset="vcf", force=True)
         return vcf_out
@@ -1538,6 +1572,8 @@ def _merge_contig_worker(  # noqa: PLR0913, PLR0912, PLR0915, C901
     cursor = 0
 
     with pysam.VariantFile(vcf_in) as inp:
+        known_info_keys = frozenset(inp.header.info)
+
         # Add LowQual filter to input header so records inherit it
         try:
             inp.header.add_line('##FILTER=<ID=LowQual,Description="SNVQ below quality threshold">')
@@ -1546,6 +1582,7 @@ def _merge_contig_worker(  # noqa: PLR0913, PLR0912, PLR0915, C901
 
         with pysam.VariantFile(vcf_out, "w", header=inp.header) as out:
             for rec in inp.fetch(contig):
+                _strip_unwanted_info(rec, known_info_keys, _ANNOTATION_INFO_FIELDS_TO_STRIP)
                 pos = rec.pos
 
                 # Advance cursor past positions before this record

--- a/src/srsnv/ugbio_srsnv/deep_srsnv/inference/dnn_vcf_inference.py
+++ b/src/srsnv/ugbio_srsnv/deep_srsnv/inference/dnn_vcf_inference.py
@@ -55,17 +55,6 @@ from ugbio_srsnv.srsnv_utils import MAX_PHRED, prob_to_phred
 
 ML_QUAL = "ML_QUAL"
 
-# INFO fields added by snvfind for multi-VCF training/inference filtering.
-# Not needed downstream after DNN merge; stripping them prevents BCF
-# dictionary overflow from orphaned rsID keys in the record data.
-_ANNOTATION_INFO_FIELDS_TO_STRIP: frozenset[str] = frozenset(
-    {
-        "EXCLUDE_TRAINING",
-        "INCLUDE_INFERENCE",
-        "PCAWG",
-    }
-)
-
 
 # ---------------------------------------------------------------------------
 # DNNQualAnnotator
@@ -104,12 +93,6 @@ class DNNQualAnnotator(VcfAnnotator):
 
     def process_records(self, records: list[pysam.VariantRecord]) -> list[pysam.VariantRecord]:
         for rec in records:
-            for field in _ANNOTATION_INFO_FIELDS_TO_STRIP:
-                try:
-                    del rec.info[field]
-                except KeyError:
-                    pass
-
             rns = self._extract_rns(rec)
             if not rns:
                 continue
@@ -1479,21 +1462,6 @@ def _parse_merge_args(argv: list[str] | None = None) -> argparse.Namespace:
     return ap.parse_args(argv)
 
 
-def _strip_unwanted_info(
-    rec: pysam.VariantRecord,
-    known_info_keys: frozenset[str],
-    fields_to_strip: frozenset[str],
-) -> None:
-    """Remove annotation and undeclared INFO fields from a record in-place.
-
-    Prevents BCF dictionary overflow when records contain fields not in the
-    output header snapshot (orphaned rsID keys or annotation fields).
-    """
-    keys_to_del = [k for k in rec.info if k in fields_to_strip or k not in known_info_keys]
-    for k in keys_to_del:
-        del rec.info[k]
-
-
 def _merge_contig_worker(  # noqa: PLR0913, PLR0912, PLR0915, C901
     contig: str,
     vcf_in: str,
@@ -1528,14 +1496,12 @@ def _merge_contig_worker(  # noqa: PLR0913, PLR0912, PLR0915, C901
     if not all_pos:
         # No predictions for this contig — copy records through without annotation
         with pysam.VariantFile(vcf_in) as inp:
-            known_info_keys = frozenset(inp.header.info)
             try:
                 inp.header.add_line('##FILTER=<ID=LowQual,Description="SNVQ below quality threshold">')
             except ValueError:
                 pass
             with pysam.VariantFile(vcf_out, "w", header=inp.header) as out:
                 for rec in inp.fetch(contig):
-                    _strip_unwanted_info(rec, known_info_keys, _ANNOTATION_INFO_FIELDS_TO_STRIP)
                     out.write(rec)
         pysam.tabix_index(vcf_out, preset="vcf", force=True)
         return vcf_out
@@ -1572,8 +1538,6 @@ def _merge_contig_worker(  # noqa: PLR0913, PLR0912, PLR0915, C901
     cursor = 0
 
     with pysam.VariantFile(vcf_in) as inp:
-        known_info_keys = frozenset(inp.header.info)
-
         # Add LowQual filter to input header so records inherit it
         try:
             inp.header.add_line('##FILTER=<ID=LowQual,Description="SNVQ below quality threshold">')
@@ -1582,7 +1546,6 @@ def _merge_contig_worker(  # noqa: PLR0913, PLR0912, PLR0915, C901
 
         with pysam.VariantFile(vcf_out, "w", header=inp.header) as out:
             for rec in inp.fetch(contig):
-                _strip_unwanted_info(rec, known_info_keys, _ANNOTATION_INFO_FIELDS_TO_STRIP)
                 pos = rec.pos
 
                 # Advance cursor past positions before this record


### PR DESCRIPTION
## Summary

Adds new filter operators to the JSON-based filter framework and fixes Flag field handling in featuremap VCF-to-Parquet conversion.

### 1. New filter operators (`filter_dataframe.py`)

Added three operators to the filter framework for annotation-based filtering:

- `is_null` — passes if the field is absent (null). Used for training exclusion: `{"field": "EXCLUDE_TRAINING", "op": "is_null"}`
- `is_not_null` — passes if the field is present. Used for inference inclusion on a single field.
- `any_not_null` — passes if at least one of multiple fields is present (OR logic). Used for inference inclusion: `{"op": "any_not_null", "fields": ["INCLUDE_INFERENCE", "PCAWG"]}`

These are unary operators (no `value` key needed). Validation updated to handle `any_not_null` using `fields` list instead of single `field`.

### 2. Flag field dtype fix (`featuremap_to_dataframe.py`)

- **Flag to pl.Utf8** instead of pl.Boolean: `bcftools query` outputs `1` for present flags and `.` for absent. Polars cannot parse `1` as Boolean (expects true/false). With Utf8, `.` becomes null via null_values and `1` stays as non-null string.
- **Flag cast passthrough**: Flag columns no longer get fill_null(False).cast(Boolean) — just pass through as-is.
- **Row count logging**: Log final parquet row count on completion.

### 3. Tests (`test_annotation_filtering.py`)

11 unit tests covering: is_null, is_not_null, any_not_null, combined filters, edge cases.

## Test plan
- [x] Unit tests pass (11 tests)
- [x] Pre-commit checks pass
- [x] Omics run 9275938 (CL10377) completed successfully with Flag annotations + JSON filters
- [x] Omics run 2885148 (CL10377) verified annotation filters active in logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the JSON filter language and changes how VCF `Flag` INFO/FORMAT fields are typed during VCF→Parquet conversion, which can alter filtering outcomes and downstream data expectations.
> 
> **Overview**
> Adds three new unary filter operators to the JSON filtering framework—`is_null`, `is_not_null`, and multi-field `any_not_null`—including updated validation and naming logic to support `fields`-based rules.
> 
> Fixes VCF `Flag` field ingestion in `featuremap_to_dataframe` by treating flags as `Utf8` (so bcftools `1`/`.` values work with null-based filters) and stops casting flags to boolean; also logs the final Parquet row count on completion.
> 
> Introduces `prepare_annotation_vcfs` CLI to generate/augment filter JSONs for annotation-driven exclusion/inclusion (coverage threshold updates, injected `is_null` rules, and `any_not_null` inference filters), and adds unit tests covering the new operators and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8ac0d32068cfe70cdead5f7f5db521dfad2dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->