### PR TITLE
Mrd skip empty parquets

### DIFF
--- a/src/cloud_utils/ugbio_cloud_utils/cloud_sync.py
+++ b/src/cloud_utils/ugbio_cloud_utils/cloud_sync.py
@@ -32,7 +32,7 @@ def download_from_gs(bucket_name, source_blob_name, destination_file_name):
 
 
 def download_from_s3(bucket_name, object_name, destination_file_name):
-    client = boto3.Session(profile_name="default").client("s3")
+    client = boto3.Session(profile_name="v1").client("s3")
     client.download_file(bucket_name, object_name, destination_file_name)
 
 

--- a/src/cloud_utils/ugbio_cloud_utils/cloud_sync.py
+++ b/src/cloud_utils/ugbio_cloud_utils/cloud_sync.py
@@ -32,7 +32,7 @@ def download_from_gs(bucket_name, source_blob_name, destination_file_name):
 
 
 def download_from_s3(bucket_name, object_name, destination_file_name):
-    client = boto3.Session(profile_name="v1").client("s3")
+    client = boto3.Session(profile_name="default").client("s3")
     client.download_file(bucket_name, object_name, destination_file_name)
 
 

--- a/src/mrd/tests/unit/test_mrd_utils.py
+++ b/src/mrd/tests/unit/test_mrd_utils.py
@@ -145,6 +145,26 @@ def test_read_intersection_dataframes(tmpdir, resources_dir):
     )
 
 
+def test_read_intersection_dataframes_skips_empty_parquets(tmpdir, resources_dir):
+    valid_parquet = pjoin(resources_dir, f"{intersection_file_basename}.expected_output.parquet")
+    empty_parquet = str(tmpdir / "sample.sig2.db_control.intersection.parquet")
+    open(empty_parquet, "w").close()
+
+    result = read_intersection_dataframes([valid_parquet, empty_parquet], return_dataframes=True)
+    assert not result.empty
+    assert len(result) > 0
+
+
+def test_read_intersection_dataframes_all_empty(tmpdir):
+    empty1 = str(tmpdir / "sample.sig1.control.intersection.parquet")
+    empty2 = str(tmpdir / "sample.sig2.db_control.intersection.parquet")
+    open(empty1, "w").close()
+    open(empty2, "w").close()
+
+    result = read_intersection_dataframes([empty1, empty2], return_dataframes=True)
+    assert result.empty
+
+
 def test_generate_synthetic_signatures(tmpdir, resources_dir):
     signature_file = pjoin(resources_dir, "mutect_mrd_signature_test.vcf.gz")
     db_file = pjoin(

--- a/src/mrd/ugbio_mrd/mrd_utils.py
+++ b/src/mrd/ugbio_mrd/mrd_utils.py
@@ -508,13 +508,19 @@ def read_intersection_dataframes(
     if isinstance(intersected_featuremaps_parquet, str):
         intersected_featuremaps_parquet = [intersected_featuremaps_parquet]
     logger.debug(f"Reading {len(intersected_featuremaps_parquet)} intersection featuremaps")
+    non_empty_files = [f for f in intersected_featuremaps_parquet if os.path.getsize(f) > 0]
+    if len(non_empty_files) < len(intersected_featuremaps_parquet):
+        logger.warning(
+            f"Skipping {len(intersected_featuremaps_parquet) - len(non_empty_files)} empty parquet file(s) "
+            f"(empty intersection)"
+        )
     df_int = pd.concat(
         pd.read_parquet(f, engine="fastparquet").assign(
             cfdna=_get_sample_name_from_file_name(f, split_position=0),
             signature=_get_sample_name_from_file_name(f, split_position=1),
             signature_type=_get_sample_name_from_file_name(f, split_position=2),
         )
-        for f in intersected_featuremaps_parquet
+        for f in non_empty_files
     )
     if output_parquet is not None:
         df_int.reset_index().to_parquet(output_parquet)

--- a/src/mrd/ugbio_mrd/mrd_utils.py
+++ b/src/mrd/ugbio_mrd/mrd_utils.py
@@ -514,14 +514,21 @@ def read_intersection_dataframes(
             f"Skipping {len(intersected_featuremaps_parquet) - len(non_empty_files)} empty parquet file(s) "
             f"(empty intersection)"
         )
-    df_int = pd.concat(
-        pd.read_parquet(f, engine="fastparquet").assign(
-            cfdna=_get_sample_name_from_file_name(f, split_position=0),
-            signature=_get_sample_name_from_file_name(f, split_position=1),
-            signature_type=_get_sample_name_from_file_name(f, split_position=2),
+    if not non_empty_files:
+        logger.warning(
+            f"All {len(intersected_featuremaps_parquet)} intersected featuremap parquet file(s) are empty — "
+            f"no variants overlap between the featuremap and any signature"
         )
-        for f in non_empty_files
-    )
+        df_int = pd.DataFrame()
+    else:
+        df_int = pd.concat(
+            pd.read_parquet(f, engine="fastparquet").assign(
+                cfdna=_get_sample_name_from_file_name(f, split_position=0),
+                signature=_get_sample_name_from_file_name(f, split_position=1),
+                signature_type=_get_sample_name_from_file_name(f, split_position=2),
+            )
+            for f in non_empty_files
+        )
     if output_parquet is not None:
         df_int.reset_index().to_parquet(output_parquet)
     if return_dataframes:


### PR DESCRIPTION
Related to a bug I got in https://github.com/Ultimagen/terra_pipeline/pull/2155

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized MRD I/O edge-case fix; callers that already handle empty intersection results should behave the same, with clearer warnings instead of parquet read failures.
> 
> **Overview**
> **`read_intersection_dataframes`** no longer calls `pd.read_parquet` on zero-byte intersection outputs. It keeps only paths with `os.path.getsize(f) > 0`, logs when some or all inputs are empty (no featuremap–signature overlap), and returns an **empty** `DataFrame` when every file is empty instead of erroring.
> 
> Unit tests cover a mix of valid and empty parquets and the all-empty case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9822be15a7df20a0e0c0347bafbfe8bae5695b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->