### PR TITLE
[BIOIN-2806] Fixed normed vcf sorting

### DIFF
--- a/src/comparison/ugbio_comparison/vcf_comparison_utils.py
+++ b/src/comparison/ugbio_comparison/vcf_comparison_utils.py
@@ -268,7 +268,8 @@ class VcfComparisonUtils:
 
         # Step1 - bcftools norm
 
-        self.__execute(f"bcftools norm -c x -f {ref} -m+any -o {tempdir}/step1.vcf.gz -O z {input_vcf}")
+        self.__execute(f"bcftools norm -c x -f {ref} -m+any -o {tempdir}/step0.5.vcf.gz -O z {input_vcf}")
+        self.vu.sort_vcf(f"{tempdir}/step0.5.vcf.gz", f"{tempdir}/step1.vcf.gz")
         self.vu.index_vcf(f"{tempdir}/step1.vcf.gz")
         self.__execute(
             f"bcftools annotate -a {input_vcf} -c CHROM,POS,CALL,BASE -Oz \
@@ -316,7 +317,7 @@ class VcfComparisonUtils:
                 -Oz -o {output_vcf} {tempdir}/step4.vcf.gz"
         )
         self.vu.index_vcf(output_vcf)
-        # shutil.rmtree(tempdir)
+        shutil.rmtree(tempdir)
 
     def fix_vcf_format(self, output_prefix: str):
         """Legacy function to fix the PS field format in the old GIAB truth sets. The function overwrites the input file


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small pipeline-ordering fix in VCF comparison utilities with no auth or data-model changes; mainly affects vcfeval output normalization correctness.
> 
> **Overview**
> **`normalize_vcfeval_vcf`** now sorts the VCF immediately after **`bcftools norm`** (`step0.5` → `step1` via **`VcfUtils.sort_vcf`**) so downstream indexing and annotation see a correctly ordered file—addressing incorrect ordering after normalization (BIOIN-2806).
> 
> Temporary working directories are removed again at the end of the pipeline (**`shutil.rmtree(tempdir)`** was re-enabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b249605b20b2a14c4414f4d796c99620ac24b498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->