### PR TITLE
ci(actions): use github.action_path so actions are callable from external repos

### DIFF
--- a/.github/actions/get-members/action.yml
+++ b/.github/actions/get-members/action.yml
@@ -14,7 +14,7 @@ runs:
   - id: list_members
     shell: bash
     run: |
-      matrix=$(python3 ${GITHUB_WORKSPACE}/.github/utils/ugbio_members_matrix.py)
+      matrix=$(python3 ${{ github.action_path }}/../../utils/ugbio_members_matrix.py)
       {
         echo 'matrix<<EOF'
         echo ${matrix}

--- a/.github/actions/update-workspaces-version/action.yml
+++ b/.github/actions/update-workspaces-version/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: Update pyproject.toml files with new dev_version
       shell: bash
-      run: python .github/utils/update_project_version.py ${{ inputs.version }}
+      run: python ${{ github.action_path }}/../../utils/update_project_version.py ${{ inputs.version }}
 
     - name: Fix file permissions
       shell: bash


### PR DESCRIPTION
## Summary

- `get-members`: replace `${GITHUB_WORKSPACE}/.github/utils/ugbio_members_matrix.py` with `${{ github.action_path }}/../../utils/ugbio_members_matrix.py`
- `update-workspaces-version`: replace relative path `.github/utils/update_project_version.py` with `${{ github.action_path }}/../../utils/update_project_version.py`

## Why

These composite actions previously resolved their Python utility scripts via `GITHUB_WORKSPACE`, which always points to the **caller's** repo. This meant any external repo calling these actions had to ship local copies of `ugbio_members_matrix.py` and `update_project_version.py`.

By switching to `github.action_path`, the scripts resolve relative to the action definition in **this repo**, making the actions fully self-contained and reusable from `ugbio-private-utils` (or any future repo) with no duplication.

## Test plan

- [ ] CI passes on this PR (pre-commit, Trivy, module tests) — validates the change doesn't break existing ugbio-utils usage
- [ ] After merge, verify `ugbio-private-utils` can call `Ultimagen/ugbio-utils/.github/actions/get-members@main` and `update-workspaces-version@main` without local script copies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates script path resolution inside two composite GitHub Actions, with no logic changes beyond where the Python utilities are located when invoked.
> 
> **Overview**
> Makes the composite actions `get-members` and `update-workspaces-version` self-contained by switching their Python script invocations to use `github.action_path` (instead of `GITHUB_WORKSPACE`/repo-relative paths).
> 
> This allows the actions to be called from external repositories without requiring the caller to include copies of the `.github/utils` helper scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d590fc055f2775de1f96eeb43333038435ff1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->