### PR TITLE
ci(actions): auto-detect base image from Dockerfile in run-workspace-tests

### DIFF
--- a/.github/actions/run-workspace-tests/action.yml
+++ b/.github/actions/run-workspace-tests/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: "AWS role name"
     required: true
   ugbio_base_image:
-      description: "Fallback base image (image:tag) when the Dockerfile has no ARG BASE_IMAGE default. Should be set to DEFAULT_BASE_IMAGE in the calling workflow."
+      description: "Fallback base image (image:tag) when the Dockerfile has no ARG BASE_IMAGE default."
       required: false
   github-token:
       description: "GitHub token for private repository access"

--- a/.github/actions/run-workspace-tests/action.yml
+++ b/.github/actions/run-workspace-tests/action.yml
@@ -22,8 +22,8 @@ inputs:
     description: "AWS role name"
     required: true
   ugbio_base_image:
-      description: "ugbio_base image"
-      required: true
+      description: "Fallback base image (image:tag) when the Dockerfile has no ARG BASE_IMAGE default. Should be set to DEFAULT_BASE_IMAGE in the calling workflow."
+      required: false
   github-token:
       description: "GitHub token for private repository access"
       required: false
@@ -42,6 +42,18 @@ runs:
       id: ecr-login
       uses: aws-actions/amazon-ecr-login@v1
 
+    - name: Extract BASE_IMAGE from Dockerfile
+      id: extract-base-image
+      shell: bash
+      run: |
+        # Only use the Dockerfile default when it contains a tag (image:tag).
+        # Plain names without a tag are placeholders — fall back to ugbio_base_image input.
+        BASE=$(grep -oP '(?<=ARG BASE_IMAGE=)\S+:\S+' ${{ inputs.docker-file }} || true)
+        if [ -z "$BASE" ]; then
+          BASE="${{ inputs.ugbio_base_image }}"
+        fi
+        echo "base_image=${BASE}" >> "${GITHUB_OUTPUT}"
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
@@ -58,7 +70,7 @@ runs:
         cache-to: type=gha,mode=max
         secrets: |
           github_token=${{ inputs.github-token }}
-        build-args: BASE_IMAGE=${{ steps.ecr-login.outputs.registry }}/${{ inputs.ugbio_base_image }}
+        build-args: BASE_IMAGE=${{ steps.ecr-login.outputs.registry }}/${{ steps.extract-base-image.outputs.base_image }}
 
     - name: Run python tests (if exist) in the container
       working-directory: src/${{ inputs.workspace-folder }}


### PR DESCRIPTION
## Summary
- Makes `ugbio_base_image` input optional in `run-workspace-tests` action
- Adds a step that reads the `ARG BASE_IMAGE=image:tag` default directly from the member's Dockerfile
- Falls back to `ugbio_base_image` input when no tagged default is present (backward-compatible for all existing members)

## Why
Members with a custom base image (e.g. `deep_srsnv` using `ugbio_deep_srsnv_base`) were receiving the wrong `BASE_IMAGE` at CI build time. This fix makes the action consistent with the approach already used in `build-workspace-docker.yml`.

## Test plan
- [ ] Verify existing members (no `ARG BASE_IMAGE` default in Dockerfile) still resolve to `ugbio_base:1.7.0`
- [ ] Verify `deep_srsnv` resolves to `ugbio_deep_srsnv_base:1.0.0` from the Dockerfile default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI Docker build argument resolution for all workspace test builds; a mis-detected or missing `BASE_IMAGE` could break module builds or pull the wrong image during CI.
> 
> **Overview**
> `run-workspace-tests` now **auto-detects** the Docker `BASE_IMAGE` by parsing `ARG BASE_IMAGE=image:tag` from the target Dockerfile and uses that value for the build arg.
> 
> The `ugbio_base_image` input is made *optional* and is only used as a fallback when no tagged default is present, keeping existing workflows compatible while fixing modules that require custom base images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea8e1bb7c08921377aa3e3b8241b280fa7f16d68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->