### PR TITLE
BIOIN-2878 Add recall@SNVQ=70 metric to srsnv report

### DIFF
--- a/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
+++ b/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
@@ -356,8 +356,8 @@ def test_calc_run_info_table_content_validation(test_resources_calc_run_info, re
         assert isinstance(quality_summary, pd.Series), "run_quality_summary_table should be a Series"
         assert len(quality_summary) > 0, "run_quality_summary_table should not be empty"
 
-        # Validate that recall@SNVQ metrics are present (including SNVQ=70)
-        expected_quality_keys = [
+        # Validate that recall@SNVQ metrics are present in legacy table (including SNVQ=70)
+        expected_legacy_keys = [
             ("Recall at SNVQ=50", "All reads"),
             ("Recall at SNVQ=60", "All reads"),
             ("Recall at SNVQ=70", "All reads"),
@@ -365,8 +365,23 @@ def test_calc_run_info_table_content_validation(test_resources_calc_run_info, re
             ("Recall at SNVQ=60", "Mixed, start"),
             ("Recall at SNVQ=70", "Mixed, start"),
         ]
-        for key in expected_quality_keys:
+        for key in expected_legacy_keys:
             assert key in quality_summary.index, f"Expected key {key} not found in run_quality_summary_table"
+
+        # Validate modern table (run_quality_summary_table_mixed_start) also has SNVQ=70
+        quality_summary_modern = pd.read_hdf(h5_file, key="run_quality_summary_table_mixed_start")
+        expected_modern_keys = [
+            ("Recall at SNVQ=50", "All reads"),
+            ("Recall at SNVQ=60", "All reads"),
+            ("Recall at SNVQ=70", "All reads"),
+            ("Recall at SNVQ=50", "Mixed"),
+            ("Recall at SNVQ=60", "Mixed"),
+            ("Recall at SNVQ=70", "Mixed"),
+        ]
+        for key in expected_modern_keys:
+            assert (
+                key in quality_summary_modern.index
+            ), f"Expected key {key} not found in run_quality_summary_table_mixed_start"
 
         # Validate training_info_table structure
         training_info = pd.read_hdf(h5_file, key="training_info_table")

--- a/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
+++ b/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
@@ -356,6 +356,18 @@ def test_calc_run_info_table_content_validation(test_resources_calc_run_info, re
         assert isinstance(quality_summary, pd.Series), "run_quality_summary_table should be a Series"
         assert len(quality_summary) > 0, "run_quality_summary_table should not be empty"
 
+        # Validate that recall@SNVQ metrics are present (including SNVQ=70)
+        expected_quality_keys = [
+            ("Recall at SNVQ=50", "All reads"),
+            ("Recall at SNVQ=60", "All reads"),
+            ("Recall at SNVQ=70", "All reads"),
+            ("Recall at SNVQ=50", "Mixed, start"),
+            ("Recall at SNVQ=60", "Mixed, start"),
+            ("Recall at SNVQ=70", "Mixed, start"),
+        ]
+        for key in expected_quality_keys:
+            assert key in quality_summary.index, f"Expected key {key} not found in run_quality_summary_table"
+
         # Validate training_info_table structure
         training_info = pd.read_hdf(h5_file, key="training_info_table")
 

--- a/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
@@ -1911,6 +1911,9 @@ class SRSNVReport:
         recall_at_60 = self._get_recall_at_snvq(snvq=60)
         recall_at_60_mixed_start = self._get_recall_at_snvq(snvq=60, condition=self.data_df[IS_MIXED_START])
         recall_at_60_mixed_both = self._get_recall_at_snvq(snvq=60, condition=self.data_df[IS_MIXED])
+        recall_at_70 = self._get_recall_at_snvq(snvq=70)
+        recall_at_70_mixed_start = self._get_recall_at_snvq(snvq=70, condition=self.data_df[IS_MIXED_START])
+        recall_at_70_mixed_both = self._get_recall_at_snvq(snvq=70, condition=self.data_df[IS_MIXED])
         roc_auc_phred = prob_to_phred(
             self._safe_roc_auc(self.data_df[LABEL], self.data_df[ML_PROB_1_TEST], name="run info total"),
             max_value=self.max_qual,
@@ -1931,6 +1934,8 @@ class SRSNVReport:
             ("Recall at SNVQ=50", "Mixed"): signif(recall_at_50_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
             ("Recall at SNVQ=60", "All reads"): signif(recall_at_60 / recall_at_0, SIG_DIGITS),
             ("Recall at SNVQ=60", "Mixed"): signif(recall_at_60_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
+            ("Recall at SNVQ=70", "All reads"): signif(recall_at_70 / recall_at_0, SIG_DIGITS),
+            ("Recall at SNVQ=70", "Mixed"): signif(recall_at_70_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
             ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed"): signif(recall_at_0_mixed_start, SIG_DIGITS),
             ("ROC AUC (Phred)", "All reads"): signif(roc_auc_phred, SIG_DIGITS),
@@ -1954,6 +1959,13 @@ class SRSNVReport:
             ),
             ("Recall at SNVQ=60", "Mixed, both ends"): signif(
                 recall_at_60_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
+            ),
+            ("Recall at SNVQ=70", "All reads"): signif(recall_at_70 / recall_at_0, SIG_DIGITS),
+            ("Recall at SNVQ=70", "Mixed, start"): signif(
+                recall_at_70_mixed_start / recall_at_0_mixed_start, SIG_DIGITS
+            ),
+            ("Recall at SNVQ=70", "Mixed, both ends"): signif(
+                recall_at_70_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
             ),
             ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed, start"): signif(recall_at_0_mixed_start, SIG_DIGITS),

--- a/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
@@ -1905,15 +1905,14 @@ class SRSNVReport:
         recall_at_0 = self._get_recall_at_snvq(snvq=0)
         recall_at_0_mixed_start = self._get_recall_at_snvq(snvq=0, condition=self.data_df[IS_MIXED_START])
         recall_at_0_mixed_both = self._get_recall_at_snvq(snvq=0, condition=self.data_df[IS_MIXED])
-        recall_at_50 = self._get_recall_at_snvq(snvq=50)
-        recall_at_50_mixed_start = self._get_recall_at_snvq(snvq=50, condition=self.data_df[IS_MIXED_START])
-        recall_at_50_mixed_both = self._get_recall_at_snvq(snvq=50, condition=self.data_df[IS_MIXED])
-        recall_at_60 = self._get_recall_at_snvq(snvq=60)
-        recall_at_60_mixed_start = self._get_recall_at_snvq(snvq=60, condition=self.data_df[IS_MIXED_START])
-        recall_at_60_mixed_both = self._get_recall_at_snvq(snvq=60, condition=self.data_df[IS_MIXED])
-        recall_at_70 = self._get_recall_at_snvq(snvq=70)
-        recall_at_70_mixed_start = self._get_recall_at_snvq(snvq=70, condition=self.data_df[IS_MIXED_START])
-        recall_at_70_mixed_both = self._get_recall_at_snvq(snvq=70, condition=self.data_df[IS_MIXED])
+        snvq_thresholds = [50, 60, 70]
+        recalls = {}
+        for snvq in snvq_thresholds:
+            recalls[snvq] = {
+                "all": self._get_recall_at_snvq(snvq=snvq),
+                "mixed_start": self._get_recall_at_snvq(snvq=snvq, condition=self.data_df[IS_MIXED_START]),
+                "mixed_both": self._get_recall_at_snvq(snvq=snvq, condition=self.data_df[IS_MIXED]),
+            }
         roc_auc_phred = prob_to_phred(
             self._safe_roc_auc(self.data_df[LABEL], self.data_df[ML_PROB_1_TEST], name="run info total"),
             max_value=self.max_qual,
@@ -1930,12 +1929,16 @@ class SRSNVReport:
         performance_info = {
             ("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS),
             ("Median SNVQ", "Mixed"): signif(median_qual_mixed_start, SIG_DIGITS),
-            ("Recall at SNVQ=50", "All reads"): signif(recall_at_50 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=50", "Mixed"): signif(recall_at_50_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
-            ("Recall at SNVQ=60", "All reads"): signif(recall_at_60 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=60", "Mixed"): signif(recall_at_60_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
-            ("Recall at SNVQ=70", "All reads"): signif(recall_at_70 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=70", "Mixed"): signif(recall_at_70_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
+            **{
+                (f"Recall at SNVQ={snvq}", "All reads"): signif(recalls[snvq]["all"] / recall_at_0, SIG_DIGITS)
+                for snvq in snvq_thresholds
+            },
+            **{
+                (f"Recall at SNVQ={snvq}", "Mixed"): signif(
+                    recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
+                )
+                for snvq in snvq_thresholds
+            },
             ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed"): signif(recall_at_0_mixed_start, SIG_DIGITS),
             ("ROC AUC (Phred)", "All reads"): signif(roc_auc_phred, SIG_DIGITS),
@@ -1946,27 +1949,22 @@ class SRSNVReport:
             ("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS),
             ("Median SNVQ", "Mixed, start"): signif(median_qual_mixed_start, SIG_DIGITS),
             ("Median SNVQ", "Mixed, both ends"): signif(median_qual_mixed_both, SIG_DIGITS),
-            ("Recall at SNVQ=50", "All reads"): signif(recall_at_50 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=50", "Mixed, start"): signif(
-                recall_at_50_mixed_start / recall_at_0_mixed_start, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=50", "Mixed, both ends"): signif(
-                recall_at_50_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=60", "All reads"): signif(recall_at_60 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=60", "Mixed, start"): signif(
-                recall_at_60_mixed_start / recall_at_0_mixed_start, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=60", "Mixed, both ends"): signif(
-                recall_at_60_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=70", "All reads"): signif(recall_at_70 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=70", "Mixed, start"): signif(
-                recall_at_70_mixed_start / recall_at_0_mixed_start, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=70", "Mixed, both ends"): signif(
-                recall_at_70_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
-            ),
+            **{
+                (f"Recall at SNVQ={snvq}", "All reads"): signif(recalls[snvq]["all"] / recall_at_0, SIG_DIGITS)
+                for snvq in snvq_thresholds
+            },
+            **{
+                (f"Recall at SNVQ={snvq}", "Mixed, start"): signif(
+                    recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
+                )
+                for snvq in snvq_thresholds
+            },
+            **{
+                (f"Recall at SNVQ={snvq}", "Mixed, both ends"): signif(
+                    recalls[snvq]["mixed_both"] / recall_at_0_mixed_both, SIG_DIGITS
+                )
+                for snvq in snvq_thresholds
+            },
             ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed, start"): signif(recall_at_0_mixed_start, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed, both ends"): signif(recall_at_0_mixed_both, SIG_DIGITS),


### PR DESCRIPTION
## Summary
- Add `recall@SNVQ=70` metric alongside existing SNVQ=50 and SNVQ=60 in both modern and legacy performance info dicts
- Add test assertions validating presence of all three SNVQ recall thresholds in the h5 output

## Test plan
- [x] CI tests pass (calc_run_info tests validate new metric keys)
- [x] Docker build passes (verified: `ugbio_srsnv:1.27.0-0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting-only change to QC summary metrics with matching test assertions; no auth, pipeline scoring, or data-model changes beyond an extra table row.
> 
> **Overview**
> Adds **Recall at SNVQ=70** to the SRSNV application QC summary alongside the existing SNVQ=50 and SNVQ=60 metrics.
> 
> In `calc_run_info_table`, recall at each threshold is computed in a loop over `[50, 60, 70]` for all reads, mixed-start, and (legacy) mixed-both slices, and the normalized recall rows are written to both the modern `run_quality_summary_table_mixed_start` and backward-compatible `run_quality_summary_table` H5 series.
> 
> Unit tests now assert those `Recall at SNVQ=*` index keys are present in both HDF tables after `calc_run_info_table` runs on real fixture data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32160e99543a28d8c097f3dc328fb7ebaf570d8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->