### PR TITLE
Fix reading sorter CSV for non-numeric categories

### DIFF
--- a/src/core/tests/unit/test_sorter_utils.py
+++ b/src/core/tests/unit/test_sorter_utils.py
@@ -57,3 +57,17 @@ def test_read_sorter_statistics_csv_dataframe_matches_series(sorter_csv):
     result = read_sorter_statistics_csv(sorter_csv, edit_metric_names=False, as_dataframe=True)
     assert result["metric"].tolist() == series.index.tolist()
     assert result["value"].tolist() == series.tolist()
+
+
+def test_read_sorter_statistics_csv_with_category_row(tmp_path):
+    csv_content = "PF_Barcode_reads,1000000\nMean_cvg,30.5\nCATEGORY,PAIRED\nMean_Read_Length,150.0\n"
+    csv_file = tmp_path / "sorter_stats.csv"
+    csv_file.write_text(csv_content)
+
+    result = read_sorter_statistics_csv(str(csv_file))
+
+    assert isinstance(result, pd.Series)
+    assert "CATEGORY" not in result.index
+    assert result["PF_Barcode_reads"] == 1000000
+    assert result["Mean_cvg"] == 30.5
+    assert result["Mean_Read_Length"] == 150.0

--- a/src/core/ugbio_core/sorter_utils.py
+++ b/src/core/ugbio_core/sorter_utils.py
@@ -31,13 +31,13 @@ def read_sorter_statistics_csv(
     df_sorter_stats = pd.read_csv(sorter_stats_csv, header=None, names=["metric", "value"]).set_index("metric")
     # replace '(' and ')' in values (legacy format for F95)
     df_sorter_stats = df_sorter_stats.assign(
-        value=df_sorter_stats["value"]
-        .astype(str)
-        .str.replace("(", "", regex=False)
-        .str.replace(")", "", regex=False)
-        .astype(float)
-        .values
+        value=pd.to_numeric(
+            df_sorter_stats["value"].astype(str).str.replace("(", "", regex=False).str.replace(")", "", regex=False),
+            errors="coerce",
+        ).values
     )
+    # drop non-numeric rows (e.g. CATEGORY row with PAIRED/UNPAIRED values)
+    df_sorter_stats = df_sorter_stats.dropna(subset=["value"])
     # add convenient metric
     if "Failed_QC_reads" in df_sorter_stats.index and "PF_Barcode_reads" in df_sorter_stats.index:
         df_sorter_stats.loc["PCT_Failed_QC_reads"] = (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Localized CSV parsing change in sorter utilities with a focused test; no auth, security, or broad API behavior changes beyond skipping non-numeric rows instead of raising.
> 
> **Overview**
> **`read_sorter_statistics_csv`** no longer fails when sorter CSVs include non-numeric metric rows (e.g. **`CATEGORY`** with values like **`PAIRED`**).
> 
> Value parsing now uses **`pd.to_numeric(..., errors="coerce")`** instead of casting directly to float, then **drops rows with non-numeric values** after stripping legacy parentheses from strings. Numeric metrics are unchanged; only string category rows are omitted from the returned Series/DataFrame.
> 
> A unit test covers a CSV with a **`CATEGORY`** row and asserts it is excluded while other metrics parse correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3bd351c7d9b828e141acfd49713643b508b8b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->