### PR TITLE
BIOIN-2885 Fix FQ_vs_recall plot failing with single-fold configuration

### DIFF
--- a/src/srsnv/tests/unit/test_smoothing_kde_consistency.py
+++ b/src/srsnv/tests/unit/test_smoothing_kde_consistency.py
@@ -36,6 +36,7 @@ from ugbio_core.logger import logger
 from ugbio_srsnv.smoothing_utils import (
     AdaptiveKDEPrecisionEstimator,
     bin_data_to_grid,
+    create_uncertainty_function_pipeline_fast,
     make_grid_and_transform,
 )
 
@@ -728,3 +729,58 @@ def test_kde_transforms_consistency():
 
 #     except Exception as e:
 #         pytest.fail(f"KDE failed with imbalanced data: {e}")
+
+
+class TestSingleFoldFallback:
+    """Tests for the single-fold (num_cv_folds=1) fallback in uncertainty estimation."""
+
+    def test_create_uncertainty_function_single_fold_returns_constant(self):
+        """With only 1 fold, create_uncertainty_function_pipeline_fast should return constant std=1.0."""
+        rng = np.random.default_rng(42)
+        n = 10000
+
+        data = {
+            "label": rng.choice([True, False], size=n),
+            "fold_id": np.full(n, np.nan),
+            "prob_fold_0": rng.uniform(0.01, 0.99, size=n),
+        }
+        single_fold_df = pd.DataFrame(data)
+
+        get_score_std, metadata = create_uncertainty_function_pipeline_fast(
+            pd_df=single_fold_df,
+            fold_col="fold_id",
+            label_col="label",
+            num_cv_folds=1,
+        )
+
+        assert metadata["fallback_used"] is True
+        assert metadata["folds_used"] == 1
+        assert get_score_std(5.0) == 1.0
+        assert np.all(get_score_std(np.array([1.0, 2.0, 3.0])) == 1.0)
+
+    def test_adaptive_kde_estimator_single_fold_produces_valid_curves(self):
+        """AdaptiveKDEPrecisionEstimator.fit() should succeed with num_cv_folds=1."""
+        rng = np.random.default_rng(42)
+        n = 10000
+
+        mqual_true = rng.gamma(shape=10, scale=2.5, size=n // 2)
+        mqual_false = rng.gamma(shape=4, scale=3, size=n // 2)
+        labels = np.concatenate([np.ones(n // 2, dtype=bool), np.zeros(n // 2, dtype=bool)])
+        mqual_all = np.concatenate([mqual_true, mqual_false])
+
+        data = {
+            "label": labels,
+            "fold_id": np.full(n, np.nan),
+            "prob_fold_0": 1 - 10 ** (-mqual_all / 10),
+            "prob_orig": 1 - 10 ** (-mqual_all / 10),
+            "mqual": mqual_all,
+        }
+        single_fold_df = pd.DataFrame(data)
+
+        estimator = AdaptiveKDEPrecisionEstimator()
+        estimator.fit(single_fold_df, num_cv_folds=1)
+
+        assert estimator.tpr is not None
+        assert estimator.fpr is not None
+        assert estimator.precision_grid is not None
+        assert np.all(np.diff(estimator.tpr) <= 1e-10)

--- a/src/srsnv/ugbio_srsnv/smoothing_utils.py
+++ b/src/srsnv/ugbio_srsnv/smoothing_utils.py
@@ -604,6 +604,33 @@ def build_score_std_interpolator(
     return get_score_std, metadata
 
 
+def _constant_std_fallback(
+    reason: str, transform_mode: str, *, validation_size: int, folds_used: int
+) -> tuple[Callable[[float | np.ndarray], float | np.ndarray], dict[str, Any]]:
+    """Return a constant std=1.0 uncertainty function when proper estimation is not possible."""
+
+    def get_score_std(score: float | np.ndarray) -> float | np.ndarray:
+        score_arr = np.asarray(score)
+        if score_arr.ndim == 0:
+            return 1.0
+        return np.ones_like(score_arr, dtype=float)
+
+    fallback_metadata = {
+        "pipeline_version": "1.0-fast",
+        "transform_mode": transform_mode,
+        "validation_size": validation_size,
+        "folds_used": folds_used,
+        "score_range": [0.0, 0.0],
+        "std_range": [1.0, 1.0],
+        "grid_size": 0,
+        "fallback_used": True,
+        "fallback_reason": reason,
+        "constant_std_value": 1.0,
+    }
+
+    return get_score_std, fallback_metadata
+
+
 def create_uncertainty_function_pipeline_fast(  # noqa: PLR0913, PLR0915, C901
     pd_df: pd.DataFrame,
     fold_col: str,
@@ -658,36 +685,9 @@ def create_uncertainty_function_pipeline_fast(  # noqa: PLR0913, PLR0915, C901
     # Step 1: Extract validation data (minimal)
     val_mask = pd_df[fold_col].isna()
     if val_mask.sum() < min_val_size:
-        logger.warning(
-            f"Insufficient validation data: {val_mask.sum()} < {min_val_size}. "
-            f"Using constant std = 1.0 as fallback."
-        )
-
-        # Return constant function that always returns 1.0
-        def get_score_std(score: float | np.ndarray) -> float | np.ndarray:
-            score_arr = np.asarray(score)
-            is_scalar = score_arr.ndim == 0
-
-            if is_scalar:
-                return 1.0
-            else:
-                return np.ones_like(score_arr, dtype=float)
-
-        # Fallback metadata
-        fallback_metadata = {
-            "pipeline_version": "1.0-fast",
-            "transform_mode": transform_mode,
-            "validation_size": val_mask.sum(),
-            "folds_used": 0,
-            "score_range": [0.0, 0.0],
-            "std_range": [1.0, 1.0],
-            "grid_size": 0,
-            "fallback_used": True,
-            "fallback_reason": f"Insufficient validation data: {val_mask.sum()} < {min_val_size}",
-            "constant_std_value": 1.0,
-        }
-
-        return get_score_std, fallback_metadata
+        reason = f"Insufficient validation data: {val_mask.sum()} < {min_val_size}"
+        logger.warning(f"{reason}. Using constant std = 1.0 as fallback.")
+        return _constant_std_fallback(reason, transform_mode, validation_size=int(val_mask.sum()), folds_used=0)
 
     val_df = pd_df.loc[val_mask].copy()
 
@@ -699,33 +699,11 @@ def create_uncertainty_function_pipeline_fast(  # noqa: PLR0913, PLR0915, C901
         raise ValueError("No probability columns found")
 
     if len(available_cols) < MIN_FOLDS_FOR_STD:
-        logger.warning(
-            f"Insufficient folds for uncertainty estimation: {len(available_cols)} < {MIN_FOLDS_FOR_STD}. "
-            f"Using constant std = 1.0 as fallback."
+        reason = f"Insufficient folds for std: {len(available_cols)} < {MIN_FOLDS_FOR_STD}"
+        logger.warning(f"{reason}. Using constant std = 1.0 as fallback.")
+        return _constant_std_fallback(
+            reason, transform_mode, validation_size=int(val_mask.sum()), folds_used=len(available_cols)
         )
-
-        def get_score_std(score: float | np.ndarray) -> float | np.ndarray:
-            score_arr = np.asarray(score)
-            is_scalar = score_arr.ndim == 0
-            if is_scalar:
-                return 1.0
-            else:
-                return np.ones_like(score_arr, dtype=float)
-
-        fallback_metadata = {
-            "pipeline_version": "1.0-fast",
-            "transform_mode": transform_mode,
-            "validation_size": int(val_mask.sum()),
-            "folds_used": len(available_cols),
-            "score_range": [0.0, 0.0],
-            "std_range": [1.0, 1.0],
-            "grid_size": 0,
-            "fallback_used": True,
-            "fallback_reason": f"Insufficient folds for std: {len(available_cols)} < {MIN_FOLDS_FOR_STD}",
-            "constant_std_value": 1.0,
-        }
-
-        return get_score_std, fallback_metadata
 
     # Convert probabilities to scores efficiently
     if transform_mode == "mqual":

--- a/src/srsnv/ugbio_srsnv/smoothing_utils.py
+++ b/src/srsnv/ugbio_srsnv/smoothing_utils.py
@@ -698,6 +698,35 @@ def create_uncertainty_function_pipeline_fast(  # noqa: PLR0913, PLR0915, C901
     if len(available_cols) == 0:
         raise ValueError("No probability columns found")
 
+    if len(available_cols) < MIN_FOLDS_FOR_STD:
+        logger.warning(
+            f"Insufficient folds for uncertainty estimation: {len(available_cols)} < {MIN_FOLDS_FOR_STD}. "
+            f"Using constant std = 1.0 as fallback."
+        )
+
+        def get_score_std(score: float | np.ndarray) -> float | np.ndarray:
+            score_arr = np.asarray(score)
+            is_scalar = score_arr.ndim == 0
+            if is_scalar:
+                return 1.0
+            else:
+                return np.ones_like(score_arr, dtype=float)
+
+        fallback_metadata = {
+            "pipeline_version": "1.0-fast",
+            "transform_mode": transform_mode,
+            "validation_size": int(val_mask.sum()),
+            "folds_used": len(available_cols),
+            "score_range": [0.0, 0.0],
+            "std_range": [1.0, 1.0],
+            "grid_size": 0,
+            "fallback_used": True,
+            "fallback_reason": f"Insufficient folds for std: {len(available_cols)} < {MIN_FOLDS_FOR_STD}",
+            "constant_std_value": 1.0,
+        }
+
+        return get_score_std, fallback_metadata
+
     # Convert probabilities to scores efficiently
     if transform_mode == "mqual":
         score_fn = prob_to_phred_fn


### PR DESCRIPTION
## Summary
- Fix `FQ_vs_recall.png` figure not being created when pipeline runs with 1-fold (single CV fold) configuration
- Root cause: `np.nanstd(..., ddof=1)` on a single `prob_fold_0` column returns all NaN, crashing the uncertainty estimation in `create_uncertainty_function_pipeline_fast()`
- Fix: return the constant std=1.0 fallback (same pattern as insufficient validation data) when fewer than `MIN_FOLDS_FOR_STD` probability columns are available

## Test plan
- [x] Added 2 new unit tests for single-fold fallback behavior
- [x] All 7 smoothing KDE tests pass
- [x] Full srsnv unit suite (366 tests) passes with no regressions
- [x] Docker image built successfully: `ugbio_srsnv:test_43b49d6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized fallback in smoothing/uncertainty estimation with tests; no auth, security, or data-path changes beyond avoiding NaN std in the 1-fold case.
> 
> **Overview**
> Fixes pipeline/report failures when cross-validation runs with **one fold** by avoiding cross-fold standard deviation on a single `prob_fold_*` column (which yields NaN and breaks uncertainty estimation used for **FQ vs recall** plots.
> 
> **`create_uncertainty_function_pipeline_fast`** now returns the same **constant std = 1.0** fallback when fewer than `MIN_FOLDS_FOR_STD` (2) fold probability columns are present, matching the existing “insufficient validation data” path. Inline fallback logic is consolidated into **`_constant_std_fallback`**.
> 
> Two unit tests cover single-fold behavior for the fast uncertainty pipeline and **`AdaptiveKDEPrecisionEstimator.fit`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20164a21891dc8cb776a972044efb6ca53bf709b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->