### PR TITLE
ci(docker): support custom base images per workspace member

### DIFF
--- a/.github/workflows/build-workspace-docker.yml
+++ b/.github/workflows/build-workspace-docker.yml
@@ -37,6 +37,9 @@ env:
   AWS_REGION: us-east-1
   AWS_ROLE_NAME: github-actions-ecr
   AWS_ACCOUNT: 337532070941
+  # Default base image used when the Dockerfile does not declare an ARG BASE_IMAGE default.
+  # If you update this version, also update UGBIO_BASE_IMAGE_NAME in ci.yml.
+  DEFAULT_BASE_IMAGE: ugbio_base:1.7.0
 
 jobs:
   pre-build:
@@ -44,11 +47,21 @@ jobs:
     outputs:
       ecr-registry: ${{ steps.ecr-login.outputs.registry }}
       project-version: ${{ steps.extract-version.outputs.project_version }}
+      base-image: ${{ steps.extract-base-image.outputs.base_image }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-sha }}
           lfs: true
+
+      - name: Extract BASE_IMAGE from Dockerfile
+        id: extract-base-image
+        run: |
+          BASE=$(grep -oP '(?<=ARG BASE_IMAGE=)\S+' ${{ inputs.docker-file }} || true)
+          if [ -z "$BASE" ]; then
+            BASE="${{ env.DEFAULT_BASE_IMAGE }}"
+          fi
+          echo "base_image=${BASE}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -93,4 +106,4 @@ jobs:
          docker-tag: ${{ inputs.docker-tag }}
          docker-context: ${{ inputs.docker-context }}
          project-version: ${{ needs.pre-build.outputs.project-version }}
-         docker-build-args: BASE_IMAGE=${{ needs.pre-build.outputs.ecr-registry }}/ugbio_base:1.7.0
+         docker-build-args: BASE_IMAGE=${{ needs.pre-build.outputs.ecr-registry }}/${{ needs.pre-build.outputs.base-image }}

--- a/.github/workflows/build-workspace-docker.yml
+++ b/.github/workflows/build-workspace-docker.yml
@@ -28,6 +28,11 @@ on:
         type: string
         default: ""
         required: false
+      runner:
+        description: "Runner type passed to docker-build-push.yml (default: ubuntu-latest)"
+        required: false
+        type: string
+        default: ubuntu-latest
 
 permissions:
   id-token: write # Required for assuming an AWS role
@@ -107,3 +112,4 @@ jobs:
          docker-context: ${{ inputs.docker-context }}
          project-version: ${{ needs.pre-build.outputs.project-version }}
          docker-build-args: BASE_IMAGE=${{ needs.pre-build.outputs.ecr-registry }}/${{ needs.pre-build.outputs.base-image }}
+         runner: ${{ inputs.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ env:
   AWS_REGION: us-east-1
   AWS_ROLE_NAME: github-actions-ecr
   AWS_ACCOUNT: 337532070941
+  # Base image used for building and testing workspace members.
+  # If you update this version, also update DEFAULT_BASE_IMAGE in build-workspace-docker.yml.
   UGBIO_BASE_IMAGE_NAME: ugbio_base:1.7.0
   UGBIO_UTILS_REPO_PATH: ./ugbio-utils
   INSTALL_BIO_PATH: ./install-bio

--- a/README.md
+++ b/README.md
@@ -158,6 +158,26 @@ Another option is to build the image locally using `docker build . -f <dockerfil
     - If you are trying to select the correct Python interpreter but things are still stuck, close and re-open the container. Sometimes VSCode needs to reload itself.
 - Make sure that the `devcontainer.json`'s `mount` key does not contain directories that are missing in your setup. In my case it was `/data` that was missing.
 
+## Base Image Version
+
+The default base image (`ugbio_base`) version is intentionally duplicated in two workflow files:
+
+| File | Variable |
+|------|----------|
+| `.github/workflows/ci.yml` | `UGBIO_BASE_IMAGE_NAME` |
+| `.github/workflows/build-workspace-docker.yml` | `DEFAULT_BASE_IMAGE` |
+
+When upgrading the base image, update **both** values in the same PR. Each file includes a comment pointing to the other.
+
+Members that require a custom base image (e.g. `deep_srsnv` which uses `ugbio_deep_srsnv_base`) declare it as an `ARG` default in their `Dockerfile`:
+
+```dockerfile
+ARG BASE_IMAGE=ugbio_deep_srsnv_base:1.0.0
+FROM ${BASE_IMAGE}
+```
+
+`build-workspace-docker.yml` reads this default at build time and prepends the ECR registry automatically. When no default is present, `DEFAULT_BASE_IMAGE` is used as the fallback.
+
 ## Run Tests
 It is recommended to run tests in the relevant dev container. See the section above for more details on how to open the dev container. Once you are running inside the dev container, you can run tests using VSCode or with `uv run pytest <tests path>`.
 

--- a/src/cnv/Dockerfile
+++ b/src/cnv/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=ugbio_base
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
 FROM python:3.11-bullseye AS build
 

--- a/src/comparison/Dockerfile
+++ b/src/comparison/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=ugbio_base
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
 FROM python:3.11-bullseye AS build
 

--- a/src/core/Dockerfile
+++ b/src/core/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=ugbio_base
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
 FROM python:3.11-bullseye AS build
 

--- a/src/featuremap/Dockerfile
+++ b/src/featuremap/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=ugbio_base
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
 FROM python:3.11-bullseye AS build
 

--- a/src/filtering/Dockerfile
+++ b/src/filtering/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=ugbio_base
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
 FROM python:3.11-bullseye AS build
 

--- a/src/freec/Dockerfile
+++ b/src/freec/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=ugbio_base
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
 FROM python:3.11-bullseye AS build
 

--- a/src/mrd/Dockerfile
+++ b/src/mrd/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=ugbio_base
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
 FROM python:3.11-bullseye AS build
 

--- a/src/ppmseq/Dockerfile
+++ b/src/ppmseq/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=ugbio_base
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
 FROM python:3.11-bullseye AS build
 

--- a/src/srsnv/Dockerfile
+++ b/src/srsnv/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=ugbio_base
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
 FROM python:3.11-bullseye AS build
 


### PR DESCRIPTION
Why this change was needed:
build-workspace-docker.yml hardcoded BASE_IMAGE to ugbio_base:1.7.0, which breaks for members that ship their own base image (e.g. deep_srsnv uses ugbio_deep_srsnv_base instead of ugbio_base).

What changed:
- Added DEFAULT_BASE_IMAGE env var to build-workspace-docker.yml as the fallback base image value
- Added a pre-build step that reads the ARG BASE_IMAGE default directly from the member's Dockerfile; falls back to DEFAULT_BASE_IMAGE when no default is declared
- Wired the resolved value into docker-build-args, replacing the hardcoded ugbio_base:1.7.0 reference
- Added cross-reference comments in ci.yml and build-workspace-docker.yml so both occurrences of the base image version are kept in sync
- Added README section documenting the duplication and the ARG-based custom base image mechanism

Problem solved:
Members with a custom base image can now declare it as an ARG default in their Dockerfile and have it picked up automatically at build time, with no workflow input changes required. All existing members continue to use ugbio_base:1.7.0 unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Docker build workflow to dynamically resolve and pass `BASE_IMAGE` from each member’s `Dockerfile`, which can affect CI/docker build behavior if parsing or defaults are incorrect.
> 
> **Overview**
> Builds no longer hardcode `ugbio_base:1.7.0` as `BASE_IMAGE`. `build-workspace-docker.yml` now extracts an `ARG BASE_IMAGE=` default from the target `Dockerfile` (falling back to a new `DEFAULT_BASE_IMAGE`) and passes the resolved value into `docker-build-args`, plus adds a `runner` input passthrough.
> 
> Updates member `Dockerfile`s to remove the `ARG BASE_IMAGE=ugbio_base` default so CI injects the base image, adds cross-reference comments to keep the duplicated base image version in sync between workflows, and documents the mechanism in `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7595ba28c8c29766214eec5fbb89c31808e9cd7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->