### PR TITLE
BIOIN-2821 Handle missing per-read data in methylation QC report

### DIFF
--- a/src/methylation/ugbio_methylation/qc_report_generator.py
+++ b/src/methylation/ugbio_methylation/qc_report_generator.py
@@ -255,7 +255,10 @@ class PerReadStatsSection(ReportSection):
     """Handles per-read statistics section."""
 
     def generate(self):
-        """Generate per-read statistics."""
+        """Generate per-read statistics. Returns None if per-read data is not available."""
+        available_tables = self.data_processor.get_available_tables()
+        if "/per_read_desc" not in available_tables:
+            return None
         df_per_read = self.data_processor.load_table("per_read_desc")
         df_per_read = df_per_read.drop(columns=["detail"])
         df_per_read = self.formatter.format_metric_names(df_per_read)
@@ -452,6 +455,9 @@ class MethylationQCReportGenerator:
     def generate_per_read_stats(self):
         """Generate and display per-read statistics."""
         stats_df = self.per_read_stats.generate()
+        if stats_df is None:
+            display(HTML("<i>Per-read statistics not available (ProcessMethylDackelPerRead was skipped).</i>"))
+            return
         display(stats_df)
 
     def generate_non_cpg_stats(self):


### PR DESCRIPTION
When ProcessMethylDackelPerRead is skipped, the per_read_desc table won't exist in the H5 file. PerReadStatsSection.generate() now checks for availability and returns None, and the report displays an informational message instead of failing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple presence check for the `per_read_desc` HDF5 table and degrades output to an informational message instead of raising at report generation time.
> 
> **Overview**
> Prevents the methylation QC report from failing when per-read output was not generated.
> 
> `PerReadStatsSection.generate()` now checks the HDF5 store for `/per_read_desc` and returns `None` if absent, and `generate_per_read_stats()` renders an italicized “not available” message instead of attempting to display a missing table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 470db14497a76d7e0427b4a2c8186b8d1b554aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->