### PR TITLE
BIOIN-2881 allow running methylation qc without control genomes

### DIFF
--- a/src/methylation/tests/unit/test_generate_methylation_report.py
+++ b/src/methylation/tests/unit/test_generate_methylation_report.py
@@ -1,8 +1,11 @@
 from pathlib import Path
+from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 from ugbio_methylation.generate_methylation_report import generate_methylation_report
 from ugbio_methylation.globals import MethylDackelConcatenationCsvs
+from ugbio_methylation.qc_report_generator import ControlGenomeSection, DataProcessor, ReportConfig
 
 
 @pytest.fixture
@@ -34,3 +37,64 @@ def test_generate_methylation_report(output_path, resources_dir):
 
     # assert report_html is not empty
     assert output_report_html.stat().st_size > 0
+
+
+@pytest.fixture
+def make_control_genome_section():
+    def _make(h5_path):
+        data_processor = DataProcessor(str(h5_path))
+        return ControlGenomeSection(data_processor, MagicMock(), MagicMock(), MagicMock())
+
+    return _make
+
+
+def test_check_control_genomes_exist_returns_false_when_table_missing(tmp_path, make_control_genome_section):
+    """When the reference has no control genomes (Lambda/pUC19), the
+    merge_context_per_position table is not written to the HDF5 file.
+    check_control_genomes_exist should return False instead of raising KeyError."""
+    h5_path = tmp_path / "test.h5"
+    with pd.HDFStore(str(h5_path), mode="w") as store:
+        store.put("merge_context_desc", pd.Series(["dummy"], name="value"))
+
+    section = make_control_genome_section(h5_path)
+    config = ReportConfig(input_h5_file=str(h5_path), input_base_file_name="test")
+
+    result = section.check_control_genomes_exist(config.control_genomes)
+    assert result is False
+
+
+def test_check_control_genomes_exist_returns_false_when_genomes_not_present(tmp_path, make_control_genome_section):
+    """When the table exists but doesn't contain the expected control genomes,
+    check_control_genomes_exist should return False."""
+    h5_path = tmp_path / "test.h5"
+    per_position = pd.DataFrame({"detail": ["hg", "hg"], "metric": ["m1", "m2"], "value": [1.0, 2.0]})
+    per_position = per_position.set_index(["detail", "metric"]).squeeze(axis=1)
+    with pd.HDFStore(str(h5_path), mode="w") as store:
+        store.put("merge_context_per_position", per_position, format="table", data_columns=True)
+
+    section = make_control_genome_section(h5_path)
+    config = ReportConfig(input_h5_file=str(h5_path), input_base_file_name="test")
+
+    result = section.check_control_genomes_exist(config.control_genomes)
+    assert result is False
+
+
+def test_check_control_genomes_exist_returns_true_when_present(tmp_path, make_control_genome_section):
+    """When control genomes are present in the table, should return True."""
+    h5_path = tmp_path / "test.h5"
+    per_position = pd.DataFrame(
+        {
+            "detail": ["Lambda", "pUC19", "hg"],
+            "metric": ["m1", "m2", "m3"],
+            "value": [1.0, 2.0, 3.0],
+        }
+    )
+    per_position = per_position.set_index(["detail", "metric"]).squeeze(axis=1)
+    with pd.HDFStore(str(h5_path), mode="w") as store:
+        store.put("merge_context_per_position", per_position, format="table", data_columns=True)
+
+    section = make_control_genome_section(h5_path)
+    config = ReportConfig(input_h5_file=str(h5_path), input_base_file_name="test")
+
+    result = section.check_control_genomes_exist(config.control_genomes)
+    assert result is True

--- a/src/methylation/ugbio_methylation/qc_report_generator.py
+++ b/src/methylation/ugbio_methylation/qc_report_generator.py
@@ -342,7 +342,10 @@ class ControlGenomeSection(ReportSection):
 
     def check_control_genomes_exist(self, control_genomes: list[str]) -> bool:
         """Check if control genomes exist in the data."""
-        df_per_position = self.data_processor.load_table("merge_context_per_position")
+        try:
+            df_per_position = self.data_processor.load_table("merge_context_per_position")
+        except KeyError:
+            return False
         available_genomes = list(set(df_per_position["detail"]))
         return all(genome in available_genomes for genome in control_genomes)
 


### PR DESCRIPTION
When the reference sequence doesn't contain Lambda/pUC19 control genomes, pandas silently skips writing the empty merge_context_per_position table to HDF5. The check_control_genomes_exist() function then raises a KeyError instead of returning False. Handle the missing table gracefully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in QC report gating plus tests; no auth, data pipeline, or security-sensitive logic.
> 
> **Overview**
> Fixes methylation QC report generation when references lack Lambda/pUC19 control genomes: **`check_control_genomes_exist`** in `qc_report_generator.py` now catches **`KeyError`** from loading the missing **`merge_context_per_position`** HDF5 table and returns **`False`** instead of failing, so the control-genome section is skipped like when controls are absent from the data.
> 
> Adds unit tests that build minimal HDF5 fixtures and assert **`False`** when the table is missing or expected genomes are not in **`detail`**, and **`True`** when Lambda/pUC19 are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998ce12868153facb9624e2954d3bfd6f7dfd74a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->