### PR TITLE
BIOIN-2878 Fix SNVQ recall report table ordering and add test coverage

### DIFF
--- a/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
+++ b/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
@@ -356,8 +356,8 @@ def test_calc_run_info_table_content_validation(test_resources_calc_run_info, re
         assert isinstance(quality_summary, pd.Series), "run_quality_summary_table should be a Series"
         assert len(quality_summary) > 0, "run_quality_summary_table should not be empty"
 
-        # Validate that recall@SNVQ metrics are present (including SNVQ=70)
-        expected_quality_keys = [
+        # Validate that recall@SNVQ metrics are present in legacy table (including SNVQ=70)
+        expected_legacy_keys = [
             ("Recall at SNVQ=50", "All reads"),
             ("Recall at SNVQ=60", "All reads"),
             ("Recall at SNVQ=70", "All reads"),
@@ -365,8 +365,23 @@ def test_calc_run_info_table_content_validation(test_resources_calc_run_info, re
             ("Recall at SNVQ=60", "Mixed, start"),
             ("Recall at SNVQ=70", "Mixed, start"),
         ]
-        for key in expected_quality_keys:
+        for key in expected_legacy_keys:
             assert key in quality_summary.index, f"Expected key {key} not found in run_quality_summary_table"
+
+        # Validate modern table (run_quality_summary_table_mixed_start) also has SNVQ=70
+        quality_summary_modern = pd.read_hdf(h5_file, key="run_quality_summary_table_mixed_start")
+        expected_modern_keys = [
+            ("Recall at SNVQ=50", "All reads"),
+            ("Recall at SNVQ=60", "All reads"),
+            ("Recall at SNVQ=70", "All reads"),
+            ("Recall at SNVQ=50", "Mixed"),
+            ("Recall at SNVQ=60", "Mixed"),
+            ("Recall at SNVQ=70", "Mixed"),
+        ]
+        for key in expected_modern_keys:
+            assert (
+                key in quality_summary_modern.index
+            ), f"Expected key {key} not found in run_quality_summary_table_mixed_start"
 
         # Validate training_info_table structure
         training_info = pd.read_hdf(h5_file, key="training_info_table")

--- a/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
+++ b/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
@@ -356,6 +356,18 @@ def test_calc_run_info_table_content_validation(test_resources_calc_run_info, re
         assert isinstance(quality_summary, pd.Series), "run_quality_summary_table should be a Series"
         assert len(quality_summary) > 0, "run_quality_summary_table should not be empty"
 
+        # Validate that recall@SNVQ metrics are present (including SNVQ=70)
+        expected_quality_keys = [
+            ("Recall at SNVQ=50", "All reads"),
+            ("Recall at SNVQ=60", "All reads"),
+            ("Recall at SNVQ=70", "All reads"),
+            ("Recall at SNVQ=50", "Mixed, start"),
+            ("Recall at SNVQ=60", "Mixed, start"),
+            ("Recall at SNVQ=70", "Mixed, start"),
+        ]
+        for key in expected_quality_keys:
+            assert key in quality_summary.index, f"Expected key {key} not found in run_quality_summary_table"
+
         # Validate training_info_table structure
         training_info = pd.read_hdf(h5_file, key="training_info_table")
 

--- a/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
@@ -1911,6 +1911,9 @@ class SRSNVReport:
         recall_at_60 = self._get_recall_at_snvq(snvq=60)
         recall_at_60_mixed_start = self._get_recall_at_snvq(snvq=60, condition=self.data_df[IS_MIXED_START])
         recall_at_60_mixed_both = self._get_recall_at_snvq(snvq=60, condition=self.data_df[IS_MIXED])
+        recall_at_70 = self._get_recall_at_snvq(snvq=70)
+        recall_at_70_mixed_start = self._get_recall_at_snvq(snvq=70, condition=self.data_df[IS_MIXED_START])
+        recall_at_70_mixed_both = self._get_recall_at_snvq(snvq=70, condition=self.data_df[IS_MIXED])
         roc_auc_phred = prob_to_phred(
             self._safe_roc_auc(self.data_df[LABEL], self.data_df[ML_PROB_1_TEST], name="run info total"),
             max_value=self.max_qual,
@@ -1931,6 +1934,8 @@ class SRSNVReport:
             ("Recall at SNVQ=50", "Mixed"): signif(recall_at_50_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
             ("Recall at SNVQ=60", "All reads"): signif(recall_at_60 / recall_at_0, SIG_DIGITS),
             ("Recall at SNVQ=60", "Mixed"): signif(recall_at_60_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
+            ("Recall at SNVQ=70", "All reads"): signif(recall_at_70 / recall_at_0, SIG_DIGITS),
+            ("Recall at SNVQ=70", "Mixed"): signif(recall_at_70_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
             ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed"): signif(recall_at_0_mixed_start, SIG_DIGITS),
             ("ROC AUC (Phred)", "All reads"): signif(roc_auc_phred, SIG_DIGITS),
@@ -1954,6 +1959,13 @@ class SRSNVReport:
             ),
             ("Recall at SNVQ=60", "Mixed, both ends"): signif(
                 recall_at_60_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
+            ),
+            ("Recall at SNVQ=70", "All reads"): signif(recall_at_70 / recall_at_0, SIG_DIGITS),
+            ("Recall at SNVQ=70", "Mixed, start"): signif(
+                recall_at_70_mixed_start / recall_at_0_mixed_start, SIG_DIGITS
+            ),
+            ("Recall at SNVQ=70", "Mixed, both ends"): signif(
+                recall_at_70_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
             ),
             ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed, start"): signif(recall_at_0_mixed_start, SIG_DIGITS),

--- a/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
@@ -1905,15 +1905,14 @@ class SRSNVReport:
         recall_at_0 = self._get_recall_at_snvq(snvq=0)
         recall_at_0_mixed_start = self._get_recall_at_snvq(snvq=0, condition=self.data_df[IS_MIXED_START])
         recall_at_0_mixed_both = self._get_recall_at_snvq(snvq=0, condition=self.data_df[IS_MIXED])
-        recall_at_50 = self._get_recall_at_snvq(snvq=50)
-        recall_at_50_mixed_start = self._get_recall_at_snvq(snvq=50, condition=self.data_df[IS_MIXED_START])
-        recall_at_50_mixed_both = self._get_recall_at_snvq(snvq=50, condition=self.data_df[IS_MIXED])
-        recall_at_60 = self._get_recall_at_snvq(snvq=60)
-        recall_at_60_mixed_start = self._get_recall_at_snvq(snvq=60, condition=self.data_df[IS_MIXED_START])
-        recall_at_60_mixed_both = self._get_recall_at_snvq(snvq=60, condition=self.data_df[IS_MIXED])
-        recall_at_70 = self._get_recall_at_snvq(snvq=70)
-        recall_at_70_mixed_start = self._get_recall_at_snvq(snvq=70, condition=self.data_df[IS_MIXED_START])
-        recall_at_70_mixed_both = self._get_recall_at_snvq(snvq=70, condition=self.data_df[IS_MIXED])
+        snvq_thresholds = [50, 60, 70]
+        recalls = {}
+        for snvq in snvq_thresholds:
+            recalls[snvq] = {
+                "all": self._get_recall_at_snvq(snvq=snvq),
+                "mixed_start": self._get_recall_at_snvq(snvq=snvq, condition=self.data_df[IS_MIXED_START]),
+                "mixed_both": self._get_recall_at_snvq(snvq=snvq, condition=self.data_df[IS_MIXED]),
+            }
         roc_auc_phred = prob_to_phred(
             self._safe_roc_auc(self.data_df[LABEL], self.data_df[ML_PROB_1_TEST], name="run info total"),
             max_value=self.max_qual,
@@ -1930,12 +1929,16 @@ class SRSNVReport:
         performance_info = {
             ("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS),
             ("Median SNVQ", "Mixed"): signif(median_qual_mixed_start, SIG_DIGITS),
-            ("Recall at SNVQ=50", "All reads"): signif(recall_at_50 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=50", "Mixed"): signif(recall_at_50_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
-            ("Recall at SNVQ=60", "All reads"): signif(recall_at_60 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=60", "Mixed"): signif(recall_at_60_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
-            ("Recall at SNVQ=70", "All reads"): signif(recall_at_70 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=70", "Mixed"): signif(recall_at_70_mixed_start / recall_at_0_mixed_start, SIG_DIGITS),
+            **{
+                (f"Recall at SNVQ={snvq}", "All reads"): signif(recalls[snvq]["all"] / recall_at_0, SIG_DIGITS)
+                for snvq in snvq_thresholds
+            },
+            **{
+                (f"Recall at SNVQ={snvq}", "Mixed"): signif(
+                    recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
+                )
+                for snvq in snvq_thresholds
+            },
             ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed"): signif(recall_at_0_mixed_start, SIG_DIGITS),
             ("ROC AUC (Phred)", "All reads"): signif(roc_auc_phred, SIG_DIGITS),
@@ -1946,27 +1949,22 @@ class SRSNVReport:
             ("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS),
             ("Median SNVQ", "Mixed, start"): signif(median_qual_mixed_start, SIG_DIGITS),
             ("Median SNVQ", "Mixed, both ends"): signif(median_qual_mixed_both, SIG_DIGITS),
-            ("Recall at SNVQ=50", "All reads"): signif(recall_at_50 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=50", "Mixed, start"): signif(
-                recall_at_50_mixed_start / recall_at_0_mixed_start, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=50", "Mixed, both ends"): signif(
-                recall_at_50_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=60", "All reads"): signif(recall_at_60 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=60", "Mixed, start"): signif(
-                recall_at_60_mixed_start / recall_at_0_mixed_start, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=60", "Mixed, both ends"): signif(
-                recall_at_60_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=70", "All reads"): signif(recall_at_70 / recall_at_0, SIG_DIGITS),
-            ("Recall at SNVQ=70", "Mixed, start"): signif(
-                recall_at_70_mixed_start / recall_at_0_mixed_start, SIG_DIGITS
-            ),
-            ("Recall at SNVQ=70", "Mixed, both ends"): signif(
-                recall_at_70_mixed_both / recall_at_0_mixed_both, SIG_DIGITS
-            ),
+            **{
+                (f"Recall at SNVQ={snvq}", "All reads"): signif(recalls[snvq]["all"] / recall_at_0, SIG_DIGITS)
+                for snvq in snvq_thresholds
+            },
+            **{
+                (f"Recall at SNVQ={snvq}", "Mixed, start"): signif(
+                    recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
+                )
+                for snvq in snvq_thresholds
+            },
+            **{
+                (f"Recall at SNVQ={snvq}", "Mixed, both ends"): signif(
+                    recalls[snvq]["mixed_both"] / recall_at_0_mixed_both, SIG_DIGITS
+                )
+                for snvq in snvq_thresholds
+            },
             ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed, start"): signif(recall_at_0_mixed_start, SIG_DIGITS),
             ("Pre-filter Recall", "Mixed, both ends"): signif(recall_at_0_mixed_both, SIG_DIGITS),

--- a/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
@@ -1867,7 +1867,7 @@ class SRSNVReport:
         return dataset_sizes
 
     @exception_handler
-    def calc_run_info_table(self):
+    def calc_run_info_table(self):  # noqa: PLR0915
         """Calculate run_info_table, a table with general run information."""
         # Generate Run Info table
         logger.info("Generating Run Info table")
@@ -1925,53 +1925,46 @@ class SRSNVReport:
             self._safe_roc_auc(mixed_both_df[LABEL], mixed_both_df[ML_PROB_1_TEST], name="run info mixed both"),
             max_value=self.max_qual,
         )
-        # Simplified performance info for display (uses IS_MIXED_START only)
+        # Note: entry order matters — unstack(sort=False) in the report notebook relies on
+        # each metric having all its categories together before the next metric appears.
         performance_info = {
             ("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS),
             ("Median SNVQ", "Mixed"): signif(median_qual_mixed_start, SIG_DIGITS),
-            **{
-                (f"Recall at SNVQ={snvq}", "All reads"): signif(recalls[snvq]["all"] / recall_at_0, SIG_DIGITS)
-                for snvq in snvq_thresholds
-            },
-            **{
-                (f"Recall at SNVQ={snvq}", "Mixed"): signif(
-                    recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
-                )
-                for snvq in snvq_thresholds
-            },
-            ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
-            ("Pre-filter Recall", "Mixed"): signif(recall_at_0_mixed_start, SIG_DIGITS),
-            ("ROC AUC (Phred)", "All reads"): signif(roc_auc_phred, SIG_DIGITS),
-            ("ROC AUC (Phred)", "Mixed"): signif(roc_auc_phred_mixed_start, SIG_DIGITS),
         }
+        for snvq in snvq_thresholds:
+            performance_info[(f"Recall at SNVQ={snvq}", "All reads")] = signif(
+                recalls[snvq]["all"] / recall_at_0, SIG_DIGITS
+            )
+            performance_info[(f"Recall at SNVQ={snvq}", "Mixed")] = signif(
+                recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
+            )
+        performance_info[("Pre-filter Recall", "All reads")] = signif(recall_at_0, SIG_DIGITS)
+        performance_info[("Pre-filter Recall", "Mixed")] = signif(recall_at_0_mixed_start, SIG_DIGITS)
+        performance_info[("ROC AUC (Phred)", "All reads")] = signif(roc_auc_phred, SIG_DIGITS)
+        performance_info[("ROC AUC (Phred)", "Mixed")] = signif(roc_auc_phred_mixed_start, SIG_DIGITS)
+
         # Legacy performance info with 3-way split for backward-compatible h5 storage
         performance_info_legacy = {
             ("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS),
             ("Median SNVQ", "Mixed, start"): signif(median_qual_mixed_start, SIG_DIGITS),
             ("Median SNVQ", "Mixed, both ends"): signif(median_qual_mixed_both, SIG_DIGITS),
-            **{
-                (f"Recall at SNVQ={snvq}", "All reads"): signif(recalls[snvq]["all"] / recall_at_0, SIG_DIGITS)
-                for snvq in snvq_thresholds
-            },
-            **{
-                (f"Recall at SNVQ={snvq}", "Mixed, start"): signif(
-                    recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
-                )
-                for snvq in snvq_thresholds
-            },
-            **{
-                (f"Recall at SNVQ={snvq}", "Mixed, both ends"): signif(
-                    recalls[snvq]["mixed_both"] / recall_at_0_mixed_both, SIG_DIGITS
-                )
-                for snvq in snvq_thresholds
-            },
-            ("Pre-filter Recall", "All reads"): signif(recall_at_0, SIG_DIGITS),
-            ("Pre-filter Recall", "Mixed, start"): signif(recall_at_0_mixed_start, SIG_DIGITS),
-            ("Pre-filter Recall", "Mixed, both ends"): signif(recall_at_0_mixed_both, SIG_DIGITS),
-            ("ROC AUC (Phred)", "All reads"): signif(roc_auc_phred, SIG_DIGITS),
-            ("ROC AUC (Phred)", "Mixed, start"): signif(roc_auc_phred_mixed_start, SIG_DIGITS),
-            ("ROC AUC (Phred)", "Mixed, both ends"): signif(roc_auc_phred_mixed_both, SIG_DIGITS),
         }
+        for snvq in snvq_thresholds:
+            performance_info_legacy[(f"Recall at SNVQ={snvq}", "All reads")] = signif(
+                recalls[snvq]["all"] / recall_at_0, SIG_DIGITS
+            )
+            performance_info_legacy[(f"Recall at SNVQ={snvq}", "Mixed, start")] = signif(
+                recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
+            )
+            performance_info_legacy[(f"Recall at SNVQ={snvq}", "Mixed, both ends")] = signif(
+                recalls[snvq]["mixed_both"] / recall_at_0_mixed_both, SIG_DIGITS
+            )
+        performance_info_legacy[("Pre-filter Recall", "All reads")] = signif(recall_at_0, SIG_DIGITS)
+        performance_info_legacy[("Pre-filter Recall", "Mixed, start")] = signif(recall_at_0_mixed_start, SIG_DIGITS)
+        performance_info_legacy[("Pre-filter Recall", "Mixed, both ends")] = signif(recall_at_0_mixed_both, SIG_DIGITS)
+        performance_info_legacy[("ROC AUC (Phred)", "All reads")] = signif(roc_auc_phred, SIG_DIGITS)
+        performance_info_legacy[("ROC AUC (Phred)", "Mixed, start")] = signif(roc_auc_phred_mixed_start, SIG_DIGITS)
+        performance_info_legacy[("ROC AUC (Phred)", "Mixed, both ends")] = signif(roc_auc_phred_mixed_both, SIG_DIGITS)
         # Info about versions
         version_info = {
             ("Pipeline version", ""): (self.params.get("pipeline_version", None)),


### PR DESCRIPTION
## Summary
- Fix report table misalignment: the refactored dict comprehension grouped all "All reads" entries together then all "Mixed" entries, but the report notebook's `.unstack(sort=False).T` requires each metric's categories to be adjacent. Switched to explicit loop preserving correct interleaved ordering.

## Context
The initial SNVQ=70 addition (merged in #326) introduced a report rendering bug where values in the HTML quality summary table were shifted between columns (e.g., SNVQ=70 value appeared in the SNVQ=60 column). Root cause: `**{...}` dict comprehensions don't preserve the per-metric interleaved ordering that `pd.Series.unstack(sort=False)` depends on.

## Test plan
- [ ] CI tests pass
- [x] Docker build succeeds (verified: `ugbio_srsnv:test_f1f79d9`)
- [x] Report table displays correctly (verified via Omics run 3447168 comparison)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-order fix only in report table construction; metric formulas and h5 keys are unchanged.
> 
> **Overview**
> Fixes **misaligned SNVQ recall columns** in the HTML quality summary table by changing how `performance_info` and `performance_info_legacy` are built in `calc_run_info_table`.
> 
> Previously, spreading separate `**{...}` comprehensions for “All reads” and “Mixed” grouped all thresholds of one category together. The report notebook reshapes the stored Series with `.unstack(sort=False).T`, which expects **each metric’s categories adjacent** (e.g. SNVQ=50 All reads, then SNVQ=50 Mixed, then SNVQ=60…). The refactor uses explicit loops over `snvq_thresholds` so keys stay interleaved; values are unchanged.
> 
> Documents that insertion order is required and adds `# noqa: PLR0915` on the method for complexity linting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d8518b41e87eded4a9cd4eef8b4a95690380a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->