### PR TITLE
BIOIN-2830: lpa_caller

### DIFF
--- a/src/cnv/pyproject.toml
+++ b/src/cnv/pyproject.toml
@@ -36,6 +36,7 @@ run_jalign = "ugbio_cnv.run_jalign:main"
 add_cipos_to_vcf = "ugbio_cnv.add_cipos:main"
 refine_cnv_breakpoints = "ugbio_cnv.breakpoint_refinement:main"
 reformat_parascopy_bed = "ugbio_cnv.reformat_parascopy_bed:main"
+lpa_caller = "ugbio_cnv.lpa_caller:main"
 
 [tool.uv.sources.ugbio_core]
 workspace = true

--- a/src/cnv/tests/resources/lpa_caller_HG01046_kiv2.bam
+++ b/src/cnv/tests/resources/lpa_caller_HG01046_kiv2.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:793eaae20ad247ea2104008c36b7e48c616ad3362cd2c9db81483e4f1778648c
+size 3993181

--- a/src/cnv/tests/resources/lpa_caller_HG01046_kiv2.bam.bai
+++ b/src/cnv/tests/resources/lpa_caller_HG01046_kiv2.bam.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6663e0bc66d5b2622436ef380755363a3ef5610f3513a80154dfea7139608cd0
+size 105608

--- a/src/cnv/tests/system/test_lpa_caller_system.py
+++ b/src/cnv/tests/system/test_lpa_caller_system.py
@@ -1,0 +1,77 @@
+"""
+System test for `ugbio_cnv.lpa_caller`.
+
+Exercises marker-based haplotype splitting and per-site small-variant inference
+against a real Ultima BAM slice (KIV-2 region of Coriell HG01046).
+
+End-to-end depth estimation (`_estimate_total_kiv2_copy_number`) requires the
+full hg38 reference and the autosomal norm regions, so it is verified offline
+on the 17-sample DRAGEN comparison rather than in CI. Here we pass the
+DRAGEN-reported KIV-2 copy number for HG01046 as a literal so the test can run
+against just the (~4 MB) KIV-2 slice.
+"""
+
+from pathlib import Path
+
+import pysam
+import pytest
+from ugbio_cnv.lpa_caller import (
+    DEFAULT_KIV2_CHROM,
+    DEFAULT_MARKER_VARIANTS,
+    DEFAULT_SMALL_VARIANTS,
+    _build_marker,
+    _call_heterozygous_markers,
+    _call_small_variant,
+    _count_alleles_at_positions,
+)
+
+# HG01046 DRAGEN-reported KIV-2 copy number (targeted-caller v4.4.7).
+HG01046_KIV2_CN = 45.72
+
+
+@pytest.fixture
+def resources_dir() -> Path:
+    return Path(__file__).parent.parent / "resources"
+
+
+@pytest.fixture
+def hg01046_bam(resources_dir: Path) -> Path:
+    return resources_dir / "lpa_caller_HG01046_kiv2.bam"
+
+
+def test_marker_split_hg01046(hg01046_bam: Path) -> None:
+    markers = [_build_marker(s) for s in DEFAULT_MARKER_VARIANTS]
+    with pysam.AlignmentFile(str(hg01046_bam), "rb") as bam:
+        ref_cn, alt_cn, call_type, per_marker = _call_heterozygous_markers(
+            bam, DEFAULT_KIV2_CHROM, markers, HG01046_KIV2_CN
+        )
+
+    assert call_type == "Heterozygous markers call"
+    assert ref_cn is not None
+    assert alt_cn is not None
+    # Production VCF emitted 25 / 21; trimmed-mean correction may shift the
+    # split by <=1 copy on either side.
+    assert ref_cn == pytest.approx(24.7, abs=1.0)
+    assert alt_cn == pytest.approx(21.0, abs=1.0)
+    assert ref_cn + alt_cn == pytest.approx(HG01046_KIV2_CN, abs=1e-6)
+
+    # Both markers must be informative (hundreds of supporting reads at 30x
+    # across 6 KIV-2 copies).
+    for counts in per_marker:
+        assert counts.informative > 100
+
+
+@pytest.mark.parametrize("hgvs", ["LPA:4925G>A", "LPA:4733G>A"])
+def test_small_variants_hg01046_negative(hg01046_bam: Path, hgvs: str) -> None:
+    """HG01046 carries no LPA small variants — both sites should call alt_cn=0."""
+    spec = next(s for s in DEFAULT_SMALL_VARIANTS if s["hgvs"] == hgvs)
+    sv = _build_marker(spec)
+
+    with pysam.AlignmentFile(str(hg01046_bam), "rb") as bam:
+        counts = _count_alleles_at_positions(bam, DEFAULT_KIV2_CHROM, sv.positions, sv.ref, sv.alt)
+    call = _call_small_variant(counts, HG01046_KIV2_CN, sv.hgvs, sv.ref, sv.alt, sv.positions)
+
+    assert counts.informative > 100
+    assert counts.alt == 0
+    assert call.alt_copy_number == 0
+    assert call.qual == 0.0

--- a/src/cnv/tests/system/test_lpa_caller_system.py
+++ b/src/cnv/tests/system/test_lpa_caller_system.py
@@ -11,10 +11,12 @@ DRAGEN-reported KIV-2 copy number for HG01046 as a literal so the test can run
 against just the (~4 MB) KIV-2 slice.
 """
 
+import json
 from pathlib import Path
 
 import pysam
 import pytest
+from ugbio_cnv import lpa_caller as lpa_caller_mod
 from ugbio_cnv.lpa_caller import (
     DEFAULT_KIV2_CHROM,
     DEFAULT_MARKER_VARIANTS,
@@ -27,6 +29,8 @@ from ugbio_cnv.lpa_caller import (
 
 # HG01046 DRAGEN-reported KIV-2 copy number (targeted-caller v4.4.7).
 HG01046_KIV2_CN = 45.72
+# 5% tolerance for numerical comparisons on the KIV-2 slice.
+CN_TOLERANCE_FRACTION = 0.05
 
 
 @pytest.fixture
@@ -75,3 +79,130 @@ def test_small_variants_hg01046_negative(hg01046_bam: Path, hgvs: str) -> None:
     assert counts.alt == 0
     assert call.alt_copy_number == 0
     assert call.qual == 0.0
+
+
+def test_run_end_to_end_on_kiv2_bam(hg01046_bam: Path, tmp_path: Path, monkeypatch) -> None:
+    """
+    End-to-end CLI run against the small (~4 MB) HG01046 KIV-2 BAM slice.
+
+    The slice has reads only inside the KIV-2 region so we cannot compute an
+    autosomal depth baseline from it. Per PR review, the normalization counts
+    are fed in by patching ``_estimate_total_kiv2_copy_number`` to return the
+    DRAGEN-reported HG01046 KIV-2 copy number, and REF-base validation is
+    stubbed because the tiny synthetic FASTA below has no real chr6 sequence.
+    Every other stage of the pipeline (marker split, small-variant binomial,
+    JSON/VCF writers) runs against the real BAM reads.
+
+    HG01046 is a known negative sample for LPA:4733G>A / LPA:4925G>A, so the
+    caller must agree on non-existence at both sites (``altCopyNumber == 0``,
+    ``qual == 0``). Numerical CN comparisons use a 5% tolerance.
+    """
+    # Minimal chr6-only stub FASTA: `_write_vcf` reads a single base at
+    # kiv2_start and falls back to 'N' when out of range, so a 1-base contig
+    # is sufficient.
+    stub_fasta = tmp_path / "chr6_stub.fa"
+    stub_fasta.write_text(">chr6\nN\n")
+
+    # Feed the KIV-2 copy number directly and skip REF-base validation (both
+    # require the full hg38 reference we deliberately don't ship here).
+    monkeypatch.setattr(
+        lpa_caller_mod,
+        "_estimate_total_kiv2_copy_number",
+        lambda *args, **kwargs: HG01046_KIV2_CN,
+    )
+    monkeypatch.setattr(
+        lpa_caller_mod,
+        "_validate_marker_positions",
+        lambda *args, **kwargs: None,
+    )
+
+    output_prefix = tmp_path / "hg01046"
+    lpa_caller_mod.run(
+        [
+            "--cram",
+            str(hg01046_bam),
+            "--reference",
+            str(stub_fasta),
+            "--sample-id",
+            "HG01046",
+            "--output-prefix",
+            str(output_prefix),
+            "--no-vcf",  # exercised separately below
+        ]
+    )
+
+    # ------------------------------------------------------------------
+    # JSON: total CN, marker split, and small-variant existence.
+    # ------------------------------------------------------------------
+    json_path = tmp_path / "hg01046.targeted.json"
+    assert json_path.exists()
+    payload = json.loads(json_path.read_text())
+    lpa = payload["lpa"]
+
+    assert payload["sampleId"] == "HG01046"
+    assert payload["genomeBuild"] == "hg38"
+    assert lpa["kiv2CopyNumber"] == pytest.approx(HG01046_KIV2_CN, rel=CN_TOLERANCE_FRACTION)
+    assert lpa["type"] == "Heterozygous markers call"
+
+    ref_cn = lpa["refMarkerAlleleCopyNumber"]
+    alt_cn = lpa["altMarkerAlleleCopyNumber"]
+    assert ref_cn is not None and alt_cn is not None
+    assert ref_cn + alt_cn == pytest.approx(HG01046_KIV2_CN, abs=1e-6)
+    # Production VCF emitted 25 / 21 (see test_marker_split_hg01046).
+    assert ref_cn == pytest.approx(25.0, rel=CN_TOLERANCE_FRACTION)
+    assert alt_cn == pytest.approx(21.0, rel=CN_TOLERANCE_FRACTION)
+
+    # Must agree on small variant existence: HG01046 has neither site called.
+    called_hgvs = {v["hgvs"]: v for v in lpa["variants"]}
+    assert set(called_hgvs) == {"LPA:4733G>A", "LPA:4925G>A"}
+    for hgvs, v in called_hgvs.items():
+        assert v["altCopyNumber"] == 0, f"{hgvs} should not exist in HG01046"
+        assert v["qual"] == 0.0, f"{hgvs} should not exist in HG01046"
+
+    # ------------------------------------------------------------------
+    # VCF: rerun with VCF enabled and check header + record shape.
+    # ------------------------------------------------------------------
+    vcf_prefix = tmp_path / "hg01046_vcf"
+    lpa_caller_mod.run(
+        [
+            "--cram",
+            str(hg01046_bam),
+            "--reference",
+            str(stub_fasta),
+            "--sample-id",
+            "HG01046",
+            "--output-prefix",
+            str(vcf_prefix),
+        ]
+    )
+    vcf_path = tmp_path / "hg01046_vcf.targeted.vcf.gz"
+    assert vcf_path.exists()
+
+    with pysam.BGZFile(str(vcf_path), "rb") as fh:
+        vcf_text = fh.read().decode()
+
+    header_lines = [line for line in vcf_text.splitlines() if line.startswith("##")]
+    body_lines = [line for line in vcf_text.splitlines() if line and not line.startswith("#")]
+
+    assert any(line.startswith("##fileformat=VCFv4.2") for line in header_lines)
+    # HG01046 has ~46 total KIV-2 copies -> more than diploid baseline (12).
+    # Expect a DUP summary record.
+    dup_rows = [line for line in body_lines if "<DUP>" in line.split("\t")[4]]
+    assert len(dup_rows) == 1
+    total_cn_str = [kv for kv in dup_rows[0].split("\t")[7].split(";") if kv.startswith("TOTAL_CN=")]
+    assert total_cn_str
+    total_cn = float(total_cn_str[0].split("=", 1)[1])
+    assert total_cn == pytest.approx(HG01046_KIV2_CN, rel=CN_TOLERANCE_FRACTION)
+
+    # Small variant rows must exist for both sites at every configured repeat
+    # position and must all call REF-only genotypes (no ALT alleles).
+    for spec in DEFAULT_SMALL_VARIANTS:
+        for pos in spec["positions"]:
+            matches = [
+                line for line in body_lines if line.split("\t")[1] == str(pos) and line.split("\t")[4] == spec["alt"]
+            ]
+            assert len(matches) == 1, f"expected 1 row at chr6:{pos} for {spec['hgvs']}"
+            sample_field = matches[0].split("\t")[-1]
+            gt = sample_field.split(":")[0]
+            # No ALT alleles in genotype -> negative small-variant call.
+            assert "1" not in gt, f"{spec['hgvs']} at {pos} unexpectedly called ALT: GT={gt}"

--- a/src/cnv/tests/system/test_lpa_caller_system.py
+++ b/src/cnv/tests/system/test_lpa_caller_system.py
@@ -76,7 +76,10 @@ def test_small_variants_hg01046_negative(hg01046_bam: Path, hgvs: str) -> None:
     call = _call_small_variant(counts, HG01046_KIV2_CN, sv.hgvs, sv.ref, sv.alt, sv.positions)
 
     assert counts.informative > 100
-    assert counts.alt == 0
+    # A handful of low-quality noise ALT bases can slip in at MIN_BASE_QUALITY=1;
+    # the binomial fit still assigns alt_cn=0 because the observed alt fraction
+    # is well below LPA_VARIANT_NOISE_FLOOR.
+    assert counts.alt / counts.informative < 0.005
     assert call.alt_copy_number == 0
     assert call.qual == 0.0
 

--- a/src/cnv/tests/unit/test_lpa_caller.py
+++ b/src/cnv/tests/unit/test_lpa_caller.py
@@ -14,10 +14,12 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from ugbio_cnv import lpa_caller as lpa_caller_mod
 from ugbio_cnv.lpa_caller import (
     DEFAULT_KIV2_REPEAT_COUNT,
     DEFAULT_KIV2_START,
     DEFAULT_KIV2_UNIT_LEN,
+    GC_BIN_SIZE,
     GC_BUCKET_WIDTH,
     HET_MARKER_ALT_FRACTION_MAX,
     HET_MARKER_ALT_FRACTION_MIN,
@@ -30,12 +32,13 @@ from ugbio_cnv.lpa_caller import (
     _build_marker,
     _call_heterozygous_markers,
     _call_small_variant,
+    _count_alleles_at_positions,
+    _estimate_total_kiv2_copy_number,
     _format_dup_record,
     _format_small_variant_record,
     _gc_fraction,
-    _log_binomial,
+    _mean_depth_over_bins,
     _parse_norm_regions,
-    _phred,
     _trimmed_mean,
     _validate_marker_positions,
     _write_json,
@@ -235,35 +238,250 @@ class TestTrimmedMean:
 
 
 # ----------------------------------------------------------------------------
-# Binomial / Phred math
+# Depth estimation (mocked pysam fetch)
 # ----------------------------------------------------------------------------
 
 
-class TestBinomialAndPhred:
-    def test_log_binomial_zero_n_is_zero(self):
-        assert _log_binomial(0, 0, 0.5) == 0.0
+class _FakeRead:
+    """Minimal pysam AlignedSegment stand-in for _mean_depth_over_bins."""
 
-    def test_log_binomial_known_value(self):
-        # log(C(4,2) * 0.5^4) = log(6/16)
-        import math
+    def __init__(
+        self,
+        reference_start: int,
+        reference_end: int,
+        mapping_quality: int = 60,
+        *,
+        is_unmapped: bool = False,
+        is_secondary: bool = False,
+        is_supplementary: bool = False,
+        is_duplicate: bool = False,
+        is_qcfail: bool = False,
+    ):
+        self.reference_start = reference_start
+        self.reference_end = reference_end
+        self.mapping_quality = mapping_quality
+        self.is_unmapped = is_unmapped
+        self.is_secondary = is_secondary
+        self.is_supplementary = is_supplementary
+        self.is_duplicate = is_duplicate
+        self.is_qcfail = is_qcfail
 
-        assert _log_binomial(4, 2, 0.5) == pytest.approx(math.log(6 / 16))
 
-    def test_log_binomial_clamps_extremes(self):
-        # p=0 would log(0) without clamping; should be finite
-        val = _log_binomial(10, 0, 0.0)
-        assert np.isfinite(val)
-        val = _log_binomial(10, 10, 1.0)
-        assert np.isfinite(val)
+def _make_bam_with_reads(reads_by_region):
+    """Return a MagicMock bam whose ``fetch(chrom, start, end)`` yields the reads
+    pre-staged under the matching (chrom, start, end) key. Other arg shapes
+    default to an empty iterator.
+    """
+    bam = MagicMock()
 
-    def test_phred_caps_at_max(self):
-        assert _phred(1e-50) == pytest.approx(MAX_PHRED_QUAL)
+    def fetch(chrom, start, end):
+        return iter(reads_by_region.get((chrom, start, end), []))
 
-    def test_phred_near_one_is_small(self):
-        assert _phred(0.999999) < 1.0
+    bam.fetch.side_effect = fetch
+    return bam
 
-    def test_phred_half_is_three(self):
-        assert _phred(0.5) == pytest.approx(3.0103, abs=1e-3)
+
+def _uniform_reads(start0: int, length: int, depth: int, read_len: int = 100):
+    """Generate reads so every base in [start0, start0+length) is covered by
+    exactly ``depth`` reads. Reads are tiled with step == read_len and ``depth``
+    copies are stacked at each offset.
+    """
+    reads = []
+    for offset in range(0, length, read_len):
+        rs = start0 + offset
+        re = min(start0 + length, rs + read_len)
+        for _ in range(depth):
+            reads.append(_FakeRead(rs, re))
+    return reads
+
+
+class TestMeanDepthOverBins:
+    def test_empty_bam_returns_no_buckets(self):
+        bam = _make_bam_with_reads({})
+        # Use a GC-50% sequence so bucket lookup is deterministic if any depth
+        # appears (here none does).
+        seq_len = 3 * GC_BIN_SIZE
+        fasta = _FakeFasta({"chr1": "GC" * (seq_len // 2)})
+        out = _mean_depth_over_bins(bam, fasta, [("chr1", 1, seq_len)])
+        # Bins exist but each has zero depth -> still recorded as 0.0.
+        assert sum(len(v) for v in out.values()) == 3
+        for depths in out.values():
+            assert all(d == 0.0 for d in depths)
+
+    def test_region_smaller_than_bin_skipped(self):
+        bam = _make_bam_with_reads({})
+        fasta = _FakeFasta({"chr1": "A" * 100})
+        # Region length < GC_BIN_SIZE -> no bins emitted.
+        out = _mean_depth_over_bins(bam, fasta, [("chr1", 1, 100)])
+        assert out == {}
+
+    def test_uniform_depth_recovered(self):
+        region_len = 2 * GC_BIN_SIZE
+        reads = _uniform_reads(start0=0, length=region_len, depth=5, read_len=100)
+        bam = _make_bam_with_reads({("chr1", 0, region_len): reads})
+        fasta = _FakeFasta({"chr1": "GC" * (region_len // 2)})
+        out = _mean_depth_over_bins(bam, fasta, [("chr1", 1, region_len)])
+        all_depths = [d for depths in out.values() for d in depths]
+        assert len(all_depths) == 2
+        # Allow a small tolerance for tiling edge effects.
+        for d in all_depths:
+            assert d == pytest.approx(5.0, rel=0.05)
+
+    def test_low_mapq_reads_filtered_out(self):
+        region_len = GC_BIN_SIZE
+        good = _uniform_reads(0, region_len, depth=3, read_len=100)
+        bad = [_FakeRead(0, 100, mapping_quality=0) for _ in range(50)]
+        bam = _make_bam_with_reads({("chr1", 0, region_len): good + bad})
+        fasta = _FakeFasta({"chr1": "GC" * (region_len // 2)})
+        out = _mean_depth_over_bins(bam, fasta, [("chr1", 1, region_len)], min_mapq=10)
+        depths = [d for depths in out.values() for d in depths]
+        assert len(depths) == 1
+        # Only the MAPQ-passing reads contribute.
+        assert depths[0] == pytest.approx(3.0, rel=0.05)
+
+    def test_duplicate_and_secondary_reads_filtered_out(self):
+        region_len = GC_BIN_SIZE
+        good = _uniform_reads(0, region_len, depth=3, read_len=100)
+        junk = [
+            _FakeRead(0, 100, is_duplicate=True),
+            _FakeRead(0, 100, is_secondary=True),
+            _FakeRead(0, 100, is_supplementary=True),
+            _FakeRead(0, 100, is_unmapped=True),
+            _FakeRead(0, 100, is_qcfail=True),
+        ] * 20
+        bam = _make_bam_with_reads({("chr1", 0, region_len): good + junk})
+        fasta = _FakeFasta({"chr1": "GC" * (region_len // 2)})
+        out = _mean_depth_over_bins(bam, fasta, [("chr1", 1, region_len)])
+        depths = [d for depths in out.values() for d in depths]
+        assert depths[0] == pytest.approx(3.0, rel=0.05)
+
+
+class TestEstimateTotalKiv2CopyNumber:
+    """Drive the end-to-end depth-CN math via _mean_depth_over_bins monkeypatch.
+
+    Patching ``_mean_depth_over_bins`` is cleaner than handcrafting reads for
+    both the norm and KIV-2 regions; the GC-correction code path is exercised
+    by feeding compatible buckets.
+    """
+
+    @staticmethod
+    def _patch_depths(monkeypatch, depths_by_region):
+        def fake(bam, fasta, regions, **_kwargs):
+            out: dict[float, list[float]] = {}
+            for r in regions:
+                for gc, depths in depths_by_region.get(tuple(r), {}).items():
+                    out.setdefault(gc, []).extend(depths)
+            return out
+
+        monkeypatch.setattr(lpa_caller_mod, "_mean_depth_over_bins", fake)
+
+    def test_diploid_call_when_kiv2_matches_baseline(self, monkeypatch):
+        # KIV-2 depth == autosomal baseline -> CN = 2 * n_ref_repeats = 12.
+        baseline = {("chr1", 1, 1000): {0.5: [30.0] * 20}}
+        kiv2 = {("chr6", 100, 200): {0.5: [30.0] * 4}}
+        self._patch_depths(monkeypatch, {**baseline, **kiv2})
+        bam = MagicMock()
+        fasta = MagicMock()
+        cn = _estimate_total_kiv2_copy_number(
+            bam, fasta, "chr6", 100, 200, n_ref_repeats=6, norm_regions=[("chr1", 1, 1000)]
+        )
+        assert cn == pytest.approx(12.0)
+
+    def test_amplified_kiv2_scales_linearly(self, monkeypatch):
+        # KIV-2 depth 1.5x baseline -> CN = 1.5 * 2 * 6 = 18.
+        baseline = {("chr1", 1, 1000): {0.5: [30.0] * 20}}
+        kiv2 = {("chr6", 100, 200): {0.5: [45.0] * 4}}
+        self._patch_depths(monkeypatch, {**baseline, **kiv2})
+        cn = _estimate_total_kiv2_copy_number(
+            MagicMock(), MagicMock(), "chr6", 100, 200, n_ref_repeats=6, norm_regions=[("chr1", 1, 1000)]
+        )
+        assert cn == pytest.approx(18.0)
+
+    def test_gc_correction_uses_matching_bucket(self, monkeypatch):
+        # Baseline depth differs between two GC buckets; KIV-2 sits entirely in
+        # the high-GC bucket. After GC scaling the KIV-2 mean is normalized
+        # against the same-bucket baseline, not the overall mean.
+        baseline = {
+            ("chr1", 1, 1000): {
+                0.45: [20.0] * 20,
+                0.55: [40.0] * 20,
+            }
+        }
+        # KIV-2 depth = 60 in the 0.55 bucket -> 60/40 = 1.5x same-bucket baseline.
+        kiv2 = {("chr6", 100, 200): {0.55: [60.0] * 4}}
+        self._patch_depths(monkeypatch, {**baseline, **kiv2})
+        cn = _estimate_total_kiv2_copy_number(
+            MagicMock(), MagicMock(), "chr6", 100, 200, n_ref_repeats=6, norm_regions=[("chr1", 1, 1000)]
+        )
+        assert cn == pytest.approx(18.0)
+
+    def test_zero_baseline_raises(self, monkeypatch):
+        # All baseline bins return zero -> trimmed mean is 0 -> RuntimeError.
+        self._patch_depths(monkeypatch, {("chr1", 1, 1000): {0.5: [0.0] * 20}})
+        with pytest.raises(RuntimeError, match="Normalization regions have zero coverage"):
+            _estimate_total_kiv2_copy_number(
+                MagicMock(), MagicMock(), "chr6", 100, 200, n_ref_repeats=6, norm_regions=[("chr1", 1, 1000)]
+            )
+
+    def test_no_kiv2_bins_raises(self, monkeypatch):
+        baseline = {("chr1", 1, 1000): {0.5: [30.0] * 20}}
+        # No depth recorded for the KIV-2 region.
+        self._patch_depths(monkeypatch, {**baseline, ("chr6", 100, 200): {}})
+        with pytest.raises(RuntimeError, match="No KIV-2 depth bins"):
+            _estimate_total_kiv2_copy_number(
+                MagicMock(), MagicMock(), "chr6", 100, 200, n_ref_repeats=6, norm_regions=[("chr1", 1, 1000)]
+            )
+
+
+# ----------------------------------------------------------------------------
+# Allele counting at pileup positions
+# ----------------------------------------------------------------------------
+
+
+class _FakePileupRead:
+    def __init__(self, base, *, is_del=False, is_refskip=False, indel=0):
+        self.is_del = is_del
+        self.is_refskip = is_refskip
+        self.indel = indel
+        self.query_position = 0
+        aln = MagicMock()
+        aln.is_secondary = False
+        aln.is_supplementary = False
+        aln.is_duplicate = False
+        aln.is_qcfail = False
+        aln.is_unmapped = False
+        aln.query_sequence = base
+        self.alignment = aln
+
+
+class _FakePileupColumn:
+    def __init__(self, reference_pos, reads):
+        self.reference_pos = reference_pos
+        self.pileups = reads
+
+
+class TestCountAllelesAtPositions:
+    def test_case_insensitive_allele_matching(self):
+        # Lowercase query bases (e.g. soft-masked reference, some aligners)
+        # must match the configured uppercase REF/ALT, not fall through to
+        # `other` and bias the allele fraction.
+        bam = MagicMock()
+        bam.pileup.return_value = [
+            _FakePileupColumn(
+                reference_pos=99,
+                reads=(
+                    [_FakePileupRead("a")] * 3
+                    + [_FakePileupRead("A")] * 2
+                    + [_FakePileupRead("g")] * 4
+                    + [_FakePileupRead("G")] * 1
+                    + [_FakePileupRead("c")]  # 'other'
+                ),
+            )
+        ]
+        counts = _count_alleles_at_positions(bam, "chr6", [100], ref_allele="A", alt_allele="G")
+        assert counts.ref == 5
+        assert counts.alt == 5
+        assert counts.other == 1
 
 
 # ----------------------------------------------------------------------------
@@ -330,6 +548,50 @@ class TestCallSmallVariant:
         assert call.alt_copy_number == 12
         assert call.qual == pytest.approx(MAX_PHRED_QUAL)
 
+    def test_low_coverage_a_few_alt_reads_kept_at_alt_cn_zero(self):
+        # 2 alt out of 100 informative reads sits at/below the noise floor
+        # (LPA_VARIANT_NOISE_FLOOR = 0.003) -> should call REF, not flap to
+        # the lowest non-zero ALT-CN.
+        counts = AlleleCounts(ref=98, alt=2)
+        call = _call_small_variant(
+            counts,
+            kiv2_copy_number=12.0,
+            hgvs="LPA:4733G>A",
+            ref_allele="C",
+            alt_allele="T",
+            positions=[1],
+        )
+        assert call.alt_copy_number == 0
+        assert call.qual == 0.0
+
+    def test_extreme_high_cn_alt_cn_is_proportional(self):
+        # Total CN ~40 with ~25% ALT -> best alt_cn ~ 10.
+        counts = AlleleCounts(ref=300, alt=100)
+        call = _call_small_variant(
+            counts,
+            kiv2_copy_number=40.0,
+            hgvs="LPA:4733G>A",
+            ref_allele="C",
+            alt_allele="T",
+            positions=[1],
+        )
+        assert call.alt_copy_number == 10
+        assert 0 < call.qual <= MAX_PHRED_QUAL
+
+    def test_zero_kiv2_cn_floors_to_one(self):
+        # kiv2_copy_number == 0 would otherwise blow up the binomial loop;
+        # the code floors total_cn to max(1, ...) so the call still returns.
+        counts = AlleleCounts(ref=10, alt=10)
+        call = _call_small_variant(
+            counts,
+            kiv2_copy_number=0.0,
+            hgvs="LPA:4733G>A",
+            ref_allele="C",
+            alt_allele="T",
+            positions=[1],
+        )
+        assert call.alt_copy_number in (0, 1)
+
 
 # ----------------------------------------------------------------------------
 # Heterozygous marker calling
@@ -338,8 +600,6 @@ class TestCallSmallVariant:
 
 def _make_marker_call(per_marker_counts):
     """Run _call_heterozygous_markers with mocked allele counting."""
-    from ugbio_cnv import lpa_caller
-
     markers = [
         _build_marker(
             {"hgvs": "LPA:1A>C", "ref": "A", "alt": "C", "first_pos": 100},
@@ -355,12 +615,12 @@ def _make_marker_call(per_marker_counts):
         return next(counts_iter)
 
     bam = MagicMock()
-    original = lpa_caller._count_alleles_at_positions
-    lpa_caller._count_alleles_at_positions = fake_count
+    original = lpa_caller_mod._count_alleles_at_positions
+    lpa_caller_mod._count_alleles_at_positions = fake_count
     try:
         return _call_heterozygous_markers(bam, "chr6", markers, kiv2_copy_number=12.0)
     finally:
-        lpa_caller._count_alleles_at_positions = original
+        lpa_caller_mod._count_alleles_at_positions = original
 
 
 class TestHeterozygousMarkerCalling:
@@ -398,6 +658,16 @@ class TestHeterozygousMarkerCalling:
         ref_cn, alt_cn, call_type, _ = _make_marker_call([AlleleCounts(ref=100, alt=9)])
         assert call_type == "Homozygous REF markers call"
         assert ref_cn is None and alt_cn is None
+
+    def test_only_other_bases_is_no_coverage(self):
+        # All reads carry a non-REF, non-ALT base -> informative count is 0 and
+        # we fall back to the "no coverage" branch instead of splitting CN.
+        ref_cn, alt_cn, call_type, _ = _make_marker_call(
+            [AlleleCounts(ref=0, alt=0, other=100), AlleleCounts(ref=0, alt=0, other=100)]
+        )
+        assert ref_cn is None
+        assert alt_cn is None
+        assert "No coverage" in call_type
 
 
 # ----------------------------------------------------------------------------

--- a/src/cnv/tests/unit/test_lpa_caller.py
+++ b/src/cnv/tests/unit/test_lpa_caller.py
@@ -47,51 +47,7 @@ from ugbio_cnv.lpa_caller import (
 )
 
 # ----------------------------------------------------------------------------
-# Data classes
-# ----------------------------------------------------------------------------
-
-
-class TestAlleleCounts:
-    def test_totals(self):
-        c = AlleleCounts(ref=4, alt=3, other=2)
-        assert c.total == 9
-        assert c.informative == 7
-
-    def test_defaults(self):
-        c = AlleleCounts()
-        assert c.total == 0
-        assert c.informative == 0
-
-
-# ----------------------------------------------------------------------------
-# Marker projection
-# ----------------------------------------------------------------------------
-
-
-class TestBuildMarker:
-    def test_explicit_positions_used_verbatim(self):
-        spec = {
-            "hgvs": "LPA:296T>G",
-            "ref": "T",
-            "alt": "G",
-            "positions": [100, 200, 300, 400, 500, 600],
-        }
-        m = _build_marker(spec, kiv2_start=1, unit_len=10, n_repeats=2)
-        # n_repeats / unit_len ignored when positions provided.
-        assert m.positions == [100, 200, 300, 400, 500, 600]
-        assert m.hgvs == "LPA:296T>G"
-        assert m.ref == "T"
-        assert m.alt == "G"
-
-    def test_extrapolated_positions(self):
-        spec = {"hgvs": "X:1A>C", "ref": "A", "alt": "C", "first_pos": 105}
-        m = _build_marker(spec, kiv2_start=100, unit_len=10, n_repeats=4)
-        # offset = 5; positions = 100+5, 100+15, 100+25, 100+35
-        assert m.positions == [105, 115, 125, 135]
-
-
-# ----------------------------------------------------------------------------
-# GC helpers
+# Reference validation
 # ----------------------------------------------------------------------------
 
 
@@ -224,17 +180,21 @@ class TestTrimmedMean:
         assert _trimmed_mean([]) == 0.0
 
     def test_trim_removes_tails(self):
-        # 0.10 of 10 = 1 trimmed per side, leaves [2..9] (mean=5.5)
-        values = list(range(1, 11))
+        # Asymmetric outliers: plain mean is dominated by the 1000 outlier;
+        # 10% trim removes both tail values (1 and 1000) and yields mean of 2..9.
+        values = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 1000.0]
+        assert float(np.mean(values)) == pytest.approx(104.5)
         assert _trimmed_mean(values, trim=0.1) == pytest.approx(5.5)
 
     def test_full_trim_falls_back_to_mean(self):
-        # trim large enough that 2*k >= size -> ungrimmed mean
+        # trim large enough that 2*k >= size -> untrimmed mean
         assert _trimmed_mean([1, 2, 3], trim=0.5) == pytest.approx(2.0)
 
     def test_handles_numpy_array(self):
-        arr = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
-        # trim=0.2 -> k=1 -> mean of [20, 30, 40]
+        # Asymmetric distribution so the trim actually changes the result.
+        arr = np.array([10.0, 20.0, 30.0, 40.0, 500.0])
+        # trim=0.2 -> k=1 -> mean of [20, 30, 40] = 30 (plain mean = 120).
+        assert float(arr.mean()) == pytest.approx(120.0)
         assert _trimmed_mean(arr, trim=0.2) == pytest.approx(30.0)
 
 
@@ -603,10 +563,12 @@ def _make_marker_call(per_marker_counts):
     """Run _call_heterozygous_markers with mocked allele counting."""
     markers = [
         _build_marker(
-            {"hgvs": "LPA:1A>C", "ref": "A", "alt": "C", "first_pos": 100},
-            kiv2_start=1,
-            unit_len=10,
-            n_repeats=len(per_marker_counts),
+            {
+                "hgvs": "LPA:1A>C",
+                "ref": "A",
+                "alt": "C",
+                "positions": [100 + i * 10 for i in range(len(per_marker_counts))],
+            }
         )
     ] * len(per_marker_counts)
 

--- a/src/cnv/tests/unit/test_lpa_caller.py
+++ b/src/cnv/tests/unit/test_lpa_caller.py
@@ -748,6 +748,16 @@ class TestFormatDupRecord:
         assert fields[4] == "<DUP>"
         assert "CN=." in fields[7]
 
+    def test_deletion_when_total_cn_below_baseline(self):
+        # n_ref_repeats=6 -> diploid baseline = 12. total_cn=8 < 12 -> <DEL>.
+        call = _make_lpa_call(ref_cn=4.0, alt_cn=4.0)
+        row = _format_dup_record("chr6", 100, 200, "A", "S1", call, n_ref_repeats=6)
+        fields = row.split("\t")
+        assert fields[4] == "<DEL>"
+        info = dict(kv.split("=", 1) for kv in fields[7].split(";") if "=" in kv)
+        assert info["SVTYPE"] == "DEL"
+        assert info["TOTAL_CN"] == "8.000000"
+
 
 class TestFormatSmallVariantRecord:
     def _make_call(self, alt_cn, ref_count, alt_count, qual=40.0):

--- a/src/cnv/tests/unit/test_lpa_caller.py
+++ b/src/cnv/tests/unit/test_lpa_caller.py
@@ -8,6 +8,7 @@ are exercised via mocked ``pysam`` objects.
 
 from __future__ import annotations
 
+import argparse
 import gzip
 import json
 from unittest.mock import MagicMock
@@ -685,6 +686,22 @@ class TestParseNormRegions:
 
     def test_empty_tokens_skipped(self):
         assert _parse_norm_regions(",chr1:1-2,, ,") == [("chr1", 1, 2)]
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "chr1",  # missing ':'
+            "chr1:100",  # missing '-'
+            "chr1:abc-200",  # non-integer start
+            "chr1:100-xyz",  # non-integer end
+            "chr1:200-100",  # start > end
+            "chr1:0-100",  # non-positive coordinate
+            "",  # nothing parsed
+        ],
+    )
+    def test_invalid_input_raises_argument_type_error(self, bad):
+        with pytest.raises(argparse.ArgumentTypeError):
+            _parse_norm_regions(bad)
 
 
 # ----------------------------------------------------------------------------

--- a/src/cnv/tests/unit/test_lpa_caller.py
+++ b/src/cnv/tests/unit/test_lpa_caller.py
@@ -1,0 +1,605 @@
+"""Unit tests for the LPA KIV-2 targeted caller.
+
+Covers the pure-Python helpers (marker projection, GC fraction/bucketing,
+trimmed mean, binomial/Phred math, marker and small-variant calling,
+CLI region parsing, and VCF row formatting). I/O paths that need a real BAM
+are exercised via mocked ``pysam`` objects.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from ugbio_cnv.lpa_caller import (
+    DEFAULT_KIV2_REPEAT_COUNT,
+    DEFAULT_KIV2_START,
+    DEFAULT_KIV2_UNIT_LEN,
+    GC_BUCKET_WIDTH,
+    HET_MARKER_ALT_FRACTION_MAX,
+    HET_MARKER_ALT_FRACTION_MIN,
+    MAX_PHRED_QUAL,
+    AlleleCounts,
+    LpaCall,
+    MarkerSpec,
+    SmallVariantCall,
+    _bucket_gc,
+    _build_marker,
+    _call_heterozygous_markers,
+    _call_small_variant,
+    _format_dup_record,
+    _format_small_variant_record,
+    _gc_fraction,
+    _log_binomial,
+    _parse_norm_regions,
+    _phred,
+    _trimmed_mean,
+    _validate_marker_positions,
+    _write_json,
+    _write_vcf,
+)
+
+# ----------------------------------------------------------------------------
+# Data classes
+# ----------------------------------------------------------------------------
+
+
+class TestAlleleCounts:
+    def test_totals(self):
+        c = AlleleCounts(ref=4, alt=3, other=2)
+        assert c.total == 9
+        assert c.informative == 7
+
+    def test_defaults(self):
+        c = AlleleCounts()
+        assert c.total == 0
+        assert c.informative == 0
+
+
+# ----------------------------------------------------------------------------
+# Marker projection
+# ----------------------------------------------------------------------------
+
+
+class TestBuildMarker:
+    def test_explicit_positions_used_verbatim(self):
+        spec = {
+            "hgvs": "LPA:296T>G",
+            "ref": "T",
+            "alt": "G",
+            "positions": [100, 200, 300, 400, 500, 600],
+        }
+        m = _build_marker(spec, kiv2_start=1, unit_len=10, n_repeats=2)
+        # n_repeats / unit_len ignored when positions provided.
+        assert m.positions == [100, 200, 300, 400, 500, 600]
+        assert m.hgvs == "LPA:296T>G"
+        assert m.ref == "T"
+        assert m.alt == "G"
+
+    def test_extrapolated_positions(self):
+        spec = {"hgvs": "X:1A>C", "ref": "A", "alt": "C", "first_pos": 105}
+        m = _build_marker(spec, kiv2_start=100, unit_len=10, n_repeats=4)
+        # offset = 5; positions = 100+5, 100+15, 100+25, 100+35
+        assert m.positions == [105, 115, 125, 135]
+
+
+# ----------------------------------------------------------------------------
+# GC helpers
+# ----------------------------------------------------------------------------
+
+
+class _FakeFasta:
+    """Tiny pyfaidx.Fasta stand-in: fake[chrom][a:b] returns a string slice."""
+
+    class _Contig:
+        def __init__(self, seq: str):
+            self._seq = seq
+
+        def __getitem__(self, sl):
+            return self._seq[sl]
+
+    def __init__(self, sequences):
+        self._sequences = sequences
+
+    def keys(self):
+        return self._sequences.keys()
+
+    def __getitem__(self, chrom):
+        return self._Contig(self._sequences.get(chrom, ""))
+
+
+class TestGcHelpers:
+    def test_gc_fraction_basic(self):
+        fasta = _FakeFasta({"chr1": "AAGCGC"})
+        # 4/6 GC
+        assert _gc_fraction(fasta, "chr1", 1, 6) == pytest.approx(4 / 6)
+
+    def test_gc_fraction_handles_lowercase(self):
+        fasta = _FakeFasta({"chr1": "aagcgc"})
+        assert _gc_fraction(fasta, "chr1", 1, 6) == pytest.approx(4 / 6)
+
+    def test_gc_fraction_ignores_n(self):
+        fasta = _FakeFasta({"chr1": "NNGCNN"})
+        # Only 2 valid bases counted: both GC
+        assert _gc_fraction(fasta, "chr1", 1, 6) == pytest.approx(1.0)
+
+    def test_gc_fraction_empty_sequence(self):
+        fasta = _FakeFasta({"chr1": ""})
+        assert _gc_fraction(fasta, "chr1", 1, 10) == 0.0
+
+    def test_gc_fraction_all_n(self):
+        fasta = _FakeFasta({"chr1": "NNNNN"})
+        assert _gc_fraction(fasta, "chr1", 1, 5) == 0.0
+
+    @pytest.mark.parametrize(
+        ("gc", "expected_bucket"),
+        [
+            (0.00, GC_BUCKET_WIDTH / 2),
+            (0.02, GC_BUCKET_WIDTH / 2),
+            (0.05, GC_BUCKET_WIDTH * 1.5),
+            (0.47, GC_BUCKET_WIDTH * 9.5),
+            (0.99, GC_BUCKET_WIDTH * 19.5),
+        ],
+    )
+    def test_bucket_gc(self, gc, expected_bucket):
+        assert _bucket_gc(gc) == pytest.approx(expected_bucket)
+
+
+# ----------------------------------------------------------------------------
+# Reference validation
+# ----------------------------------------------------------------------------
+
+
+def _make_fake_fasta(bases_by_position, contigs=("chr6",)):
+    """Build a pyfaidx-style fake where bases_by_position[(chrom, 1based_pos)] picks the base."""
+    by_contig = {c: ["N"] * 1000 for c in contigs}
+    for (chrom, pos), base in bases_by_position.items():
+        if chrom in by_contig and 1 <= pos <= 1000:
+            by_contig[chrom][pos - 1] = base
+    return _FakeFasta({c: "".join(seq) for c, seq in by_contig.items()})
+
+
+class TestValidateMarkerPositions:
+    def _markers(self):
+        return [
+            MarkerSpec(hgvs="LPA:test", ref="A", alt="G", positions=[100, 200, 300]),
+        ]
+
+    def test_matching_ref_bases_pass(self):
+        fasta = _make_fake_fasta({("chr6", 100): "A", ("chr6", 200): "A", ("chr6", 300): "A"})
+        # Should not raise.
+        _validate_marker_positions(fasta, "chr6", self._markers(), genome_build="hg38")
+
+    def test_case_insensitive_match(self):
+        fasta = _make_fake_fasta({("chr6", 100): "a", ("chr6", 200): "a", ("chr6", 300): "a"})
+        _validate_marker_positions(fasta, "chr6", self._markers(), genome_build="hg38")
+
+    def test_mismatch_raises_with_helpful_message(self):
+        fasta = _make_fake_fasta({("chr6", 100): "A", ("chr6", 200): "T", ("chr6", 300): "C"})
+        with pytest.raises(RuntimeError) as exc:
+            _validate_marker_positions(fasta, "chr6", self._markers(), genome_build="hg38")
+        msg = str(exc.value)
+        assert "hg38" in msg
+        assert "LPA:test" in msg
+        # Both mismatched sites should be reported.
+        assert "chr6:200" in msg
+        assert "chr6:300" in msg
+
+    def test_missing_contig_raises(self):
+        fasta = _make_fake_fasta({}, contigs=("1", "2"))
+        with pytest.raises(RuntimeError) as exc:
+            _validate_marker_positions(fasta, "chr6", self._markers(), genome_build="hg38")
+        assert "chr6" in str(exc.value)
+
+    def test_many_mismatches_truncated_in_message(self):
+        markers = [
+            MarkerSpec(
+                hgvs="LPA:bulk",
+                ref="A",
+                alt="G",
+                positions=list(range(1, 11)),
+            )
+        ]
+        # Every position returns 'C' -> 10 mismatches
+        fasta = _make_fake_fasta({("chr6", p): "C" for p in range(1, 11)})
+        with pytest.raises(RuntimeError) as exc:
+            _validate_marker_positions(fasta, "chr6", markers, genome_build="hg38")
+        assert "+5 more" in str(exc.value)
+
+
+# ----------------------------------------------------------------------------
+# Trimmed mean
+# ----------------------------------------------------------------------------
+
+
+class TestTrimmedMean:
+    def test_empty(self):
+        assert _trimmed_mean([]) == 0.0
+
+    def test_trim_removes_tails(self):
+        # 0.10 of 10 = 1 trimmed per side, leaves [2..9] (mean=5.5)
+        values = list(range(1, 11))
+        assert _trimmed_mean(values, trim=0.1) == pytest.approx(5.5)
+
+    def test_full_trim_falls_back_to_mean(self):
+        # trim large enough that 2*k >= size -> ungrimmed mean
+        assert _trimmed_mean([1, 2, 3], trim=0.5) == pytest.approx(2.0)
+
+    def test_handles_numpy_array(self):
+        arr = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+        # trim=0.2 -> k=1 -> mean of [20, 30, 40]
+        assert _trimmed_mean(arr, trim=0.2) == pytest.approx(30.0)
+
+
+# ----------------------------------------------------------------------------
+# Binomial / Phred math
+# ----------------------------------------------------------------------------
+
+
+class TestBinomialAndPhred:
+    def test_log_binomial_zero_n_is_zero(self):
+        assert _log_binomial(0, 0, 0.5) == 0.0
+
+    def test_log_binomial_known_value(self):
+        # log(C(4,2) * 0.5^4) = log(6/16)
+        import math
+
+        assert _log_binomial(4, 2, 0.5) == pytest.approx(math.log(6 / 16))
+
+    def test_log_binomial_clamps_extremes(self):
+        # p=0 would log(0) without clamping; should be finite
+        val = _log_binomial(10, 0, 0.0)
+        assert np.isfinite(val)
+        val = _log_binomial(10, 10, 1.0)
+        assert np.isfinite(val)
+
+    def test_phred_caps_at_max(self):
+        assert _phred(1e-50) == pytest.approx(MAX_PHRED_QUAL)
+
+    def test_phred_near_one_is_small(self):
+        assert _phred(0.999999) < 1.0
+
+    def test_phred_half_is_three(self):
+        assert _phred(0.5) == pytest.approx(3.0103, abs=1e-3)
+
+
+# ----------------------------------------------------------------------------
+# Small-variant calling
+# ----------------------------------------------------------------------------
+
+
+class TestCallSmallVariant:
+    def test_no_coverage_returns_zero_call(self):
+        counts = AlleleCounts(ref=0, alt=0)
+        call = _call_small_variant(
+            counts,
+            kiv2_copy_number=12.0,
+            hgvs="LPA:4733G>A",
+            ref_allele="C",
+            alt_allele="T",
+            positions=[1, 2, 3],
+        )
+        assert call.alt_copy_number == 0
+        assert call.qual == 0.0
+        assert call.alt_copy_number_quality == 0.0
+        assert call.ref_count == 0
+        assert call.alt_count == 0
+        assert call.positions == [1, 2, 3]
+
+    def test_pure_reference_yields_alt_cn_zero(self):
+        counts = AlleleCounts(ref=200, alt=0)
+        call = _call_small_variant(
+            counts,
+            kiv2_copy_number=12.0,
+            hgvs="LPA:4733G>A",
+            ref_allele="C",
+            alt_allele="T",
+            positions=[1],
+        )
+        assert call.alt_copy_number == 0
+        # By VCF convention QUAL is 0 when the best call is REF.
+        assert call.qual == 0.0
+
+    def test_half_alt_signal_for_cn12_yields_six(self):
+        # ~50% ALT fraction with total CN ~12 -> best ALT copy number = 6
+        counts = AlleleCounts(ref=100, alt=100)
+        call = _call_small_variant(
+            counts,
+            kiv2_copy_number=12.0,
+            hgvs="LPA:4733G>A",
+            ref_allele="C",
+            alt_allele="T",
+            positions=[1],
+        )
+        assert call.alt_copy_number == 6
+        assert call.qual > 50.0  # Strong signal
+
+    def test_full_alt_signal_yields_total_cn(self):
+        counts = AlleleCounts(ref=0, alt=200)
+        call = _call_small_variant(
+            counts,
+            kiv2_copy_number=12.0,
+            hgvs="LPA:4733G>A",
+            ref_allele="C",
+            alt_allele="T",
+            positions=[1],
+        )
+        assert call.alt_copy_number == 12
+        assert call.qual == pytest.approx(MAX_PHRED_QUAL)
+
+
+# ----------------------------------------------------------------------------
+# Heterozygous marker calling
+# ----------------------------------------------------------------------------
+
+
+def _make_marker_call(per_marker_counts):
+    """Run _call_heterozygous_markers with mocked allele counting."""
+    from ugbio_cnv import lpa_caller
+
+    markers = [
+        _build_marker(
+            {"hgvs": "LPA:1A>C", "ref": "A", "alt": "C", "first_pos": 100},
+            kiv2_start=1,
+            unit_len=10,
+            n_repeats=len(per_marker_counts),
+        )
+    ] * len(per_marker_counts)
+
+    counts_iter = iter(per_marker_counts)
+
+    def fake_count(*_args, **_kwargs):
+        return next(counts_iter)
+
+    bam = MagicMock()
+    original = lpa_caller._count_alleles_at_positions
+    lpa_caller._count_alleles_at_positions = fake_count
+    try:
+        return _call_heterozygous_markers(bam, "chr6", markers, kiv2_copy_number=12.0)
+    finally:
+        lpa_caller._count_alleles_at_positions = original
+
+
+class TestHeterozygousMarkerCalling:
+    def test_no_coverage(self):
+        ref_cn, alt_cn, call_type, _ = _make_marker_call([AlleleCounts(ref=0, alt=0), AlleleCounts(ref=0, alt=0)])
+        assert ref_cn is None
+        assert alt_cn is None
+        assert "No coverage" in call_type
+
+    def test_homozygous_ref(self):
+        # ALT fraction below HET_MARKER_ALT_FRACTION_MIN
+        ref_cn, alt_cn, call_type, _ = _make_marker_call([AlleleCounts(ref=100, alt=1), AlleleCounts(ref=100, alt=2)])
+        assert ref_cn is None
+        assert alt_cn is None
+        assert call_type == "Homozygous REF markers call"
+
+    def test_homozygous_alt(self):
+        # ALT fraction above HET_MARKER_ALT_FRACTION_MAX
+        ref_cn, alt_cn, call_type, _ = _make_marker_call([AlleleCounts(ref=1, alt=100), AlleleCounts(ref=2, alt=100)])
+        assert ref_cn is None
+        assert alt_cn is None
+        assert call_type == "Homozygous ALT markers call"
+
+    def test_heterozygous_split(self):
+        # ALT fraction = 0.5 in the het window -> split kiv2_cn=12 evenly.
+        ref_cn, alt_cn, call_type, _ = _make_marker_call([AlleleCounts(ref=50, alt=50), AlleleCounts(ref=50, alt=50)])
+        assert call_type == "Heterozygous markers call"
+        assert ref_cn == pytest.approx(6.0)
+        assert alt_cn == pytest.approx(6.0)
+
+    def test_boundary_fractions(self):
+        # Just below and above the boundaries fall into the homozygous calls.
+        assert HET_MARKER_ALT_FRACTION_MIN < HET_MARKER_ALT_FRACTION_MAX
+        # 9 / (100+9) ~= 0.0826 < 0.10
+        ref_cn, alt_cn, call_type, _ = _make_marker_call([AlleleCounts(ref=100, alt=9)])
+        assert call_type == "Homozygous REF markers call"
+        assert ref_cn is None and alt_cn is None
+
+
+# ----------------------------------------------------------------------------
+# CLI region parser
+# ----------------------------------------------------------------------------
+
+
+class TestParseNormRegions:
+    def test_single_region(self):
+        assert _parse_norm_regions("chr1:100-200") == [("chr1", 100, 200)]
+
+    def test_multiple_regions(self):
+        out = _parse_norm_regions("chr1:100-200, chr2:300-400 ,chr3:5-6")
+        assert out == [("chr1", 100, 200), ("chr2", 300, 400), ("chr3", 5, 6)]
+
+    def test_empty_tokens_skipped(self):
+        assert _parse_norm_regions(",chr1:1-2,, ,") == [("chr1", 1, 2)]
+
+
+# ----------------------------------------------------------------------------
+# VCF row formatting
+# ----------------------------------------------------------------------------
+
+
+def _make_lpa_call(ref_cn=6.0, alt_cn=8.0, variants=None):
+    return LpaCall(
+        kiv2_copy_number=ref_cn + alt_cn,
+        ref_marker_allele_copy_number=ref_cn,
+        alt_marker_allele_copy_number=alt_cn,
+        call_type="Heterozygous markers call",
+        variants=variants or [],
+    )
+
+
+class TestFormatDupRecord:
+    def test_heterozygous_record(self):
+        call = _make_lpa_call(ref_cn=6.0, alt_cn=8.0)
+        row = _format_dup_record(
+            "chr6",
+            start=100,
+            end=200,
+            ref_base="A",
+            sample_id="S1",
+            call=call,
+            n_ref_repeats=6,
+        )
+        fields = row.split("\t")
+        assert fields[0] == "chr6"
+        assert fields[1] == "100"
+        assert fields[3] == "A"
+        # Single symbolic <DUP> ALT (the previous <DUP>,<DUP> form was ambiguous
+        # to VCF parsers); per-haplotype values are reported via INFO/CN.
+        # SVTYPE=DUP keeps the record compatible with downstream merge filters.
+        assert fields[4] == "<DUP>"
+        assert fields[6] == "PASS"
+        info = dict(kv.split("=", 1) for kv in fields[7].split(";") if "=" in kv)
+        assert info["SVTYPE"] == "DUP"
+        assert info["END"] == "200"
+        # 1-based inclusive: end - start + 1.
+        assert info["SVLEN"] == "101"
+        assert info["CN"] == "1.000000,1.333333"
+        assert info["TOTAL_CN"] == "14.000000"
+
+    def test_missing_marker_allele_falls_back(self):
+        call = LpaCall(
+            kiv2_copy_number=12.0,
+            ref_marker_allele_copy_number=None,
+            alt_marker_allele_copy_number=None,
+            call_type="Homozygous REF markers call",
+            variants=[],
+        )
+        row = _format_dup_record("chr6", 100, 200, "A", "S1", call, n_ref_repeats=6)
+        fields = row.split("\t")
+        assert fields[4] == "<DUP>"
+        assert "CN=." in fields[7]
+
+
+class TestFormatSmallVariantRecord:
+    def _make_call(self, alt_cn, ref_count, alt_count, qual=40.0):
+        return SmallVariantCall(
+            hgvs="LPA:4733G>A",
+            qual=qual,
+            alt_copy_number=alt_cn,
+            alt_copy_number_quality=35.0,
+            ref_count=ref_count,
+            alt_count=alt_count,
+            positions=[100, 200, 300],
+            ref_allele="C",
+            alt_allele="T",
+        )
+
+    def test_one_row_per_position(self):
+        call = self._make_call(alt_cn=3, ref_count=90, alt_count=90)
+        rows = _format_small_variant_record("chr6", call, total_cn=6, phase_set=1)
+        assert len(rows) == 3
+        positions = [r.split("\t")[1] for r in rows]
+        assert positions == ["100", "200", "300"]
+
+    def test_pass_filter_for_consistent_partition(self):
+        # alt_cn=3 / total_cn=6 -> expected_alt = 0.5 * (90+90) = 90 (exact).
+        call = self._make_call(alt_cn=3, ref_count=90, alt_count=90, qual=40.0)
+        rows = _format_small_variant_record("chr6", call, total_cn=6, phase_set=1)
+        assert all(r.split("\t")[6] == "PASS" for r in rows)
+        # GT is 3 REF + 3 ALT alleles
+        gt = rows[0].split("\t")[-1].split(":")[0]
+        assert gt == "0/0/0/1/1/1"
+
+    def test_low_qual_filter(self):
+        call = self._make_call(alt_cn=3, ref_count=90, alt_count=90, qual=1.0)
+        rows = _format_small_variant_record("chr6", call, total_cn=6, phase_set=1)
+        for r in rows:
+            assert "TargetedLowQual" in r.split("\t")[6]
+
+    def test_repeat_conflict_filter(self):
+        # alt_cn=0 but observed alt_count=20 -> residual = 20/120 ~= 0.166 > 0.05
+        call = self._make_call(alt_cn=0, ref_count=100, alt_count=20, qual=40.0)
+        rows = _format_small_variant_record("chr6", call, total_cn=6, phase_set=1)
+        for r in rows:
+            assert "TargetedRepeatConflict" in r.split("\t")[6]
+
+
+# ----------------------------------------------------------------------------
+# JSON / VCF writers (end-to-end on a minimal call object)
+# ----------------------------------------------------------------------------
+
+
+def _build_minimal_call():
+    return LpaCall(
+        kiv2_copy_number=12.0,
+        ref_marker_allele_copy_number=6.0,
+        alt_marker_allele_copy_number=6.0,
+        call_type="Heterozygous markers call",
+        variants=[
+            SmallVariantCall(
+                hgvs="LPA:4733G>A",
+                qual=42.5,
+                alt_copy_number=2,
+                alt_copy_number_quality=30.0,
+                ref_count=80,
+                alt_count=20,
+                positions=[1000, 2000],
+                ref_allele="C",
+                alt_allele="T",
+            )
+        ],
+    )
+
+
+class TestWriteJson:
+    def test_payload_round_trip(self, tmp_path):
+        out = tmp_path / "x.targeted.json"
+        _write_json(out, "S1", _build_minimal_call(), "hg38")
+        payload = json.loads(out.read_text())
+        assert payload["sampleId"] == "S1"
+        assert payload["genomeBuild"] == "hg38"
+        lpa = payload["lpa"]
+        assert lpa["kiv2CopyNumber"] == 12.0
+        assert lpa["refMarkerAlleleCopyNumber"] == 6.0
+        assert lpa["altMarkerAlleleCopyNumber"] == 6.0
+        assert lpa["type"] == "Heterozygous markers call"
+        assert len(lpa["variants"]) == 1
+        v = lpa["variants"][0]
+        assert v["hgvs"] == "LPA:4733G>A"
+        assert v["altCopyNumber"] == 2
+
+
+class TestWriteVcf:
+    def test_writes_header_and_rows(self, tmp_path):
+        fasta = _FakeFasta({"chr6": "A" * 1000})
+        out = tmp_path / "x.targeted.vcf.gz"
+        _write_vcf(
+            out,
+            sample_id="S1",
+            call=_build_minimal_call(),
+            chrom="chr6",
+            kiv2_start=100,
+            kiv2_end=200,
+            n_ref_repeats=6,
+            fasta=fasta,
+            contigs=[("chr6", 170_000_000)],
+        )
+        with gzip.open(out, "rt") as f:
+            text = f.read()
+        assert text.startswith("##fileformat=VCFv4.2")
+        assert "##contig=<ID=chr6,length=170000000>" in text
+        # Sample column header
+        assert text.split("\n")[-2 - 2].endswith("S1") or "\tS1" in text
+        # One SV row + one row per variant position
+        body = [line for line in text.splitlines() if line and not line.startswith("#")]
+        assert len(body) == 1 + 2  # 1 DUP row, 2 small-variant rows
+
+
+# ----------------------------------------------------------------------------
+# Sanity check on module defaults (catch accidental edits)
+# ----------------------------------------------------------------------------
+
+
+class TestModuleDefaults:
+    def test_default_repeat_count_matches_unit_len(self):
+        # 6 repeats x ~5552 bp ~ 33312 bp; KIV-2 array span is 33507 bp
+        approx_len = DEFAULT_KIV2_REPEAT_COUNT * DEFAULT_KIV2_UNIT_LEN
+        assert 33_000 < approx_len < 34_000
+
+    def test_default_kiv2_start_is_positive(self):
+        assert DEFAULT_KIV2_START > 0

--- a/src/cnv/tests/unit/test_lpa_caller.py
+++ b/src/cnv/tests/unit/test_lpa_caller.py
@@ -632,6 +632,22 @@ class TestHeterozygousMarkerCalling:
         assert alt_cn is None
         assert "No coverage" in call_type
 
+    def test_disagreeing_markers_flagged(self):
+        # One marker is homozygous REF, the other homozygous ALT. Pooling would
+        # give ~50% ALT and falsely emit a heterozygous split; the per-marker
+        # classifier must instead flag the disagreement.
+        ref_cn, alt_cn, call_type, _ = _make_marker_call([AlleleCounts(ref=100, alt=1), AlleleCounts(ref=1, alt=100)])
+        assert ref_cn is None
+        assert alt_cn is None
+        assert call_type == "Marker sites disagree"
+
+    def test_one_het_one_homref_flagged(self):
+        # Mixed het + hom-REF: still a disagreement; do not emit a het split.
+        ref_cn, alt_cn, call_type, _ = _make_marker_call([AlleleCounts(ref=50, alt=50), AlleleCounts(ref=100, alt=1)])
+        assert ref_cn is None
+        assert alt_cn is None
+        assert call_type == "Marker sites disagree"
+
 
 # ----------------------------------------------------------------------------
 # CLI region parser

--- a/src/cnv/tests/unit/test_lpa_caller.py
+++ b/src/cnv/tests/unit/test_lpa_caller.py
@@ -730,6 +730,10 @@ class TestFormatDupRecord:
         assert info["SVLEN"] == "101"
         assert info["CN"] == "1.000000,1.333333"
         assert info["TOTAL_CN"] == "14.000000"
+        # FORMAT/CN now reports diploid repeat-unit copy number, identical to
+        # INFO/TOTAL_CN, matching the repo CNV VCF convention.
+        sample_subfields = fields[9].split(":")
+        assert sample_subfields[1] == "14.000000"
 
     def test_missing_marker_allele_falls_back(self):
         call = LpaCall(

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -30,21 +30,21 @@
 from __future__ import annotations
 
 import argparse
-import gzip
 import json
-import math
 import sys
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import numpy as np
+import pyfaidx
 import pysam
 from ugbio_core.logger import logger
-
+from ugbio_core.math_utils import log_binomial
+from ugbio_core.math_utils import phred as core_phred
 
 # ----------------------------------------------------------------------------
-# Defaults (hg38). All overridable via CLI.
+# LPA caller defaults (hg38). All overridable via CLI.
 # ----------------------------------------------------------------------------
 
 # Reference KIV-2 array on hg38: chr6:160613491-160646997
@@ -142,13 +142,10 @@ LPA_VARIANT_NOISE_FLOOR = 0.003
 # Standard VCF QUAL cap.
 MAX_PHRED_QUAL = 99.0
 
-# Trim this fraction from each tail when estimating the autosomal baseline
-# depth. Drops mappability gaps (near-zero bins, e.g. chr7 telomere/repeat
-# clusters) and any bins that overlap copy-number outliers. With ~12k bins
-# across the 6 default 2 Mb regions, 10% per tail discards ~2400 bins each side
-# and leaves the central ~9600 for a robust mean. The median was previously
-# used but it is biased high on bimodal panels (some bins ~0, some bins ~50),
-# producing a systematic ~6-7% CN underestimate on this dataset.
+# Trim this fraction from each tail of the per-bin depth distribution when
+# estimating the autosomal baseline. Drops mappability gaps (near-zero bins)
+# and CN outliers. Using the median instead biased the baseline ~6-7% high on
+# this dataset because the panel is bimodal (some bins ~0, most ~30x).
 NORM_TRIM_FRACTION = 0.10
 
 
@@ -223,19 +220,9 @@ def _build_marker(spec: dict, kiv2_start: int, unit_len: int, n_repeats: int) ->
     return MarkerSpec(hgvs=spec["hgvs"], ref=spec["ref"], alt=spec["alt"], positions=positions)
 
 
-def _open_alignment(path: str, reference: str | None) -> pysam.AlignmentFile:
-    mode = "rc" if path.endswith(".cram") else "rb"
-    if mode == "rc" and not reference:
-        raise ValueError("CRAM input requires a reference FASTA (--reference)")
-    kwargs = {}
-    if reference:
-        kwargs["reference_filename"] = reference
-    return pysam.AlignmentFile(path, mode, **kwargs)
-
-
-def _gc_fraction(fasta: pysam.FastaFile, chrom: str, start: int, end: int) -> float:
+def _gc_fraction(fasta: pyfaidx.Fasta, chrom: str, start: int, end: int) -> float:
     """GC fraction in [start, end] (1-based, inclusive)."""
-    seq = fasta.fetch(chrom, start - 1, end).upper()
+    seq = str(fasta[chrom][start - 1 : end]).upper()
     if not seq:
         return 0.0
     # str.count is C-level and ~30x faster than a Python generator sum.
@@ -249,12 +236,14 @@ def _gc_fraction(fasta: pysam.FastaFile, chrom: str, start: int, end: int) -> fl
 
 def _bucket_gc(gc: float) -> float:
     """Round GC fraction down to the nearest bucket midpoint."""
-    idx = int(gc / GC_BUCKET_WIDTH)
+    # Clamp so GC exactly == 1.0 lands in the top bucket instead of one past it.
+    n_buckets = int(round(1.0 / GC_BUCKET_WIDTH))
+    idx = min(int(gc / GC_BUCKET_WIDTH), n_buckets - 1)
     return (idx + 0.5) * GC_BUCKET_WIDTH
 
 
 def _validate_marker_positions(
-    fasta: pysam.FastaFile,
+    fasta: pyfaidx.Fasta,
     chrom: str,
     markers: list[MarkerSpec],
     genome_build: str,
@@ -265,11 +254,8 @@ def _validate_marker_positions(
     different reference build is supplied without overriding the positions on
     the CLI, the caller would otherwise silently call against the wrong sites.
     """
-    try:
-        contigs = set(fasta.references)
-    except Exception:  # pragma: no cover - older pysam without .references
-        contigs = set()
-    if contigs and chrom not in contigs:
+    contigs = set(fasta.keys())
+    if chrom not in contigs:
         raise RuntimeError(
             f"Reference FASTA does not contain contig {chrom!r}. "
             f"If your reference is not {genome_build}, override --kiv2-chrom and the "
@@ -279,7 +265,7 @@ def _validate_marker_positions(
     mismatches: list[str] = []
     for m in markers:
         for pos in m.positions:
-            base = fasta.fetch(chrom, pos - 1, pos).upper()
+            base = str(fasta[chrom][pos - 1 : pos]).upper()
             if base != m.ref.upper():
                 mismatches.append(f"{m.hgvs} {chrom}:{pos} expected {m.ref} got {base or 'N/A'}")
 
@@ -302,7 +288,7 @@ def _validate_marker_positions(
 
 def _mean_depth_over_bins(
     bam: pysam.AlignmentFile,
-    fasta: pysam.FastaFile,
+    fasta: pyfaidx.Fasta,
     regions: Iterable[tuple[str, int, int]],
     bin_size: int = GC_BIN_SIZE,
     min_mapq: int = MIN_MAPPING_QUALITY,
@@ -370,7 +356,7 @@ def _trimmed_mean(values: list[float] | np.ndarray, trim: float = NORM_TRIM_FRAC
 
 def _estimate_total_kiv2_copy_number(
     bam: pysam.AlignmentFile,
-    fasta: pysam.FastaFile,
+    fasta: pyfaidx.Fasta,
     kiv2_chrom: str,
     kiv2_start: int,
     kiv2_end: int,
@@ -440,7 +426,6 @@ def _estimate_total_kiv2_copy_number(
 
 def _count_alleles_at_positions(
     bam: pysam.AlignmentFile,
-    fasta: pysam.FastaFile,
     chrom: str,
     positions: list[int],
     ref_allele: str,
@@ -463,7 +448,6 @@ def _count_alleles_at_positions(
         min_mapping_quality=KIV2_MIN_MAPPING_QUALITY,
         ignore_overlaps=True,
         stepper="samtools",
-        fastafile=fasta,
     ):
         ref_pos_1based = column.reference_pos + 1
         if ref_pos_1based not in pos_set:
@@ -471,7 +455,13 @@ def _count_alleles_at_positions(
         for read in column.pileups:
             if read.is_del or read.is_refskip or read.indel != 0:
                 continue
-            base = read.alignment.query_sequence[read.query_position]
+            aln = read.alignment
+            # Match the depth-side read filtering. The pysam "samtools" stepper
+            # already drops these by default, but make it explicit so the count
+            # stays correct if the stepper / pileup options ever change.
+            if aln.is_secondary or aln.is_supplementary or aln.is_duplicate or aln.is_qcfail or aln.is_unmapped:
+                continue
+            base = aln.query_sequence[read.query_position]
             if base == ref_allele:
                 counts.ref += 1
             elif base == alt_allele:
@@ -488,7 +478,6 @@ def _count_alleles_at_positions(
 
 def _call_heterozygous_markers(
     bam: pysam.AlignmentFile,
-    fasta: pysam.FastaFile,
     chrom: str,
     markers: list[MarkerSpec],
     kiv2_copy_number: float,
@@ -497,7 +486,7 @@ def _call_heterozygous_markers(
     Use the linked marker sites to split kiv2_copy_number into REF/ALT haplotype
     unit copy numbers. Returns (ref_cn, alt_cn, call_type, per_marker_counts).
     """
-    per_marker_counts = [_count_alleles_at_positions(bam, fasta, chrom, m.positions, m.ref, m.alt) for m in markers]
+    per_marker_counts = [_count_alleles_at_positions(bam, chrom, m.positions, m.ref, m.alt) for m in markers]
     total_alt = sum(c.alt for c in per_marker_counts)
     total_informative = sum(c.informative for c in per_marker_counts)
     if total_informative == 0:
@@ -521,15 +510,16 @@ def _call_heterozygous_markers(
 
 
 def _log_binomial(n: int, k: int, p: float) -> float:
-    if n == 0:
-        return 0.0
-    p = min(max(p, 1e-9), 1 - 1e-9)
-    return math.lgamma(n + 1) - math.lgamma(k + 1) - math.lgamma(n - k + 1) + k * math.log(p) + (n - k) * math.log1p(-p)
+    # Thin module-local alias for ugbio_core.math_utils.log_binomial; kept so
+    # existing unit tests under the _log_binomial name continue to work.
+    return log_binomial(n, k, p)
 
 
 def _phred(p: float) -> float:
+    # Thin wrapper around ugbio_core.math_utils.phred that clamps to a finite
+    # Phred range (the core helper returns +/- inf for p in {0, 1}).
     p = max(min(p, 1 - 1e-15), 1e-15)
-    return min(-10.0 * math.log10(p), MAX_PHRED_QUAL)
+    return min(float(core_phred([p])[0]), MAX_PHRED_QUAL)
 
 
 def _call_small_variant(
@@ -641,29 +631,32 @@ def _format_dup_record(
     call: LpaCall,
     n_ref_repeats: int,
 ) -> str:
-    """One <DUP>,<DUP> SV record summarizing both haplotype copy numbers."""
-    sv_len = end - start
+    """Single <DUP> SV record summarizing total + per-haplotype KIV-2 copy numbers.
+
+    A single symbolic ALT (<DUP>) is used instead of <DUP>,<DUP> because the
+    duplicate-ALT form is ambiguous to common VCF parsers. SVTYPE=DUP keeps
+    the record compatible with downstream merge logic that filters on
+    SVTYPE in {DEL,DUP}. Per-haplotype unit counts are reported via
+    FORMAT/REPCN, total via FORMAT/CN and INFO/TOTAL_CN.
+    """
+    # start/end are 1-based inclusive (KIV-2: chr6:160613491-160646997 = 33507 bp).
+    sv_len = end - start + 1
     total_cn = call.kiv2_copy_number
     if call.ref_marker_allele_copy_number is not None and call.alt_marker_allele_copy_number is not None:
-        # Per-haplotype copy ratio (vs. the n_ref_repeats reference baseline).
         cn1 = call.ref_marker_allele_copy_number / n_ref_repeats
         cn2 = call.alt_marker_allele_copy_number / n_ref_repeats
-        cn_field = f"{cn1:.6f},{cn2:.6f}"
-        gt = "1|2"
+        cn_info = f"{cn1:.6f},{cn2:.6f}"
         repcn = f"{int(round(call.ref_marker_allele_copy_number))}|{int(round(call.alt_marker_allele_copy_number))}"
-        alt = "<DUP>,<DUP>"
     else:
-        cn_field = ".,."
-        gt = "1|2"
+        cn_info = "."
         repcn = ".|."
-        alt = "<DUP>,<CNV>"
     info = (
-        f"SVCLAIM=D,D;END={end};SVLEN={sv_len},{sv_len};CN={cn_field};"
-        f"EVENT=LPA:KIV2,.;EVENTTYPE=VNTR,.;TOTAL_CN={total_cn:.6f}"
+        f"SVTYPE=DUP;SVCLAIM=D;END={end};SVLEN={sv_len};CN={cn_info};"
+        f"EVENT=LPA:KIV2;EVENTTYPE=VNTR;TOTAL_CN={total_cn:.6f}"
     )
     fmt = "GT:CN:REPCN:PS"
-    sample_field = f"{gt}:{total_cn / n_ref_repeats:.6f}:{repcn}:{start}"
-    return f"{chrom}\t{start}\t.\t{ref_base}\t{alt}\t.\tPASS\t{info}\t{fmt}\t{sample_field}"
+    sample_field = f"0/1:{total_cn / n_ref_repeats:.6f}:{repcn}:{start}"
+    return f"{chrom}\t{start}\t.\t{ref_base}\t<DUP>\t.\tPASS\t{info}\t{fmt}\t{sample_field}"
 
 
 def _format_small_variant_record(
@@ -697,8 +690,8 @@ def _format_small_variant_record(
     info = f"EVENT={v.hgvs};EVENTTYPE=VARIANT_IN_HOMOLOGY_REGION"
 
     for pos in v.positions:
-        fmt = "GT:GQ"
-        sample_field = f"{gt}:{int(round(v.alt_copy_number_quality))}"
+        fmt = "GT:GQ:PS"
+        sample_field = f"{gt}:{int(round(v.alt_copy_number_quality))}:{phase_set}"
         lines.append(
             f"{chrom}\t{pos}\t.\t{v.ref_allele}\t{v.alt_allele}\t{qual_field}\t{filter_field}\t{info}\t{fmt}\t{sample_field}"
         )
@@ -713,23 +706,23 @@ def _write_vcf(
     kiv2_start: int,
     kiv2_end: int,
     n_ref_repeats: int,
-    fasta: pysam.FastaFile,
+    fasta: pyfaidx.Fasta,
     contigs: list[tuple[str, int]],
 ) -> None:
-    ref_base = fasta.fetch(chrom, kiv2_start - 1, kiv2_start).upper() or "N"
+    ref_base = str(fasta[chrom][kiv2_start - 1 : kiv2_start]).upper() or "N"
     header = [
         "##fileformat=VCFv4.2",
         "##source=ugbio_cnv.lpa_caller",
-        '##ALT=<ID=DUP,Description="Duplication">',
-        '##ALT=<ID=CNV,Description="Copy number variant">',
+        '##ALT=<ID=DUP,Description="Duplication relative to the reference">',
         '##FILTER=<ID=TargetedLowQual,Description="Variant quality below threshold">',
         '##FILTER=<ID=TargetedRepeatConflict,Description="Read counts inconsistent with an integer copy partition">',
         '##INFO=<ID=END,Number=1,Type=Integer,Description="End position">',
-        '##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of structural variant">',
-        '##INFO=<ID=SVCLAIM,Number=.,Type=String,Description="Claims supported for the structural variant">',
+        '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">',
+        '##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Length of structural variant">',
+        '##INFO=<ID=SVCLAIM,Number=1,Type=String,Description="Claims supported for the structural variant (D=depth)">',
         '##INFO=<ID=CN,Number=.,Type=Float,Description="Per-haplotype copy number ratio vs reference">',
-        '##INFO=<ID=EVENT,Number=.,Type=String,Description="Event name">',
-        '##INFO=<ID=EVENTTYPE,Number=.,Type=String,Description="Event type">',
+        '##INFO=<ID=EVENT,Number=1,Type=String,Description="Event name">',
+        '##INFO=<ID=EVENTTYPE,Number=1,Type=String,Description="Event type">',
         '##INFO=<ID=TOTAL_CN,Number=1,Type=Float,Description="Total LPA KIV-2 unit copy number (diploid)">',
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
         '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">',
@@ -743,13 +736,22 @@ def _write_vcf(
 
     rows = [_format_dup_record(chrom, kiv2_start, kiv2_end, ref_base, sample_id, call, n_ref_repeats)]
     total_cn_int = max(1, int(round(call.kiv2_copy_number)))
+    small_rows = []
     for v in call.variants:
-        rows.extend(_format_small_variant_record(chrom, v, total_cn_int, kiv2_start))
+        small_rows.extend(_format_small_variant_record(chrom, v, total_cn_int, kiv2_start))
+    # Per-repeat rows are emitted per-variant, not by position; sort so the
+    # contig stays coordinate-ordered for tabix indexing.
+    small_rows.sort(key=lambda line: int(line.split("\t", 2)[1]))
+    rows.extend(small_rows)
 
     text = "\n".join(header + rows) + "\n"
-    opener = gzip.open if str(out_path).endswith(".gz") else open
-    with opener(out_path, "wt") as f:
-        f.write(text)
+    # .vcf.gz must be BGZF (not plain gzip) for bcftools/tabix to index/read it.
+    if str(out_path).endswith(".gz"):
+        with pysam.BGZFile(str(out_path), "w") as f:
+            f.write(text.encode())
+    else:
+        with open(out_path, "w") as f:
+            f.write(text)
 
 
 # ----------------------------------------------------------------------------
@@ -809,8 +811,9 @@ def run(argv: list[str]) -> None:
 
     norm_regions = _parse_norm_regions(args.norm_regions) if args.norm_regions else DEFAULT_NORM_REGIONS
 
-    bam = _open_alignment(args.cram, args.reference)
-    fasta = pysam.FastaFile(args.reference)
+    mode = "rc" if args.cram.endswith(".cram") else "rb"
+    bam = pysam.AlignmentFile(args.cram, mode, reference_filename=args.reference)
+    fasta = pyfaidx.Fasta(args.reference)
 
     try:
         markers = [
@@ -836,12 +839,12 @@ def run(argv: list[str]) -> None:
         )
         logger.info("Total KIV-2 copy number (diploid): %.3f", kiv2_cn)
 
-        ref_cn, alt_cn, call_type, _ = _call_heterozygous_markers(bam, fasta, args.kiv2_chrom, markers, kiv2_cn)
+        ref_cn, alt_cn, call_type, _ = _call_heterozygous_markers(bam, args.kiv2_chrom, markers, kiv2_cn)
         logger.info("Marker call: %s (ref=%s, alt=%s)", call_type, ref_cn, alt_cn)
 
         variant_calls = []
         for var in small_variants:
-            counts = _count_alleles_at_positions(bam, fasta, args.kiv2_chrom, var.positions, var.ref, var.alt)
+            counts = _count_alleles_at_positions(bam, args.kiv2_chrom, var.positions, var.ref, var.alt)
             call = _call_small_variant(
                 counts,
                 kiv2_cn,

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -375,7 +375,7 @@ def _estimate_total_kiv2_copy_number(
     norm_by_gc = _mean_depth_over_bins(bam, fasta, norm_regions)
     # Per-GC-bucket baseline uses a trimmed mean too, for the same reason
     # the overall baseline does.
-    gc_medians = {gc: _trimmed_mean(depths) for gc, depths in norm_by_gc.items() if depths}
+    gc_baselines = {gc: _trimmed_mean(depths) for gc, depths in norm_by_gc.items() if depths}
     all_depths = [d for depths in norm_by_gc.values() for d in depths]
     overall_baseline = _trimmed_mean(all_depths)
     if overall_baseline <= 0:
@@ -393,7 +393,7 @@ def _estimate_total_kiv2_copy_number(
     )
     corrected = []
     for gc, depths in kiv2_by_gc.items():
-        baseline = gc_medians.get(gc, overall_baseline)
+        baseline = gc_baselines.get(gc, overall_baseline)
         if baseline <= 0:
             baseline = overall_baseline
         scale = overall_baseline / baseline

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 import argparse
 import gzip
 import json
-import logging
 import math
 import sys
 from collections.abc import Iterable
@@ -41,9 +40,7 @@ from pathlib import Path
 
 import numpy as np
 import pysam
-
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-logger = logging.getLogger("lpa_caller")
+from ugbio_core.logger import logger
 
 
 # ----------------------------------------------------------------------------

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -639,7 +639,7 @@ def _format_dup_record(
         f"EVENT=LPA:KIV2;EVENTTYPE=VNTR;TOTAL_CN={total_cn:.6f}"
     )
     fmt = "GT:CN:REPCN:PS"
-    sample_field = f"0/1:{total_cn / n_ref_repeats:.6f}:{repcn}:{start}"
+    sample_field = f"0/1:{total_cn:.6f}:{repcn}:{start}"
     return f"{chrom}\t{start}\t.\t{ref_base}\t<DUP>\t.\tPASS\t{info}\t{fmt}\t{sample_field}"
 
 
@@ -710,7 +710,7 @@ def _write_vcf(
         '##INFO=<ID=TOTAL_CN,Number=1,Type=Float,Description="Total LPA KIV-2 unit copy number (diploid)">',
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
         '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">',
-        '##FORMAT=<ID=CN,Number=1,Type=Float,Description="Total copy-number ratio">',
+        '##FORMAT=<ID=CN,Number=1,Type=Float,Description="Total LPA KIV-2 unit copy number (diploid)">',
         '##FORMAT=<ID=REPCN,Number=1,Type=String,Description="Per-haplotype repeat unit copy number">',
         '##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set">',
     ]

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -1,0 +1,880 @@
+# Copyright 2026 Ultima Genomics Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# DESCRIPTION
+#    LPA Caller for Ultima Genomics WGS data.
+#
+#    Re-implementation of the Illumina DRAGEN LPA targeted caller
+#    (https://help.dragen.illumina.com/dragen-v4.5/product-guides/dragen-v4.5/
+#     dragen-dna-pipeline/targeted-caller/lpa-calling) on a single CRAM/BAM.
+#
+#    Three steps:
+#      1. Estimate the total LPA KIV-2 VNTR unit copy number from depth in the
+#         KIV-2 reference region, normalized against autosomal stable regions
+#         with GC-bias correction.
+#      2. Estimate the haplotype-resolved (heterozygous) unit copy number using
+#         two linked marker SNV sites (LPA:296T>G + LPA:1264C>G) whose ALT
+#         alleles co-occur on the same KIV-2 repeat copy.
+#      3. Call two small variants (LPA:4733G>A, LPA:4925G>A) by collapsing read
+#         counts across all 6 reference repeat copies and applying a binomial
+#         likelihood across all possible ALT copy-number values bounded by the
+#         total KIV-2 copy number.
+#
+#    Outputs <prefix>.targeted.json and <prefix>.targeted.vcf(.gz), restricted
+#    to the LPA section (DRAGEN packs PGx star-allele + LPA + HBA + RH into the
+#    same files; here we emit LPA only).
+#
+#    Default constants (hg38 coordinates, repeat unit length, marker variants)
+#    are taken from public DRAGEN documentation example output and the LPA
+#    literature. Any can be overridden from the command line.
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import logging
+import math
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pysam
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("lpa_caller")
+
+
+# ----------------------------------------------------------------------------
+# Defaults (hg38). All overridable via CLI.
+# ----------------------------------------------------------------------------
+
+# DRAGEN anchors the reference KIV-2 array at chr6:160613491-160646997
+# (33507 bp, 6 repeat units of ~5552 bp).
+DEFAULT_KIV2_CHROM = "chr6"
+DEFAULT_KIV2_START = 160613491  # 1-based, inclusive
+DEFAULT_KIV2_END = 160646997  # 1-based, inclusive
+DEFAULT_KIV2_REPEAT_COUNT = 6
+DEFAULT_KIV2_UNIT_LEN = 5552
+
+# Heterozygous-marker SNV pair (linked across every repeat copy of a haplotype).
+# Per-repeat spacing is irregular (~5543-5552 bp) so explicit positions are used
+# instead of uniform extrapolation.
+DEFAULT_MARKER_VARIANTS = [
+    {
+        "hgvs": "LPA:296T>G",
+        "ref": "T",
+        "alt": "G",
+        "positions": [160613786, 160619338, 160624884, 160630428, 160635977, 160641520],
+    },
+    {
+        "hgvs": "LPA:1264C>G",
+        "ref": "C",
+        "alt": "G",
+        "positions": [160614754, 160620306, 160625852, 160631396, 160636945, 160642488],
+    },
+]
+
+# Small variant sites in the KIV-2 repeat (DRAGEN's two reported LPA variants).
+# REF/ALT are genome-strand (LPA gene is on minus strand, hence the C/T pair
+# for variants DRAGEN labels "G>A"). Per-repeat positions are explicit because
+# the small-variant region uses a slightly different per-repeat spacing than
+# the marker region, and DRAGEN omits repeat 4 of LPA:4925G>A.
+DEFAULT_SMALL_VARIANTS = [
+    {
+        "hgvs": "LPA:4925G>A",
+        "ref": "C",
+        "alt": "T",
+        "positions": [160618484, 160624030, 160629574, 160640667, 160646214],
+    },
+    {
+        "hgvs": "LPA:4733G>A",
+        "ref": "C",
+        "alt": "T",
+        "positions": [160618676, 160624222, 160629766, 160635315, 160640859, 160646406],
+    },
+]
+
+# Autosomal stable regions used as the diploid depth baseline.
+# Picked from broadly euchromatic, copy-stable intervals (no segdup overlap,
+# moderate GC) on chromosomes 1, 4, 7, 11, 14, 19. Roughly 6 x 2 Mb = 12 Mb,
+# which is plenty for a robust mean-depth estimate at 30x.
+DEFAULT_NORM_REGIONS = [
+    ("chr1", 50_000_000, 52_000_000),
+    ("chr4", 80_000_000, 82_000_000),
+    ("chr7", 60_000_000, 62_000_000),
+    ("chr11", 40_000_000, 42_000_000),
+    ("chr14", 70_000_000, 72_000_000),
+    ("chr19", 20_000_000, 22_000_000),
+]
+
+# Bin size for GC-bias correction.
+GC_BIN_SIZE = 1000
+# GC bucket width (fraction): 0.05 -> 20 buckets between 0 and 1.
+GC_BUCKET_WIDTH = 0.05
+
+# Variant filter thresholds, matching the spirit of DRAGEN's TargetedLowQual /
+# TargetedRepeatConflict tags.
+LOW_QUAL_THRESHOLD = 10.0
+# Residual ALT-count fraction above which the integer copy partition is flagged
+# as inconsistent and the TargetedRepeatConflict filter is applied.
+REPEAT_CONFLICT_RESIDUAL = 0.05
+
+# ALT-allele fraction window for calling the marker pair heterozygous. Outside
+# this window the call collapses to homozygous REF (below) or homozygous ALT
+# (above).
+HET_MARKER_ALT_FRACTION_MIN = 0.10
+HET_MARKER_ALT_FRACTION_MAX = 0.90
+
+MIN_BASE_QUALITY = 20
+MIN_MAPPING_QUALITY = 10
+# KIV-2 is a 6-copy VNTR: ~90% of reads have MAPQ=0 because they multi-map
+# across the reference repeat units. DRAGEN's targeted caller does not filter
+# them out; doing so collapses observed KIV-2 depth ~10x and breaks total CN.
+KIV2_MIN_MAPPING_QUALITY = 0
+
+# Per-base noise floor for small-variant calling: combined sequencing error and
+# residual cross-paralog/cross-repeat mismapping rate at KIV-2 sites. Without
+# this, the binomial P(alt|alt_cn=0) collapses to ~1e-85 for any real signal
+# and QUAL pins at the Phred floor.
+#
+# Calibrated separately for SNPs and indels because UG flow chemistry has very
+# different error spectra: SNP substitution errors are rare (~0.1-0.3% per base,
+# matching DRAGEN's implicit ~0.15% scale on this dataset), while indel errors
+# in homopolymer/short-tandem-repeat contexts can reach ~1%. Using a single
+# 1% floor crushes SNP QUAL by ~5x relative to DRAGEN; using 0.1% for indels
+# would re-admit homopolymer-driven false positives.
+LPA_VARIANT_NOISE_FLOOR_SNP = 0.003
+LPA_VARIANT_NOISE_FLOOR_INDEL = 0.01
+# Standard VCF QUAL cap.
+MAX_PHRED_QUAL = 99.0
+
+# Trim this fraction from each tail when estimating the autosomal baseline
+# depth. Drops mappability gaps (near-zero bins, e.g. chr7 telomere/repeat
+# clusters) and any bins that overlap copy-number outliers. With ~12k bins
+# across the 6 default 2 Mb regions, 10% per tail discards ~2400 bins each side
+# and leaves the central ~9600 for a robust mean. The median was previously
+# used but it is biased high on bimodal panels (some bins ~0, some bins ~50),
+# producing a systematic ~6-7% CN underestimate on this dataset.
+NORM_TRIM_FRACTION = 0.10
+
+
+# ----------------------------------------------------------------------------
+# Data classes
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class MarkerSpec:
+    hgvs: str
+    ref: str
+    alt: str
+    positions: list[int]  # 1-based positions in every reference repeat copy
+
+
+@dataclass
+class AlleleCounts:
+    ref: int = 0
+    alt: int = 0
+    other: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.ref + self.alt + self.other
+
+    @property
+    def informative(self) -> int:
+        return self.ref + self.alt
+
+
+@dataclass
+class SmallVariantCall:
+    hgvs: str
+    qual: float
+    alt_copy_number: int
+    alt_copy_number_quality: float
+    ref_count: int
+    alt_count: int
+    positions: list[int] = field(default_factory=list)
+    ref_allele: str = ""
+    alt_allele: str = ""
+
+
+@dataclass
+class LpaCall:
+    kiv2_copy_number: float
+    ref_marker_allele_copy_number: float | None
+    alt_marker_allele_copy_number: float | None
+    call_type: str
+    variants: list[SmallVariantCall]
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _build_marker(spec: dict, kiv2_start: int, unit_len: int, n_repeats: int) -> MarkerSpec:
+    """Project a marker onto every repeat copy.
+
+    If the spec provides an explicit ``positions`` list, use it as-is
+    (small variants need this because their per-repeat spacing is not the
+    uniform ``unit_len`` of the marker region). Otherwise extrapolate from
+    ``first_pos`` at fixed ``unit_len`` spacing.
+    """
+    if "positions" in spec:
+        positions = list(spec["positions"])
+    else:
+        offset = spec["first_pos"] - kiv2_start
+        positions = [kiv2_start + offset + i * unit_len for i in range(n_repeats)]
+    return MarkerSpec(hgvs=spec["hgvs"], ref=spec["ref"], alt=spec["alt"], positions=positions)
+
+
+def _open_alignment(path: str, reference: str | None) -> pysam.AlignmentFile:
+    mode = "rc" if path.endswith(".cram") else "rb"
+    if mode == "rc" and not reference:
+        raise ValueError("CRAM input requires a reference FASTA (--reference)")
+    kwargs = {}
+    if reference:
+        kwargs["reference_filename"] = reference
+    return pysam.AlignmentFile(path, mode, **kwargs)
+
+
+def _gc_fraction(fasta: pysam.FastaFile, chrom: str, start: int, end: int) -> float:
+    """GC fraction in [start, end] (1-based, inclusive)."""
+    seq = fasta.fetch(chrom, start - 1, end).upper()
+    if not seq:
+        return 0.0
+    # str.count is C-level and ~30x faster than a Python generator sum.
+    g = seq.count("G")
+    c = seq.count("C")
+    a = seq.count("A")
+    t = seq.count("T")
+    at_gc = a + c + g + t
+    return (g + c) / at_gc if at_gc > 0 else 0.0
+
+
+def _bucket_gc(gc: float) -> float:
+    """Round GC fraction down to the nearest bucket midpoint."""
+    idx = int(gc / GC_BUCKET_WIDTH)
+    return (idx + 0.5) * GC_BUCKET_WIDTH
+
+
+# ----------------------------------------------------------------------------
+# Depth estimation
+# ----------------------------------------------------------------------------
+
+
+def _mean_depth_over_bins(
+    bam: pysam.AlignmentFile,
+    fasta: pysam.FastaFile,
+    regions: Iterable[tuple[str, int, int]],
+    bin_size: int = GC_BIN_SIZE,
+    min_mapq: int = MIN_MAPPING_QUALITY,
+) -> dict[float, list[float]]:
+    """
+    Compute per-bin mean read depth across the given regions, grouped by GC
+    bucket. Returns {gc_bucket: [depths_per_bin]}.
+
+    Implementation: one ``fetch`` per region, accumulate each read's reference
+    span (``reference_start``..``reference_end``) into a numpy depth array, then
+    bin and average. This is ~100x faster than calling ``count_coverage`` per
+    bin because it avoids per-base CIGAR pileup and amortizes pysam's per-call
+    overhead across the whole region. We trade exact base-resolution coverage
+    (CIGAR D/N gaps are not subtracted) for binned mean depth, which is what
+    GC normalization actually needs — and the gap bias is uniform across
+    regions, so it cancels in the depth ratio.
+    """
+    by_gc: dict[float, list[float]] = {}
+    for chrom, start, end in regions:
+        region_len = end - start + 1
+        if region_len < bin_size:
+            continue
+        depth = np.zeros(region_len, dtype=np.int32)
+        region_start0 = start - 1  # 0-based offset within the depth array
+        for read in bam.fetch(chrom, region_start0, end):
+            if (
+                read.is_unmapped
+                or read.is_secondary
+                or read.is_supplementary
+                or read.is_duplicate
+                or read.mapping_quality < min_mapq
+            ):
+                continue
+            rs = read.reference_start
+            re = read.reference_end
+            if re is None or re <= region_start0 or rs >= end:
+                continue
+            lo = max(rs, region_start0) - region_start0
+            hi = min(re, end) - region_start0
+            if hi > lo:
+                depth[lo:hi] += 1
+
+        n_bins = region_len // bin_size
+        if n_bins == 0:
+            continue
+        # Reshape into (n_bins, bin_size) and take per-bin mean in one go.
+        binned = depth[: n_bins * bin_size].reshape(n_bins, bin_size).mean(axis=1)
+        for b in range(n_bins):
+            bin_start = start + b * bin_size
+            bin_end = bin_start + bin_size - 1
+            gc = _gc_fraction(fasta, chrom, bin_start, bin_end)
+            by_gc.setdefault(_bucket_gc(gc), []).append(float(binned[b]))
+    return by_gc
+
+
+def _trimmed_mean(values: list[float] | np.ndarray, trim: float = NORM_TRIM_FRACTION) -> float:
+    arr = np.sort(np.asarray(values, dtype=float))
+    if arr.size == 0:
+        return 0.0
+    k = int(round(arr.size * trim))
+    if 2 * k >= arr.size:
+        return float(arr.mean())
+    return float(arr[k : arr.size - k].mean())
+
+
+def _estimate_total_kiv2_copy_number(
+    bam: pysam.AlignmentFile,
+    fasta: pysam.FastaFile,
+    kiv2_chrom: str,
+    kiv2_start: int,
+    kiv2_end: int,
+    n_ref_repeats: int,
+    norm_regions: list[tuple[str, int, int]],
+    mean_coverage_override: float | None = None,
+) -> float:
+    """
+    Total LPA KIV-2 VNTR unit copy number, summed over the two haplotypes.
+
+    With 6 reference repeat units and a perfectly diploid reference call, KIV-2
+    bin depth equals the autosomal mean depth and the returned value is 2*6=12.
+    Returned value is the per-cell (diploid) repeat-unit count.
+
+    If ``mean_coverage_override`` is given, that value is used as the diploid
+    baseline and the panel-based estimation is skipped (use it to feed in
+    DRAGEN-style genome-wide mean coverage from external metrics).
+    """
+    if mean_coverage_override is not None:
+        if mean_coverage_override <= 0:
+            raise ValueError("mean_coverage_override must be positive")
+        overall_baseline = float(mean_coverage_override)
+        gc_medians: dict[float, float] = {}
+        logger.info("Using user-supplied autosomal mean coverage: %.2f", overall_baseline)
+    else:
+        logger.info("Estimating GC-bias profile from %d normalization regions", len(norm_regions))
+        norm_by_gc = _mean_depth_over_bins(bam, fasta, norm_regions)
+        # Per-GC-bucket baseline uses a trimmed mean too, for the same reason
+        # the overall baseline does.
+        gc_medians = {gc: _trimmed_mean(depths) for gc, depths in norm_by_gc.items() if depths}
+        all_depths = [d for depths in norm_by_gc.values() for d in depths]
+        overall_baseline = _trimmed_mean(all_depths)
+        if overall_baseline <= 0:
+            raise RuntimeError("Normalization regions have zero coverage; check input/reference")
+        logger.info(
+            "Autosomal trimmed-mean depth (drop %.0f%% each tail): %.2f",
+            100 * NORM_TRIM_FRACTION,
+            overall_baseline,
+        )
+
+    # KIV-2 binned depth, GC-corrected against the normalization profile.
+    # MAPQ filter is dropped here: most KIV-2 reads multi-map (MAPQ=0).
+    kiv2_by_gc = _mean_depth_over_bins(
+        bam, fasta, [(kiv2_chrom, kiv2_start, kiv2_end)], min_mapq=KIV2_MIN_MAPPING_QUALITY
+    )
+    corrected = []
+    for gc, depths in kiv2_by_gc.items():
+        baseline = gc_medians.get(gc, overall_baseline)
+        if baseline <= 0:
+            baseline = overall_baseline
+        scale = overall_baseline / baseline
+        corrected.extend(d * scale for d in depths)
+    if not corrected:
+        raise RuntimeError("No KIV-2 depth bins computed")
+    kiv2_mean = float(np.mean(corrected))
+    logger.info("GC-corrected KIV-2 mean depth: %.2f", kiv2_mean)
+
+    # Ratio * 2 (haplotype copies) * n_ref_repeats (per-allele baseline).
+    copy_number = (kiv2_mean / overall_baseline) * 2.0 * n_ref_repeats
+    return copy_number
+
+
+# ----------------------------------------------------------------------------
+# Allele counting at marker / variant positions
+# ----------------------------------------------------------------------------
+
+
+def _count_alleles_at_positions(
+    bam: pysam.AlignmentFile,
+    fasta: pysam.FastaFile,
+    chrom: str,
+    positions: list[int],
+    ref_allele: str,
+    alt_allele: str,
+) -> AlleleCounts:
+    """Sum REF/ALT read counts across all listed (1-based) positions."""
+    counts = AlleleCounts()
+    if not positions:
+        return counts
+    start = min(positions) - 1
+    end = max(positions)
+    pos_set = set(positions)
+    # KIV-2 reads multi-map -> use the KIV-2 MAPQ floor, not the autosomal one.
+    for column in bam.pileup(
+        chrom,
+        start,
+        end,
+        truncate=True,
+        min_base_quality=MIN_BASE_QUALITY,
+        min_mapping_quality=KIV2_MIN_MAPPING_QUALITY,
+        ignore_overlaps=True,
+        stepper="samtools",
+        fastafile=fasta,
+    ):
+        ref_pos_1based = column.reference_pos + 1
+        if ref_pos_1based not in pos_set:
+            continue
+        for read in column.pileups:
+            if read.is_del or read.is_refskip or read.indel != 0:
+                continue
+            base = read.alignment.query_sequence[read.query_position]
+            if base == ref_allele:
+                counts.ref += 1
+            elif base == alt_allele:
+                counts.alt += 1
+            else:
+                counts.other += 1
+    return counts
+
+
+# ----------------------------------------------------------------------------
+# Heterozygous marker calling
+# ----------------------------------------------------------------------------
+
+
+def _call_heterozygous_markers(
+    bam: pysam.AlignmentFile,
+    fasta: pysam.FastaFile,
+    chrom: str,
+    markers: list[MarkerSpec],
+    kiv2_copy_number: float,
+) -> tuple[float | None, float | None, str, list[AlleleCounts]]:
+    """
+    Use the linked marker sites to split kiv2_copy_number into REF/ALT haplotype
+    unit copy numbers. Returns (ref_cn, alt_cn, call_type, per_marker_counts).
+    """
+    per_marker_counts = [_count_alleles_at_positions(bam, fasta, chrom, m.positions, m.ref, m.alt) for m in markers]
+    total_alt = sum(c.alt for c in per_marker_counts)
+    total_informative = sum(c.informative for c in per_marker_counts)
+    if total_informative == 0:
+        return None, None, "No coverage at marker sites", per_marker_counts
+
+    alt_fraction = total_alt / total_informative
+    # ALT-allele evidence threshold (>=10% reads supports a heterozygous call).
+    if alt_fraction < HET_MARKER_ALT_FRACTION_MIN:
+        return None, None, "Homozygous REF markers call", per_marker_counts
+    if alt_fraction > HET_MARKER_ALT_FRACTION_MAX:
+        return None, None, "Homozygous ALT markers call", per_marker_counts
+
+    alt_cn = kiv2_copy_number * alt_fraction
+    ref_cn = kiv2_copy_number - alt_cn
+    return ref_cn, alt_cn, "Heterozygous markers call", per_marker_counts
+
+
+# ----------------------------------------------------------------------------
+# Small-variant calling (binomial across all possible ALT copy numbers)
+# ----------------------------------------------------------------------------
+
+
+def _log_binomial(n: int, k: int, p: float) -> float:
+    if n == 0:
+        return 0.0
+    p = min(max(p, 1e-9), 1 - 1e-9)
+    return math.lgamma(n + 1) - math.lgamma(k + 1) - math.lgamma(n - k + 1) + k * math.log(p) + (n - k) * math.log1p(-p)
+
+
+def _phred(p: float) -> float:
+    p = max(min(p, 1 - 1e-15), 1e-15)
+    return min(-10.0 * math.log10(p), MAX_PHRED_QUAL)
+
+
+def _noise_floor_for(ref_allele: str, alt_allele: str) -> float:
+    """SNP vs indel noise floor selector. Anything that isn't a single-base
+    substitution is treated as indel-like."""
+    if len(ref_allele) == 1 and len(alt_allele) == 1:
+        return LPA_VARIANT_NOISE_FLOOR_SNP
+    return LPA_VARIANT_NOISE_FLOOR_INDEL
+
+
+def _call_small_variant(
+    counts: AlleleCounts,
+    kiv2_copy_number: float,
+    hgvs: str,
+    ref_allele: str,
+    alt_allele: str,
+    positions: list[int],
+) -> SmallVariantCall:
+    """
+    Likelihood ratio: P(alt_cn = best) vs. P(alt_cn = 0). Both QUAL and ALT-CN
+    quality are reported as Phred-scaled posteriors under a uniform prior over
+    integer ALT copy numbers in [0, round(kiv2_copy_number)].
+    """
+    total_cn = max(1, int(round(kiv2_copy_number)))
+    n = counts.informative
+    if n == 0:
+        return SmallVariantCall(
+            hgvs=hgvs,
+            qual=0.0,
+            alt_copy_number=0,
+            alt_copy_number_quality=0.0,
+            ref_count=counts.ref,
+            alt_count=counts.alt,
+            positions=positions,
+            ref_allele=ref_allele,
+            alt_allele=alt_allele,
+        )
+
+    noise = _noise_floor_for(ref_allele, alt_allele)
+    log_liks = []
+    for alt_cn in range(total_cn + 1):
+        # Mix the ideal alt fraction with a flat noise floor so the alt_cn=0
+        # hypothesis can absorb sporadic mis-mapped/error reads instead of
+        # being assigned probability 0.
+        ideal = alt_cn / total_cn
+        p_alt = ideal * (1.0 - noise) + (1.0 - ideal) * noise
+        log_liks.append(_log_binomial(n, counts.alt, p_alt))
+
+    log_liks = np.array(log_liks)
+    # Posterior under uniform prior.
+    m = log_liks.max()
+    post = np.exp(log_liks - m)
+    post = post / post.sum()
+    best = int(np.argmax(post))
+    best_post = float(post[best])
+
+    # QUAL is the Phred-scaled posterior that a variant IS present, i.e.
+    # -10*log10(P(alt_cn=0)). When the best call IS alt_cn=0, P(alt_cn=0)
+    # ~= 1 and that formula collapses to ~0, which is misleading. Match the
+    # standard VCF convention (and DRAGEN) by reporting 0.0 in that case.
+    if best == 0:
+        qual = 0.0
+    else:
+        qual = _phred(float(post[0]))
+
+    alt_cn_quality = _phred(1.0 - best_post)
+
+    return SmallVariantCall(
+        hgvs=hgvs,
+        qual=qual,
+        alt_copy_number=best,
+        alt_copy_number_quality=alt_cn_quality,
+        ref_count=counts.ref,
+        alt_count=counts.alt,
+        positions=positions,
+        ref_allele=ref_allele,
+        alt_allele=alt_allele,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Output writers
+# ----------------------------------------------------------------------------
+
+
+def _write_json(out_path: Path, sample_id: str, call: LpaCall, genome_build: str) -> None:
+    payload = {
+        "softwareVersion": "ugbio_cnv.lpa_caller",
+        "sampleId": sample_id,
+        "genomeBuild": genome_build,
+        "lpa": {
+            "kiv2CopyNumber": call.kiv2_copy_number,
+            "refMarkerAlleleCopyNumber": call.ref_marker_allele_copy_number,
+            "altMarkerAlleleCopyNumber": call.alt_marker_allele_copy_number,
+            "type": call.call_type,
+            "variants": [
+                {
+                    "hgvs": v.hgvs,
+                    "qual": v.qual,
+                    "altCopyNumber": v.alt_copy_number,
+                    "altCopyNumberQuality": v.alt_copy_number_quality,
+                }
+                for v in call.variants
+            ],
+        },
+    }
+    with out_path.open("w") as f:
+        json.dump(payload, f, indent=2)
+
+
+def _format_dup_record(
+    chrom: str,
+    start: int,
+    end: int,
+    ref_base: str,
+    sample_id: str,
+    call: LpaCall,
+    n_ref_repeats: int,
+) -> str:
+    """One <DUP>,<DUP> SV record summarizing both haplotype copy numbers."""
+    sv_len = end - start
+    total_cn = call.kiv2_copy_number
+    if call.ref_marker_allele_copy_number is not None and call.alt_marker_allele_copy_number is not None:
+        # Per-haplotype copy ratio (vs. the n_ref_repeats reference baseline).
+        cn1 = call.ref_marker_allele_copy_number / n_ref_repeats
+        cn2 = call.alt_marker_allele_copy_number / n_ref_repeats
+        cn_field = f"{cn1:.6f},{cn2:.6f}"
+        gt = "1|2"
+        repcn = f"{int(round(call.ref_marker_allele_copy_number))}|{int(round(call.alt_marker_allele_copy_number))}"
+        alt = "<DUP>,<DUP>"
+    else:
+        cn_field = ".,."
+        gt = "1|2"
+        repcn = ".|."
+        alt = "<DUP>,<CNV>"
+    info = (
+        f"SVCLAIM=D,D;END={end};SVLEN={sv_len},{sv_len};CN={cn_field};"
+        f"EVENT=LPA:KIV2,.;EVENTTYPE=VNTR,.;TOTAL_CN={total_cn:.6f}"
+    )
+    fmt = "GT:CN:REPCN:PS"
+    sample_field = f"{gt}:{total_cn / n_ref_repeats:.6f}:{repcn}:{start}"
+    return f"{chrom}\t{start}\t.\t{ref_base}\t{alt}\t.\tPASS\t{info}\t{fmt}\t{sample_field}"
+
+
+def _format_small_variant_record(
+    chrom: str,
+    v: SmallVariantCall,
+    total_cn: int,
+    phase_set: int,
+) -> list[str]:
+    """One VCF row per reference repeat copy carrying the variant."""
+    lines = []
+    # FILTER tags
+    filters = []
+    if v.qual < LOW_QUAL_THRESHOLD:
+        filters.append("TargetedLowQual")
+    # "Repeat conflict" is a soft signal that REF/ALT counts don't cleanly match
+    # an integer copy partition. Approximate it by residual against the best fit.
+    if total_cn > 0 and (v.ref_count + v.alt_count) > 0:
+        expected_alt = (v.alt_copy_number / total_cn) * (v.ref_count + v.alt_count)
+        residual = abs(v.alt_count - expected_alt) / max(1, v.ref_count + v.alt_count)
+        if residual > REPEAT_CONFLICT_RESIDUAL:
+            filters.append("TargetedRepeatConflict")
+    filter_field = ";".join(filters) if filters else "PASS"
+
+    # Genotype: total_cn alleles, alt_copy_number of which are 1.
+    n_alt = v.alt_copy_number
+    n_ref = max(0, total_cn - n_alt)
+    gt_alleles = ["0"] * n_ref + ["1"] * n_alt
+    gt = "/".join(gt_alleles) if gt_alleles else "."
+
+    qual_field = f"{v.qual:.2f}"
+    info = f"EVENT={v.hgvs};EVENTTYPE=VARIANT_IN_HOMOLOGY_REGION"
+
+    for pos in v.positions:
+        fmt = "GT:GQ"
+        sample_field = f"{gt}:{int(round(v.alt_copy_number_quality))}"
+        lines.append(
+            f"{chrom}\t{pos}\t.\t{v.ref_allele}\t{v.alt_allele}\t{qual_field}\t{filter_field}\t{info}\t{fmt}\t{sample_field}"
+        )
+    return lines
+
+
+def _write_vcf(
+    out_path: Path,
+    sample_id: str,
+    call: LpaCall,
+    chrom: str,
+    kiv2_start: int,
+    kiv2_end: int,
+    n_ref_repeats: int,
+    fasta: pysam.FastaFile,
+    contigs: list[tuple[str, int]],
+) -> None:
+    ref_base = fasta.fetch(chrom, kiv2_start - 1, kiv2_start).upper() or "N"
+    header = [
+        "##fileformat=VCFv4.2",
+        "##source=ugbio_cnv.lpa_caller",
+        '##ALT=<ID=DUP,Description="Duplication">',
+        '##ALT=<ID=CNV,Description="Copy number variant">',
+        '##FILTER=<ID=TargetedLowQual,Description="Variant quality below threshold">',
+        '##FILTER=<ID=TargetedRepeatConflict,Description="Read counts inconsistent with an integer copy partition">',
+        '##INFO=<ID=END,Number=1,Type=Integer,Description="End position">',
+        '##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Length of structural variant">',
+        '##INFO=<ID=SVCLAIM,Number=.,Type=String,Description="Claims supported for the structural variant">',
+        '##INFO=<ID=CN,Number=.,Type=Float,Description="Per-haplotype copy number ratio vs reference">',
+        '##INFO=<ID=EVENT,Number=.,Type=String,Description="Event name">',
+        '##INFO=<ID=EVENTTYPE,Number=.,Type=String,Description="Event type">',
+        '##INFO=<ID=TOTAL_CN,Number=1,Type=Float,Description="Total LPA KIV-2 unit copy number (diploid)">',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">',
+        '##FORMAT=<ID=CN,Number=1,Type=Float,Description="Total copy-number ratio">',
+        '##FORMAT=<ID=REPCN,Number=1,Type=String,Description="Per-haplotype repeat unit copy number">',
+        '##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set">',
+    ]
+    for c_name, c_len in contigs:
+        header.append(f"##contig=<ID={c_name},length={c_len}>")
+    header.append(f"#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t{sample_id}")
+
+    rows = [_format_dup_record(chrom, kiv2_start, kiv2_end, ref_base, sample_id, call, n_ref_repeats)]
+    total_cn_int = max(1, int(round(call.kiv2_copy_number)))
+    for v in call.variants:
+        rows.extend(_format_small_variant_record(chrom, v, total_cn_int, kiv2_start))
+
+    text = "\n".join(header + rows) + "\n"
+    opener = gzip.open if str(out_path).endswith(".gz") else open
+    with opener(out_path, "wt") as f:
+        f.write(text)
+
+
+# ----------------------------------------------------------------------------
+# Main entry point
+# ----------------------------------------------------------------------------
+
+
+def _parse_norm_regions(text: str) -> list[tuple[str, int, int]]:
+    out = []
+    for raw in text.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        chrom, rng = token.split(":")
+        start, end = rng.split("-")
+        out.append((chrom, int(start), int(end)))
+    return out
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(prog="lpa_caller", description="LPA KIV-2 VNTR copy number and variant caller")
+    ap.add_argument("--cram", required=True, help="Input CRAM or BAM file (indexed)")
+    ap.add_argument("--reference", required=True, help="Reference FASTA (hg38)")
+    ap.add_argument("--sample-id", required=True, help="Sample identifier emitted in JSON/VCF")
+    ap.add_argument("--output-prefix", required=True, help="Output prefix; writes <prefix>.targeted.{json,vcf.gz}")
+    ap.add_argument("--genome-build", default="hg38")
+    ap.add_argument("--kiv2-chrom", default=DEFAULT_KIV2_CHROM)
+    ap.add_argument("--kiv2-start", type=int, default=DEFAULT_KIV2_START)
+    ap.add_argument("--kiv2-end", type=int, default=DEFAULT_KIV2_END)
+    ap.add_argument("--kiv2-repeat-count", type=int, default=DEFAULT_KIV2_REPEAT_COUNT)
+    ap.add_argument("--kiv2-unit-length", type=int, default=DEFAULT_KIV2_UNIT_LEN)
+    ap.add_argument(
+        "--norm-regions",
+        type=str,
+        default=None,
+        help="Comma-separated chrom:start-end regions used as the autosomal depth baseline. "
+        "Default: 6 x 2 Mb stable regions hardcoded in the module.",
+    )
+    ap.add_argument(
+        "--mean-coverage",
+        type=float,
+        default=None,
+        help="Override the autosomal diploid baseline depth (e.g. DRAGEN-style "
+        "genome-wide mean coverage from external metrics). When set, the panel-"
+        "based normalization is skipped, which is faster and avoids panel bias.",
+    )
+    ap.add_argument(
+        "--no-vcf",
+        action="store_true",
+        help="Skip writing the VCF (JSON only).",
+    )
+    return ap.parse_args(argv)
+
+
+def run(argv: list[str]) -> None:
+    args = _parse_args(argv)
+
+    norm_regions = _parse_norm_regions(args.norm_regions) if args.norm_regions else DEFAULT_NORM_REGIONS
+
+    bam = _open_alignment(args.cram, args.reference)
+    fasta = pysam.FastaFile(args.reference)
+
+    try:
+        markers = [
+            _build_marker(spec, args.kiv2_start, args.kiv2_unit_length, args.kiv2_repeat_count)
+            for spec in DEFAULT_MARKER_VARIANTS
+        ]
+        small_variants = [
+            _build_marker(spec, args.kiv2_start, args.kiv2_unit_length, args.kiv2_repeat_count)
+            for spec in DEFAULT_SMALL_VARIANTS
+        ]
+
+        kiv2_cn = _estimate_total_kiv2_copy_number(
+            bam,
+            fasta,
+            args.kiv2_chrom,
+            args.kiv2_start,
+            args.kiv2_end,
+            args.kiv2_repeat_count,
+            norm_regions,
+            mean_coverage_override=args.mean_coverage,
+        )
+        logger.info("Total KIV-2 copy number (diploid): %.3f", kiv2_cn)
+
+        ref_cn, alt_cn, call_type, _ = _call_heterozygous_markers(bam, fasta, args.kiv2_chrom, markers, kiv2_cn)
+        logger.info("Marker call: %s (ref=%s, alt=%s)", call_type, ref_cn, alt_cn)
+
+        variant_calls = []
+        for var in small_variants:
+            counts = _count_alleles_at_positions(bam, fasta, args.kiv2_chrom, var.positions, var.ref, var.alt)
+            call = _call_small_variant(
+                counts,
+                kiv2_cn,
+                hgvs=var.hgvs,
+                ref_allele=var.ref,
+                alt_allele=var.alt,
+                positions=var.positions,
+            )
+            variant_calls.append(call)
+            logger.info(
+                "Variant %s: alt_cn=%d qual=%.2f (ref=%d alt=%d)",
+                var.hgvs,
+                call.alt_copy_number,
+                call.qual,
+                counts.ref,
+                counts.alt,
+            )
+
+        result = LpaCall(
+            kiv2_copy_number=kiv2_cn,
+            ref_marker_allele_copy_number=ref_cn,
+            alt_marker_allele_copy_number=alt_cn,
+            call_type=call_type,
+            variants=variant_calls,
+        )
+
+        out_prefix = Path(args.output_prefix)
+        out_prefix.parent.mkdir(parents=True, exist_ok=True)
+        json_path = Path(str(out_prefix) + ".targeted.json")
+        _write_json(json_path, args.sample_id, result, args.genome_build)
+        logger.info("Wrote %s", json_path)
+
+        if not args.no_vcf:
+            contigs = list(zip(bam.references, bam.lengths, strict=False))
+            vcf_path = Path(str(out_prefix) + ".targeted.vcf.gz")
+            _write_vcf(
+                vcf_path,
+                args.sample_id,
+                result,
+                args.kiv2_chrom,
+                args.kiv2_start,
+                args.kiv2_end,
+                args.kiv2_repeat_count,
+                fasta,
+                contigs,
+            )
+            logger.info("Wrote %s", vcf_path)
+    finally:
+        bam.close()
+        fasta.close()
+
+
+def main() -> None:
+    run(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -754,14 +754,35 @@ def _write_vcf(
 
 
 def _parse_norm_regions(text: str) -> list[tuple[str, int, int]]:
+    """Parse a comma-separated ``chrom:start-end`` region list with clear errors.
+
+    Raises ``argparse.ArgumentTypeError`` so argparse renders a user-friendly
+    message (without a traceback) on malformed input.
+    """
     out = []
     for raw in text.split(","):
         token = raw.strip()
         if not token:
             continue
-        chrom, rng = token.split(":")
-        start, end = rng.split("-")
-        out.append((chrom, int(start), int(end)))
+        if ":" not in token or "-" not in token.split(":", 1)[1]:
+            raise argparse.ArgumentTypeError(
+                f"invalid region '{token}': expected 'chrom:start-end' (e.g. chr1:50000000-52000000)"
+            )
+        chrom, rng = token.split(":", 1)
+        start_str, end_str = rng.split("-", 1)
+        try:
+            start, end = int(start_str), int(end_str)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(f"invalid region '{token}': start/end must be integers") from exc
+        if start < 1 or end < 1:
+            raise argparse.ArgumentTypeError(
+                f"invalid region '{token}': start/end must be positive 1-based coordinates"
+            )
+        if start > end:
+            raise argparse.ArgumentTypeError(f"invalid region '{token}': start ({start}) must be <= end ({end})")
+        out.append((chrom, start, end))
+    if not out:
+        raise argparse.ArgumentTypeError("no regions parsed from --norm-regions")
     return out
 
 

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -56,9 +56,13 @@ DEFAULT_KIV2_END = 160646997  # 1-based, inclusive
 DEFAULT_KIV2_REPEAT_COUNT = 6
 DEFAULT_KIV2_UNIT_LEN = 5552
 
-# Heterozygous-marker SNV pair (linked across every repeat copy of a haplotype).
-# Per-repeat spacing is irregular (~5543-5552 bp) so explicit positions are used
-# instead of uniform extrapolation.
+# Two heterozygous-marker SNVs (linked across every KIV-2 repeat copy of a
+# haplotype) used ONLY to split the total KIV-2 copy number into the two
+# haplotypes (ref-haplotype-allele copies vs alt-haplotype-allele copies).
+# They are not the LPA "variants of interest" — they're convenient SNPs
+# whose REF/ALT genotype labels which repeat unit belongs to which haplotype.
+# Per-repeat spacing is irregular (~5543-5552 bp) so explicit positions are
+# used instead of uniform extrapolation.
 DEFAULT_MARKER_VARIANTS = [
     {
         "hgvs": "LPA:296T>G",
@@ -74,7 +78,10 @@ DEFAULT_MARKER_VARIANTS = [
     },
 ]
 
-# Small variant sites in the KIV-2 repeat (the two reported LPA variants).
+# Small variant sites in the KIV-2 repeat — the LPA variants we actually want
+# to call (clinically relevant SNVs that contribute to LPA expression). For
+# each site we infer an ALT copy number in [0, total_cn] across the whole
+# KIV-2 array via a binomial fit on the per-site REF/ALT pileup.
 # REF/ALT are genome-strand (LPA gene is on minus strand, hence the C/T pair
 # for variants labeled "G>A"). Per-repeat positions are explicit because the
 # small-variant region uses a slightly different per-repeat spacing than the
@@ -205,20 +212,19 @@ class LpaCall:
 # ----------------------------------------------------------------------------
 
 
-def _build_marker(spec: dict, kiv2_start: int, unit_len: int, n_repeats: int) -> MarkerSpec:
-    """Project a marker onto every repeat copy.
+def _build_marker(spec: dict) -> MarkerSpec:
+    """Build a MarkerSpec from an explicit per-repeat ``positions`` list.
 
-    If the spec provides an explicit ``positions`` list, use it as-is
-    (small variants need this because their per-repeat spacing is not the
-    uniform ``unit_len`` of the marker region). Otherwise extrapolate from
-    ``first_pos`` at fixed ``unit_len`` spacing.
+    The KIV-2 per-repeat spacing is not exactly uniform (~5543-5552 bp), so
+    every marker / small-variant spec must list its positions explicitly
+    — uniform extrapolation from a single ``first_pos`` is not reliable.
     """
-    if "positions" in spec:
-        positions = list(spec["positions"])
-    else:
-        offset = spec["first_pos"] - kiv2_start
-        positions = [kiv2_start + offset + i * unit_len for i in range(n_repeats)]
-    return MarkerSpec(hgvs=spec["hgvs"], ref=spec["ref"], alt=spec["alt"], positions=positions)
+    return MarkerSpec(
+        hgvs=spec["hgvs"],
+        ref=spec["ref"],
+        alt=spec["alt"],
+        positions=list(spec["positions"]),
+    )
 
 
 def _gc_fraction(fasta: pyfaidx.Fasta, chrom: str, start: int, end: int) -> float:
@@ -363,6 +369,7 @@ def _estimate_total_kiv2_copy_number(
     kiv2_end: int,
     n_ref_repeats: int,
     norm_regions: list[tuple[str, int, int]],
+    min_mapq: int = MIN_MAPPING_QUALITY,
 ) -> float:
     """
     Total LPA KIV-2 VNTR unit copy number, summed over the two haplotypes.
@@ -372,7 +379,7 @@ def _estimate_total_kiv2_copy_number(
     Returned value is the per-cell (diploid) repeat-unit count.
     """
     logger.info("Estimating GC-bias profile from %d normalization regions", len(norm_regions))
-    norm_by_gc = _mean_depth_over_bins(bam, fasta, norm_regions)
+    norm_by_gc = _mean_depth_over_bins(bam, fasta, norm_regions, min_mapq=min_mapq)
     # Per-GC-bucket baseline uses a trimmed mean too, for the same reason
     # the overall baseline does.
     gc_baselines = {gc: _trimmed_mean(depths) for gc, depths in norm_by_gc.items() if depths}
@@ -400,8 +407,10 @@ def _estimate_total_kiv2_copy_number(
         corrected.extend(d * scale for d in depths)
     if not corrected:
         raise RuntimeError("No KIV-2 depth bins computed")
-    kiv2_mean = float(np.mean(corrected))
-    logger.info("GC-corrected KIV-2 mean depth: %.2f", kiv2_mean)
+    # Trimmed mean (same fraction as the baseline) drops mappability outliers
+    # near the KIV-2 boundaries / segdup edges, matching the autosomal panel.
+    kiv2_mean = _trimmed_mean(corrected)
+    logger.info("GC-corrected KIV-2 trimmed-mean depth: %.2f", kiv2_mean)
 
     # Ratio * 2 (haplotype copies) * n_ref_repeats (per-allele baseline).
     copy_number = (kiv2_mean / overall_baseline) * 2.0 * n_ref_repeats
@@ -800,10 +809,20 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     ap.add_argument("--kiv2-unit-length", type=int, default=DEFAULT_KIV2_UNIT_LEN)
     ap.add_argument(
         "--norm-regions",
-        type=str,
-        default=None,
+        type=_parse_norm_regions,
+        default=DEFAULT_NORM_REGIONS,
         help="Comma-separated chrom:start-end regions used as the autosomal depth baseline. "
         "Default: 6 x 2 Mb stable regions hardcoded in the module.",
+    )
+    ap.add_argument(
+        "--min-mapq",
+        type=int,
+        default=MIN_MAPPING_QUALITY,
+        help=(
+            f"Min MAPQ for the autosomal depth panel (default {MIN_MAPPING_QUALITY}). "
+            "KIV-2 bins always use MAPQ=0 (most reads multi-map). "
+            "UG flow data may benefit from a lower autosomal threshold."
+        ),
     )
     ap.add_argument(
         "--no-vcf",
@@ -816,91 +835,100 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
 def run(argv: list[str]) -> None:
     args = _parse_args(argv)
 
-    norm_regions = _parse_norm_regions(args.norm_regions) if args.norm_regions else DEFAULT_NORM_REGIONS
+    # argparse normalizes --norm-regions via _parse_norm_regions (clean CLI
+    # error on bad input); a missing flag yields the DEFAULT_NORM_REGIONS list.
+    norm_regions = args.norm_regions
 
     mode = "rc" if args.cram.lower().endswith(".cram") else "rb"
+    # Open both handles inside try/finally so a pyfaidx failure does not leak
+    # the BAM handle (and vice versa).
     bam = pysam.AlignmentFile(args.cram, mode, reference_filename=args.reference)
-    fasta = pyfaidx.Fasta(args.reference)
-
     try:
-        markers = [
-            _build_marker(spec, args.kiv2_start, args.kiv2_unit_length, args.kiv2_repeat_count)
-            for spec in DEFAULT_MARKER_VARIANTS
-        ]
-        small_variants = [
-            _build_marker(spec, args.kiv2_start, args.kiv2_unit_length, args.kiv2_repeat_count)
-            for spec in DEFAULT_SMALL_VARIANTS
-        ]
+        fasta = pyfaidx.Fasta(args.reference)
+        try:
+            markers = [_build_marker(spec) for spec in DEFAULT_MARKER_VARIANTS]
+            small_variants = [_build_marker(spec) for spec in DEFAULT_SMALL_VARIANTS]
 
-        _validate_marker_positions(fasta, args.kiv2_chrom, markers + small_variants, args.genome_build)
+            _validate_marker_positions(fasta, args.kiv2_chrom, markers + small_variants, args.genome_build)
 
-        kiv2_cn = _estimate_total_kiv2_copy_number(
-            bam,
-            fasta,
-            args.kiv2_chrom,
-            args.kiv2_start,
-            args.kiv2_end,
-            args.kiv2_repeat_count,
-            norm_regions,
-        )
-        logger.info("Total KIV-2 copy number (diploid): %.3f", kiv2_cn)
-
-        ref_cn, alt_cn, call_type, _ = _call_heterozygous_markers(bam, args.kiv2_chrom, markers, kiv2_cn)
-        logger.info("Marker call: %s (ref=%s, alt=%s)", call_type, ref_cn, alt_cn)
-
-        variant_calls = []
-        for var in small_variants:
-            counts = _count_alleles_at_positions(bam, args.kiv2_chrom, var.positions, var.ref, var.alt)
-            call = _call_small_variant(
-                counts,
-                kiv2_cn,
-                hgvs=var.hgvs,
-                ref_allele=var.ref,
-                alt_allele=var.alt,
-                positions=var.positions,
-            )
-            variant_calls.append(call)
-            logger.info(
-                "Variant %s: alt_cn=%d qual=%.2f (ref=%d alt=%d)",
-                var.hgvs,
-                call.alt_copy_number,
-                call.qual,
-                counts.ref,
-                counts.alt,
-            )
-
-        result = LpaCall(
-            kiv2_copy_number=kiv2_cn,
-            ref_marker_allele_copy_number=ref_cn,
-            alt_marker_allele_copy_number=alt_cn,
-            call_type=call_type,
-            variants=variant_calls,
-        )
-
-        out_prefix = Path(args.output_prefix)
-        out_prefix.parent.mkdir(parents=True, exist_ok=True)
-        json_path = Path(str(out_prefix) + ".targeted.json")
-        _write_json(json_path, args.sample_id, result, args.genome_build)
-        logger.info("Wrote %s", json_path)
-
-        if not args.no_vcf:
-            contigs = list(zip(bam.references, bam.lengths, strict=False))
-            vcf_path = Path(str(out_prefix) + ".targeted.vcf.gz")
-            _write_vcf(
-                vcf_path,
-                args.sample_id,
-                result,
+            # Stage 1: total KIV-2 unit copy number from GC-corrected depth.
+            kiv2_cn = _estimate_total_kiv2_copy_number(
+                bam,
+                fasta,
                 args.kiv2_chrom,
                 args.kiv2_start,
                 args.kiv2_end,
                 args.kiv2_repeat_count,
-                fasta,
-                contigs,
+                norm_regions,
+                min_mapq=args.min_mapq,
             )
-            logger.info("Wrote %s", vcf_path)
+            logger.info("Total KIV-2 copy number (diploid): %.3f", kiv2_cn)
+
+            # Stage 2: split total CN between the two haplotypes using the
+            # heterozygous-marker SNVs (their ALT fraction tells us what share
+            # of the array carries the alternate haplotype). Output ref/alt CN
+            # are *haplotype* unit counts — not variant calls themselves.
+            ref_cn, alt_cn, call_type, _ = _call_heterozygous_markers(bam, args.kiv2_chrom, markers, kiv2_cn)
+            logger.info("Marker call: %s (ref=%s, alt=%s)", call_type, ref_cn, alt_cn)
+
+            # Stage 3: for each clinically-relevant small variant, count
+            # REF/ALT reads at its per-repeat positions and infer its ALT
+            # copy number in [0, kiv2_cn] via a binomial fit. These are the
+            # actual LPA variant calls emitted in the VCF.
+            variant_calls = []
+            for var in small_variants:
+                counts = _count_alleles_at_positions(bam, args.kiv2_chrom, var.positions, var.ref, var.alt)
+                call = _call_small_variant(
+                    counts,
+                    kiv2_cn,
+                    hgvs=var.hgvs,
+                    ref_allele=var.ref,
+                    alt_allele=var.alt,
+                    positions=var.positions,
+                )
+                variant_calls.append(call)
+                logger.info(
+                    "Variant %s: alt_cn=%d qual=%.2f (ref=%d alt=%d)",
+                    var.hgvs,
+                    call.alt_copy_number,
+                    call.qual,
+                    counts.ref,
+                    counts.alt,
+                )
+
+            result = LpaCall(
+                kiv2_copy_number=kiv2_cn,
+                ref_marker_allele_copy_number=ref_cn,
+                alt_marker_allele_copy_number=alt_cn,
+                call_type=call_type,
+                variants=variant_calls,
+            )
+
+            out_prefix = Path(args.output_prefix)
+            out_prefix.parent.mkdir(parents=True, exist_ok=True)
+            json_path = Path(str(out_prefix) + ".targeted.json")
+            _write_json(json_path, args.sample_id, result, args.genome_build)
+            logger.info("Wrote %s", json_path)
+
+            if not args.no_vcf:
+                contigs = list(zip(bam.references, bam.lengths, strict=False))
+                vcf_path = Path(str(out_prefix) + ".targeted.vcf.gz")
+                _write_vcf(
+                    vcf_path,
+                    args.sample_id,
+                    result,
+                    args.kiv2_chrom,
+                    args.kiv2_start,
+                    args.kiv2_end,
+                    args.kiv2_repeat_count,
+                    fasta,
+                    contigs,
+                )
+                logger.info("Wrote %s", vcf_path)
+        finally:
+            fasta.close()
     finally:
         bam.close()
-        fasta.close()
 
 
 def main() -> None:

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -407,10 +407,8 @@ def _estimate_total_kiv2_copy_number(
         corrected.extend(d * scale for d in depths)
     if not corrected:
         raise RuntimeError("No KIV-2 depth bins computed")
-    # Trimmed mean (same fraction as the baseline) drops mappability outliers
-    # near the KIV-2 boundaries / segdup edges, matching the autosomal panel.
-    kiv2_mean = _trimmed_mean(corrected)
-    logger.info("GC-corrected KIV-2 trimmed-mean depth: %.2f", kiv2_mean)
+    kiv2_mean = float(np.mean(corrected))
+    logger.info("GC-corrected KIV-2 mean depth: %.2f", kiv2_mean)
 
     # Ratio * 2 (haplotype copies) * n_ref_repeats (per-allele baseline).
     copy_number = (kiv2_mean / overall_baseline) * 2.0 * n_ref_repeats

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -139,13 +139,9 @@ KIV2_MIN_MAPPING_QUALITY = 0
 # this, the binomial P(alt|alt_cn=0) collapses to ~1e-85 for any real signal
 # and QUAL pins at the Phred floor.
 #
-# Calibrated separately for SNPs and indels because UG flow chemistry has very
-# different error spectra: SNP substitution errors are rare (~0.1-0.3% per base,
-# ~0.15% on this dataset), while indel errors in homopolymer/short-tandem-repeat
-# contexts can reach ~1%. Using a single 1% floor crushes SNP QUAL by ~5x;
-# using 0.1% for indels would re-admit homopolymer-driven false positives.
-LPA_VARIANT_NOISE_FLOOR_SNP = 0.003
-LPA_VARIANT_NOISE_FLOOR_INDEL = 0.01
+# Calibrated for UG flow chemistry SNP substitution errors (~0.1-0.3% per base,
+# ~0.15% on this dataset). All currently configured small variants are SNVs.
+LPA_VARIANT_NOISE_FLOOR = 0.003
 # Standard VCF QUAL cap.
 MAX_PHRED_QUAL = 99.0
 
@@ -258,6 +254,48 @@ def _bucket_gc(gc: float) -> float:
     """Round GC fraction down to the nearest bucket midpoint."""
     idx = int(gc / GC_BUCKET_WIDTH)
     return (idx + 0.5) * GC_BUCKET_WIDTH
+
+
+def _validate_marker_positions(
+    fasta: pysam.FastaFile,
+    chrom: str,
+    markers: list[MarkerSpec],
+    genome_build: str,
+) -> None:
+    """Fail fast if the configured REF base does not match the reference FASTA.
+
+    The default marker / small-variant positions are hg38 coordinates. If a
+    different reference build is supplied without overriding the positions on
+    the CLI, the caller would otherwise silently call against the wrong sites.
+    """
+    try:
+        contigs = set(fasta.references)
+    except Exception:  # pragma: no cover - older pysam without .references
+        contigs = set()
+    if contigs and chrom not in contigs:
+        raise RuntimeError(
+            f"Reference FASTA does not contain contig {chrom!r}. "
+            f"If your reference is not {genome_build}, override --kiv2-chrom and the "
+            "marker / small-variant positions on the command line."
+        )
+
+    mismatches: list[str] = []
+    for m in markers:
+        for pos in m.positions:
+            base = fasta.fetch(chrom, pos - 1, pos).upper()
+            if base != m.ref.upper():
+                mismatches.append(f"{m.hgvs} {chrom}:{pos} expected {m.ref} got {base or 'N/A'}")
+
+    if mismatches:
+        max_preview = 5
+        preview = "; ".join(mismatches[:max_preview])
+        more = f" (+{len(mismatches) - max_preview} more)" if len(mismatches) > max_preview else ""
+        raise RuntimeError(
+            "Marker REF bases do not match the reference FASTA — the configured "
+            f"positions are {genome_build} coordinates and look wrong for this reference. "
+            "Override --kiv2-chrom / --kiv2-start / --kiv2-end / --kiv2-unit-length, or "
+            f"supply a {genome_build} reference. Mismatches: {preview}{more}"
+        )
 
 
 # ----------------------------------------------------------------------------
@@ -497,14 +535,6 @@ def _phred(p: float) -> float:
     return min(-10.0 * math.log10(p), MAX_PHRED_QUAL)
 
 
-def _noise_floor_for(ref_allele: str, alt_allele: str) -> float:
-    """SNP vs indel noise floor selector. Anything that isn't a single-base
-    substitution is treated as indel-like."""
-    if len(ref_allele) == 1 and len(alt_allele) == 1:
-        return LPA_VARIANT_NOISE_FLOOR_SNP
-    return LPA_VARIANT_NOISE_FLOOR_INDEL
-
-
 def _call_small_variant(
     counts: AlleleCounts,
     kiv2_copy_number: float,
@@ -533,7 +563,7 @@ def _call_small_variant(
             alt_allele=alt_allele,
         )
 
-    noise = _noise_floor_for(ref_allele, alt_allele)
+    noise = LPA_VARIANT_NOISE_FLOOR
     log_liks = []
     for alt_cn in range(total_cn + 1):
         # Mix the ideal alt fraction with a flat noise floor so the alt_cn=0
@@ -794,6 +824,8 @@ def run(argv: list[str]) -> None:
             _build_marker(spec, args.kiv2_start, args.kiv2_unit_length, args.kiv2_repeat_count)
             for spec in DEFAULT_SMALL_VARIANTS
         ]
+
+        _validate_marker_positions(fasta, args.kiv2_chrom, markers + small_variants, args.genome_build)
 
         kiv2_cn = _estimate_total_kiv2_copy_number(
             bam,

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -23,8 +23,19 @@
 #         likelihood across all possible ALT copy-number values bounded by the
 #         total KIV-2 copy number.
 #
-#    Outputs <prefix>.targeted.json and <prefix>.targeted.vcf(.gz) containing
-#    the LPA results only.
+#    Outputs (all prefixed with ``<prefix>.targeted.``):
+#      * ``json`` — full call payload (copy numbers, per-variant details).
+#      * ``vcf.gz`` (+ ``.tbi``) — bgzipped, tabix-indexed VCF containing the
+#        KIV-2 symbolic CNV record and one row per reference repeat copy for
+#        each LPA small variant.
+#      * ``small_variants.vcf.gz`` (+ ``.tbi``) — same VCF with the symbolic
+#        CNV row filtered out (small variants only).
+#      * ``acnv.bed`` — aggregated CNV in the ``#gffTags`` 4-column BED format
+#        used by parascopy ``reformat_parascopy_bed`` (single row summarizing
+#        the total KIV-2 unit count).
+#      * ``pcnv.bed`` — paralog CNV in the same ``#gffTags`` format. Two
+#        overlapping rows (one per haplotype) when marker calling was phased,
+#        a single row otherwise.
 #
 
 from __future__ import annotations
@@ -723,6 +734,8 @@ def _write_vcf(
     n_ref_repeats: int,
     fasta: pyfaidx.Fasta,
     contigs: list[tuple[str, int]],
+    *,
+    small_variants_only: bool = False,
 ) -> None:
     ref_base = str(fasta[chrom][kiv2_start - 1 : kiv2_start]).upper() or "N"
     header = [
@@ -750,7 +763,9 @@ def _write_vcf(
         header.append(f"##contig=<ID={c_name},length={c_len}>")
     header.append(f"#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t{sample_id}")
 
-    rows = [_format_dup_record(chrom, kiv2_start, kiv2_end, ref_base, sample_id, call, n_ref_repeats)]
+    rows = []
+    if not small_variants_only:
+        rows.append(_format_dup_record(chrom, kiv2_start, kiv2_end, ref_base, sample_id, call, n_ref_repeats))
     total_cn_int = max(1, int(round(call.kiv2_copy_number)))
     small_rows = []
     for v in call.variants:
@@ -765,9 +780,76 @@ def _write_vcf(
     if str(out_path).endswith(".gz"):
         with pysam.BGZFile(str(out_path), "w") as f:
             f.write(text.encode())
+        pysam.tabix_index(str(out_path), preset="vcf", force=True)
     else:
         with open(out_path, "w") as f:
             f.write(text)
+
+
+# ----------------------------------------------------------------------------
+# BED writers (parascopy #gffTags 4-column format, chrom/start/end/tags)
+#
+# Coordinates match the LPA caller's 1-based inclusive [kiv2_start, kiv2_end]
+# convention: BED start is (kiv2_start - 1) (0-based), BED end is kiv2_end
+# (BED end is exclusive but numerically equals the 1-based inclusive end).
+# ----------------------------------------------------------------------------
+
+
+def _write_acnv_bed(
+    out_path: Path,
+    sample_id: str,
+    call: LpaCall,
+    chrom: str,
+    kiv2_start: int,
+    kiv2_end: int,
+) -> None:
+    """Single aggregated row summarizing total KIV-2 unit copy number."""
+    total_units = int(round(call.kiv2_copy_number))
+    tags = [
+        "locus=LPA-KIV2",
+        f"sample={sample_id}",
+        "agCN_filter=PASS",
+        f"agCN={total_units}",
+        "agCN_qual=.",
+    ]
+    with out_path.open("w") as f:
+        f.write("#gffTags\n")
+        f.write(f"{chrom}\t{kiv2_start - 1}\t{kiv2_end}\t{';'.join(tags)}\n")
+
+
+def _write_pcnv_bed(
+    out_path: Path,
+    sample_id: str,
+    call: LpaCall,
+    chrom: str,
+    kiv2_start: int,
+    kiv2_end: int,
+) -> None:
+    """Per-haplotype rows. Two overlapping rows when phased, one otherwise."""
+    total_units = int(round(call.kiv2_copy_number))
+    main_region = f"{chrom}:{kiv2_start}-{kiv2_end}"
+    phased = call.ref_marker_allele_copy_number is not None and call.alt_marker_allele_copy_number is not None
+    with out_path.open("w") as f:
+        f.write("#gffTags\n")
+        if phased:
+            per_hap_units = (
+                int(round(call.ref_marker_allele_copy_number)),
+                int(round(call.alt_marker_allele_copy_number)),
+            )
+        else:
+            per_hap_units = (total_units,)
+        for units in per_hap_units:
+            tags = [
+                f"sample={sample_id}",
+                "cn_filter=PASS",
+                f"cn={units}",
+                "cn_qual=.",
+                "agcn_filter=PASS",
+                f"agcn={total_units}",
+                "agcn_qual=.",
+                f"main_region={main_region}",
+            ]
+            f.write(f"{chrom}\t{kiv2_start - 1}\t{kiv2_end}\t{';'.join(tags)}\n")
 
 
 # ----------------------------------------------------------------------------
@@ -813,7 +895,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     ap.add_argument("--cram", required=True, help="Input CRAM or BAM file (indexed)")
     ap.add_argument("--reference", required=True, help="Reference FASTA (hg38)")
     ap.add_argument("--sample-id", required=True, help="Sample identifier emitted in JSON/VCF")
-    ap.add_argument("--output-prefix", required=True, help="Output prefix; writes <prefix>.targeted.{json,vcf.gz}")
+    ap.add_argument(
+        "--output-prefix",
+        required=True,
+        help=(
+            "Output prefix; writes <prefix>.targeted.{json, vcf.gz(+.tbi), "
+            "small_variants.vcf.gz(+.tbi), acnv.bed, pcnv.bed}"
+        ),
+    )
     ap.add_argument("--genome-build", default="hg38")
     ap.add_argument("--kiv2-chrom", default=DEFAULT_KIV2_CHROM)
     ap.add_argument("--kiv2-start", type=int, default=DEFAULT_KIV2_START)
@@ -839,7 +928,12 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     ap.add_argument(
         "--no-vcf",
         action="store_true",
-        help="Skip writing the VCF (JSON only).",
+        help="Skip writing the VCF outputs (JSON and BED still emitted).",
+    )
+    ap.add_argument(
+        "--no-bed",
+        action="store_true",
+        help="Skip writing the acnv/pcnv BED outputs.",
     )
     return ap.parse_args(argv)
 
@@ -937,6 +1031,28 @@ def run(argv: list[str]) -> None:
                     contigs,
                 )
                 logger.info("Wrote %s", vcf_path)
+                small_vcf_path = Path(str(out_prefix) + ".targeted.small_variants.vcf.gz")
+                _write_vcf(
+                    small_vcf_path,
+                    args.sample_id,
+                    result,
+                    args.kiv2_chrom,
+                    args.kiv2_start,
+                    args.kiv2_end,
+                    args.kiv2_repeat_count,
+                    fasta,
+                    contigs,
+                    small_variants_only=True,
+                )
+                logger.info("Wrote %s", small_vcf_path)
+
+            if not args.no_bed:
+                acnv_path = Path(str(out_prefix) + ".targeted.acnv.bed")
+                _write_acnv_bed(acnv_path, args.sample_id, result, args.kiv2_chrom, args.kiv2_start, args.kiv2_end)
+                logger.info("Wrote %s", acnv_path)
+                pcnv_path = Path(str(out_prefix) + ".targeted.pcnv.bed")
+                _write_pcnv_bed(pcnv_path, args.sample_id, result, args.kiv2_chrom, args.kiv2_start, args.kiv2_end)
+                logger.info("Wrote %s", pcnv_path)
         finally:
             fasta.close()
     finally:

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -615,17 +615,26 @@ def _format_dup_record(
     call: LpaCall,
     n_ref_repeats: int,
 ) -> str:
-    """Single <DUP> SV record summarizing total + per-haplotype KIV-2 copy numbers.
+    """Single symbolic SV record summarizing total + per-haplotype KIV-2 copy numbers.
 
-    A single symbolic ALT (<DUP>) is used instead of <DUP>,<DUP> because the
-    duplicate-ALT form is ambiguous to common VCF parsers. SVTYPE=DUP keeps
-    the record compatible with downstream merge logic that filters on
-    SVTYPE in {DEL,DUP}. Per-haplotype unit counts are reported via
-    FORMAT/REPCN, total via FORMAT/CN and INFO/TOTAL_CN.
+    SVTYPE/ALT are chosen relative to the diploid reference baseline
+    (``2 * n_ref_repeats``): a sample with fewer total KIV-2 units than the
+    reference is emitted as ``<DEL>`` (``SVTYPE=DEL``), more units as ``<DUP>``
+    (``SVTYPE=DUP``). A single symbolic ALT is used instead of duplicated ALTs
+    because the duplicate-ALT form is ambiguous to common VCF parsers.
+    Per-haplotype unit counts are reported via FORMAT/REPCN, total via
+    FORMAT/CN and INFO/TOTAL_CN.
     """
     # start/end are 1-based inclusive (KIV-2: chr6:160613491-160646997 = 33507 bp).
     sv_len = end - start + 1
     total_cn = call.kiv2_copy_number
+    diploid_baseline = 2 * n_ref_repeats
+    if total_cn < diploid_baseline:
+        svtype = "DEL"
+        alt = "<DEL>"
+    else:
+        svtype = "DUP"
+        alt = "<DUP>"
     if call.ref_marker_allele_copy_number is not None and call.alt_marker_allele_copy_number is not None:
         cn1 = call.ref_marker_allele_copy_number / n_ref_repeats
         cn2 = call.alt_marker_allele_copy_number / n_ref_repeats
@@ -635,12 +644,12 @@ def _format_dup_record(
         cn_info = "."
         repcn = ".|."
     info = (
-        f"SVTYPE=DUP;SVCLAIM=D;END={end};SVLEN={sv_len};CN={cn_info};"
+        f"SVTYPE={svtype};SVCLAIM=D;END={end};SVLEN={sv_len};CN={cn_info};"
         f"EVENT=LPA:KIV2;EVENTTYPE=VNTR;TOTAL_CN={total_cn:.6f}"
     )
     fmt = "GT:CN:REPCN:PS"
     sample_field = f"0/1:{total_cn:.6f}:{repcn}:{start}"
-    return f"{chrom}\t{start}\t.\t{ref_base}\t<DUP>\t.\tPASS\t{info}\t{fmt}\t{sample_field}"
+    return f"{chrom}\t{start}\t.\t{ref_base}\t{alt}\t.\tPASS\t{info}\t{fmt}\t{sample_field}"
 
 
 def _format_small_variant_record(
@@ -698,6 +707,7 @@ def _write_vcf(
         "##fileformat=VCFv4.2",
         "##source=ugbio_cnv.lpa_caller",
         '##ALT=<ID=DUP,Description="Duplication relative to the reference">',
+        '##ALT=<ID=DEL,Description="Deletion relative to the reference">',
         '##FILTER=<ID=TargetedLowQual,Description="Variant quality below threshold">',
         '##FILTER=<ID=TargetedRepeatConflict,Description="Read counts inconsistent with an integer copy partition">',
         '##INFO=<ID=END,Number=1,Type=Integer,Description="End position">',

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -132,7 +132,7 @@ REPEAT_CONFLICT_RESIDUAL = 0.05
 HET_MARKER_ALT_FRACTION_MIN = 0.10
 HET_MARKER_ALT_FRACTION_MAX = 0.90
 
-MIN_BASE_QUALITY = 20
+MIN_BASE_QUALITY = 1
 MIN_MAPPING_QUALITY = 10
 # KIV-2 is a 6-copy VNTR: ~90% of reads have MAPQ=0 because they multi-map
 # across the reference repeat units. They must not be filtered out; doing so

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -736,14 +736,14 @@ def _write_vcf(
         '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">',
         '##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Length of structural variant">',
         '##INFO=<ID=SVCLAIM,Number=1,Type=String,Description="Claims supported for the structural variant (D=depth)">',
-        '##INFO=<ID=CN,Number=.,Type=Float,Description="Per-haplotype copy number ratio vs reference">',
+        '##INFO=<ID=CN,Number=A,Type=Float,Description="Copy number of CNV / breakpoint">',
         '##INFO=<ID=EVENT,Number=1,Type=String,Description="Event name">',
         '##INFO=<ID=EVENTTYPE,Number=1,Type=String,Description="Event type">',
         '##INFO=<ID=TOTAL_CN,Number=1,Type=Float,Description="Total LPA KIV-2 unit copy number (diploid)">',
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
         '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">',
-        '##FORMAT=<ID=CN,Number=1,Type=Float,Description="Total LPA KIV-2 unit copy number (diploid)">',
-        '##FORMAT=<ID=REPCN,Number=1,Type=String,Description="Per-haplotype repeat unit copy number">',
+        '##FORMAT=<ID=CN,Number=1,Type=Float,Description="Estimated copy number">',
+        '##FORMAT=<ID=REPCN,Number=1,Type=String,Description="Number of repeat units spanned by the allele">',
         '##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phase set">',
     ]
     for c_name, c_len in contigs:

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -895,6 +895,14 @@ def _parse_norm_regions(text: str) -> list[tuple[str, int, int]]:
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     ap = argparse.ArgumentParser(prog="lpa_caller", description="LPA KIV-2 VNTR copy number and variant caller")
     ap.add_argument("--cram", required=True, help="Input CRAM or BAM file (indexed)")
+    ap.add_argument(
+        "--crai",
+        default=None,
+        help=(
+            "Path to the CRAM/BAM index. If omitted, htslib looks for an index next to --cram "
+            "(<cram>.crai/<cram>.bai). Use this to read from a read-only mount without staging."
+        ),
+    )
     ap.add_argument("--reference", required=True, help="Reference FASTA (hg38)")
     ap.add_argument("--sample-id", required=True, help="Sample identifier emitted in JSON/VCF")
     ap.add_argument(
@@ -950,7 +958,10 @@ def run(argv: list[str]) -> None:
     mode = "rc" if args.cram.lower().endswith(".cram") else "rb"
     # Open both handles inside try/finally so a pyfaidx failure does not leak
     # the BAM handle (and vice versa).
-    bam = pysam.AlignmentFile(args.cram, mode, reference_filename=args.reference)
+    open_kwargs = {"reference_filename": args.reference}
+    if args.crai is not None:
+        open_kwargs["index_filename"] = args.crai
+    bam = pysam.AlignmentFile(args.cram, mode, **open_kwargs)
     try:
         fasta = pyfaidx.Fasta(args.reference)
         try:

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -9,9 +9,7 @@
 # DESCRIPTION
 #    LPA Caller for Ultima Genomics WGS data.
 #
-#    Re-implementation of the Illumina DRAGEN LPA targeted caller
-#    (https://help.dragen.illumina.com/dragen-v4.5/product-guides/dragen-v4.5/
-#     dragen-dna-pipeline/targeted-caller/lpa-calling) on a single CRAM/BAM.
+#    Targeted caller for the LPA KIV-2 VNTR on a single CRAM/BAM.
 #
 #    Three steps:
 #      1. Estimate the total LPA KIV-2 VNTR unit copy number from depth in the
@@ -25,13 +23,9 @@
 #         likelihood across all possible ALT copy-number values bounded by the
 #         total KIV-2 copy number.
 #
-#    Outputs <prefix>.targeted.json and <prefix>.targeted.vcf(.gz), restricted
-#    to the LPA section (DRAGEN packs PGx star-allele + LPA + HBA + RH into the
-#    same files; here we emit LPA only).
+#    Outputs <prefix>.targeted.json and <prefix>.targeted.vcf(.gz) containing
+#    the LPA results only.
 #
-#    Default constants (hg38 coordinates, repeat unit length, marker variants)
-#    are taken from public DRAGEN documentation example output and the LPA
-#    literature. Any can be overridden from the command line.
 
 from __future__ import annotations
 
@@ -56,7 +50,7 @@ logger = logging.getLogger("lpa_caller")
 # Defaults (hg38). All overridable via CLI.
 # ----------------------------------------------------------------------------
 
-# DRAGEN anchors the reference KIV-2 array at chr6:160613491-160646997
+# Reference KIV-2 array on hg38: chr6:160613491-160646997
 # (33507 bp, 6 repeat units of ~5552 bp).
 DEFAULT_KIV2_CHROM = "chr6"
 DEFAULT_KIV2_START = 160613491  # 1-based, inclusive
@@ -82,11 +76,11 @@ DEFAULT_MARKER_VARIANTS = [
     },
 ]
 
-# Small variant sites in the KIV-2 repeat (DRAGEN's two reported LPA variants).
+# Small variant sites in the KIV-2 repeat (the two reported LPA variants).
 # REF/ALT are genome-strand (LPA gene is on minus strand, hence the C/T pair
-# for variants DRAGEN labels "G>A"). Per-repeat positions are explicit because
-# the small-variant region uses a slightly different per-repeat spacing than
-# the marker region, and DRAGEN omits repeat 4 of LPA:4925G>A.
+# for variants labeled "G>A"). Per-repeat positions are explicit because the
+# small-variant region uses a slightly different per-repeat spacing than the
+# marker region, and repeat 4 of LPA:4925G>A is omitted.
 DEFAULT_SMALL_VARIANTS = [
     {
         "hgvs": "LPA:4925G>A",
@@ -120,8 +114,8 @@ GC_BIN_SIZE = 1000
 # GC bucket width (fraction): 0.05 -> 20 buckets between 0 and 1.
 GC_BUCKET_WIDTH = 0.05
 
-# Variant filter thresholds, matching the spirit of DRAGEN's TargetedLowQual /
-# TargetedRepeatConflict tags.
+# Variant filter thresholds for the TargetedLowQual / TargetedRepeatConflict
+# tags emitted on the small-variant rows.
 LOW_QUAL_THRESHOLD = 10.0
 # Residual ALT-count fraction above which the integer copy partition is flagged
 # as inconsistent and the TargetedRepeatConflict filter is applied.
@@ -136,8 +130,8 @@ HET_MARKER_ALT_FRACTION_MAX = 0.90
 MIN_BASE_QUALITY = 20
 MIN_MAPPING_QUALITY = 10
 # KIV-2 is a 6-copy VNTR: ~90% of reads have MAPQ=0 because they multi-map
-# across the reference repeat units. DRAGEN's targeted caller does not filter
-# them out; doing so collapses observed KIV-2 depth ~10x and breaks total CN.
+# across the reference repeat units. They must not be filtered out; doing so
+# collapses observed KIV-2 depth ~10x and breaks total CN.
 KIV2_MIN_MAPPING_QUALITY = 0
 
 # Per-base noise floor for small-variant calling: combined sequencing error and
@@ -147,10 +141,9 @@ KIV2_MIN_MAPPING_QUALITY = 0
 #
 # Calibrated separately for SNPs and indels because UG flow chemistry has very
 # different error spectra: SNP substitution errors are rare (~0.1-0.3% per base,
-# matching DRAGEN's implicit ~0.15% scale on this dataset), while indel errors
-# in homopolymer/short-tandem-repeat contexts can reach ~1%. Using a single
-# 1% floor crushes SNP QUAL by ~5x relative to DRAGEN; using 0.1% for indels
-# would re-admit homopolymer-driven false positives.
+# ~0.15% on this dataset), while indel errors in homopolymer/short-tandem-repeat
+# contexts can reach ~1%. Using a single 1% floor crushes SNP QUAL by ~5x;
+# using 0.1% for indels would re-admit homopolymer-driven false positives.
 LPA_VARIANT_NOISE_FLOOR_SNP = 0.003
 LPA_VARIANT_NOISE_FLOOR_INDEL = 0.01
 # Standard VCF QUAL cap.
@@ -358,8 +351,8 @@ def _estimate_total_kiv2_copy_number(
     Returned value is the per-cell (diploid) repeat-unit count.
 
     If ``mean_coverage_override`` is given, that value is used as the diploid
-    baseline and the panel-based estimation is skipped (use it to feed in
-    DRAGEN-style genome-wide mean coverage from external metrics).
+    baseline and the panel-based estimation is skipped (use it to feed in a
+    genome-wide mean coverage from external metrics).
     """
     if mean_coverage_override is not None:
         if mean_coverage_override <= 0:
@@ -560,8 +553,8 @@ def _call_small_variant(
 
     # QUAL is the Phred-scaled posterior that a variant IS present, i.e.
     # -10*log10(P(alt_cn=0)). When the best call IS alt_cn=0, P(alt_cn=0)
-    # ~= 1 and that formula collapses to ~0, which is misleading. Match the
-    # standard VCF convention (and DRAGEN) by reporting 0.0 in that case.
+    # ~= 1 and that formula collapses to ~0, which is misleading. Follow the
+    # standard VCF convention and report 0.0 in that case.
     if best == 0:
         qual = 0.0
     else:
@@ -772,9 +765,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         "--mean-coverage",
         type=float,
         default=None,
-        help="Override the autosomal diploid baseline depth (e.g. DRAGEN-style "
-        "genome-wide mean coverage from external metrics). When set, the panel-"
-        "based normalization is skipped, which is faster and avoids panel bias.",
+        help="Override the autosomal diploid baseline depth (e.g. a genome-wide "
+        "mean coverage from external metrics). When set, the panel-based "
+        "normalization is skipped, which is faster and avoids panel bias.",
     )
     ap.add_argument(
         "--no-vcf",

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -40,11 +40,12 @@ import numpy as np
 import pyfaidx
 import pysam
 from ugbio_core.logger import logger
-from ugbio_core.math_utils import log_binomial
-from ugbio_core.math_utils import phred as core_phred
+from ugbio_core.math_utils import log_binomial, phred
 
 # ----------------------------------------------------------------------------
-# LPA caller defaults (hg38). All overridable via CLI.
+# LPA caller defaults (hg38). The KIV-2 array coordinates and the autosomal
+# normalization regions are overridable via CLI; the marker and small-variant
+# site lists are hg38-specific and hard-coded (no CLI override).
 # ----------------------------------------------------------------------------
 
 # Reference KIV-2 array on hg38: chr6:160613491-160646997
@@ -250,16 +251,16 @@ def _validate_marker_positions(
 ) -> None:
     """Fail fast if the configured REF base does not match the reference FASTA.
 
-    The default marker / small-variant positions are hg38 coordinates. If a
-    different reference build is supplied without overriding the positions on
-    the CLI, the caller would otherwise silently call against the wrong sites.
+    The marker / small-variant positions are hard-coded hg38 coordinates and
+    are not overridable on the CLI. If a different reference build is supplied,
+    the caller would otherwise silently call against the wrong sites.
     """
     contigs = set(fasta.keys())
     if chrom not in contigs:
         raise RuntimeError(
             f"Reference FASTA does not contain contig {chrom!r}. "
-            f"If your reference is not {genome_build}, override --kiv2-chrom and the "
-            "marker / small-variant positions on the command line."
+            f"The marker / small-variant positions are hard-coded {genome_build} coordinates; "
+            f"supply a {genome_build} reference."
         )
 
     mismatches: list[str] = []
@@ -274,10 +275,9 @@ def _validate_marker_positions(
         preview = "; ".join(mismatches[:max_preview])
         more = f" (+{len(mismatches) - max_preview} more)" if len(mismatches) > max_preview else ""
         raise RuntimeError(
-            "Marker REF bases do not match the reference FASTA — the configured "
+            "Marker REF bases do not match the reference FASTA — the hard-coded "
             f"positions are {genome_build} coordinates and look wrong for this reference. "
-            "Override --kiv2-chrom / --kiv2-start / --kiv2-end / --kiv2-unit-length, or "
-            f"supply a {genome_build} reference. Mismatches: {preview}{more}"
+            f"Supply a {genome_build} reference. Mismatches: {preview}{more}"
         )
 
 
@@ -319,6 +319,7 @@ def _mean_depth_over_bins(
                 or read.is_secondary
                 or read.is_supplementary
                 or read.is_duplicate
+                or read.is_qcfail
                 or read.mapping_quality < min_mapq
             ):
                 continue
@@ -362,7 +363,6 @@ def _estimate_total_kiv2_copy_number(
     kiv2_end: int,
     n_ref_repeats: int,
     norm_regions: list[tuple[str, int, int]],
-    mean_coverage_override: float | None = None,
 ) -> float:
     """
     Total LPA KIV-2 VNTR unit copy number, summed over the two haplotypes.
@@ -370,32 +370,21 @@ def _estimate_total_kiv2_copy_number(
     With 6 reference repeat units and a perfectly diploid reference call, KIV-2
     bin depth equals the autosomal mean depth and the returned value is 2*6=12.
     Returned value is the per-cell (diploid) repeat-unit count.
-
-    If ``mean_coverage_override`` is given, that value is used as the diploid
-    baseline and the panel-based estimation is skipped (use it to feed in a
-    genome-wide mean coverage from external metrics).
     """
-    if mean_coverage_override is not None:
-        if mean_coverage_override <= 0:
-            raise ValueError("mean_coverage_override must be positive")
-        overall_baseline = float(mean_coverage_override)
-        gc_medians: dict[float, float] = {}
-        logger.info("Using user-supplied autosomal mean coverage: %.2f", overall_baseline)
-    else:
-        logger.info("Estimating GC-bias profile from %d normalization regions", len(norm_regions))
-        norm_by_gc = _mean_depth_over_bins(bam, fasta, norm_regions)
-        # Per-GC-bucket baseline uses a trimmed mean too, for the same reason
-        # the overall baseline does.
-        gc_medians = {gc: _trimmed_mean(depths) for gc, depths in norm_by_gc.items() if depths}
-        all_depths = [d for depths in norm_by_gc.values() for d in depths]
-        overall_baseline = _trimmed_mean(all_depths)
-        if overall_baseline <= 0:
-            raise RuntimeError("Normalization regions have zero coverage; check input/reference")
-        logger.info(
-            "Autosomal trimmed-mean depth (drop %.0f%% each tail): %.2f",
-            100 * NORM_TRIM_FRACTION,
-            overall_baseline,
-        )
+    logger.info("Estimating GC-bias profile from %d normalization regions", len(norm_regions))
+    norm_by_gc = _mean_depth_over_bins(bam, fasta, norm_regions)
+    # Per-GC-bucket baseline uses a trimmed mean too, for the same reason
+    # the overall baseline does.
+    gc_medians = {gc: _trimmed_mean(depths) for gc, depths in norm_by_gc.items() if depths}
+    all_depths = [d for depths in norm_by_gc.values() for d in depths]
+    overall_baseline = _trimmed_mean(all_depths)
+    if overall_baseline <= 0:
+        raise RuntimeError("Normalization regions have zero coverage; check input/reference")
+    logger.info(
+        "Autosomal trimmed-mean depth (drop %.0f%% each tail): %.2f",
+        100 * NORM_TRIM_FRACTION,
+        overall_baseline,
+    )
 
     # KIV-2 binned depth, GC-corrected against the normalization profile.
     # MAPQ filter is dropped here: most KIV-2 reads multi-map (MAPQ=0).
@@ -438,6 +427,10 @@ def _count_alleles_at_positions(
     start = min(positions) - 1
     end = max(positions)
     pos_set = set(positions)
+    # Normalize to uppercase so lowercase query bases (soft-masked reference,
+    # some aligners) match the configured REF/ALT and don't fall into 'other'.
+    ref_upper = ref_allele.upper()
+    alt_upper = alt_allele.upper()
     # KIV-2 reads multi-map -> use the KIV-2 MAPQ floor, not the autosomal one.
     for column in bam.pileup(
         chrom,
@@ -461,10 +454,10 @@ def _count_alleles_at_positions(
             # stays correct if the stepper / pileup options ever change.
             if aln.is_secondary or aln.is_supplementary or aln.is_duplicate or aln.is_qcfail or aln.is_unmapped:
                 continue
-            base = aln.query_sequence[read.query_position]
-            if base == ref_allele:
+            base = aln.query_sequence[read.query_position].upper()
+            if base == ref_upper:
                 counts.ref += 1
-            elif base == alt_allele:
+            elif base == alt_upper:
                 counts.alt += 1
             else:
                 counts.other += 1
@@ -509,19 +502,6 @@ def _call_heterozygous_markers(
 # ----------------------------------------------------------------------------
 
 
-def _log_binomial(n: int, k: int, p: float) -> float:
-    # Thin module-local alias for ugbio_core.math_utils.log_binomial; kept so
-    # existing unit tests under the _log_binomial name continue to work.
-    return log_binomial(n, k, p)
-
-
-def _phred(p: float) -> float:
-    # Thin wrapper around ugbio_core.math_utils.phred that clamps to a finite
-    # Phred range (the core helper returns +/- inf for p in {0, 1}).
-    p = max(min(p, 1 - 1e-15), 1e-15)
-    return min(float(core_phred([p])[0]), MAX_PHRED_QUAL)
-
-
 def _call_small_variant(
     counts: AlleleCounts,
     kiv2_copy_number: float,
@@ -558,7 +538,7 @@ def _call_small_variant(
         # being assigned probability 0.
         ideal = alt_cn / total_cn
         p_alt = ideal * (1.0 - noise) + (1.0 - ideal) * noise
-        log_liks.append(_log_binomial(n, counts.alt, p_alt))
+        log_liks.append(log_binomial(n, counts.alt, p_alt))
 
     log_liks = np.array(log_liks)
     # Posterior under uniform prior.
@@ -575,9 +555,13 @@ def _call_small_variant(
     if best == 0:
         qual = 0.0
     else:
-        qual = _phred(float(post[0]))
+        # Clamp p away from 0 so phred() does not return +inf, then cap at
+        # the VCF QUAL ceiling.
+        p0 = min(max(float(post[0]), 1e-15), 1 - 1e-15)
+        qual = min(float(phred([p0])[0]), MAX_PHRED_QUAL)
 
-    alt_cn_quality = _phred(1.0 - best_post)
+    p_resid = min(max(1.0 - best_post, 1e-15), 1 - 1e-15)
+    alt_cn_quality = min(float(phred([p_resid])[0]), MAX_PHRED_QUAL)
 
     return SmallVariantCall(
         hgvs=hgvs,
@@ -791,14 +775,6 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         "Default: 6 x 2 Mb stable regions hardcoded in the module.",
     )
     ap.add_argument(
-        "--mean-coverage",
-        type=float,
-        default=None,
-        help="Override the autosomal diploid baseline depth (e.g. a genome-wide "
-        "mean coverage from external metrics). When set, the panel-based "
-        "normalization is skipped, which is faster and avoids panel bias.",
-    )
-    ap.add_argument(
         "--no-vcf",
         action="store_true",
         help="Skip writing the VCF (JSON only).",
@@ -835,7 +811,6 @@ def run(argv: list[str]) -> None:
             args.kiv2_end,
             args.kiv2_repeat_count,
             norm_regions,
-            mean_coverage_override=args.mean_coverage,
         )
         logger.info("Total KIV-2 copy number (diploid): %.3f", kiv2_cn)
 

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -492,13 +492,28 @@ def _call_heterozygous_markers(
     if total_informative == 0:
         return None, None, "No coverage at marker sites", per_marker_counts
 
-    alt_fraction = total_alt / total_informative
-    # ALT-allele evidence threshold (>=10% reads supports a heterozygous call).
-    if alt_fraction < HET_MARKER_ALT_FRACTION_MIN:
+    # Classify each informative marker independently so that a
+    # hom-REF / hom-ALT combination does not silently average into a false
+    # heterozygous split (pooling would give ~0.5 ALT fraction).
+    def _classify(f: float) -> str:
+        if f < HET_MARKER_ALT_FRACTION_MIN:
+            return "hom_ref"
+        if f > HET_MARKER_ALT_FRACTION_MAX:
+            return "hom_alt"
+        return "het"
+
+    per_marker_states = [_classify(c.alt / c.informative) for c in per_marker_counts if c.informative > 0]
+    unique_states = set(per_marker_states)
+    if len(unique_states) > 1:
+        return None, None, "Marker sites disagree", per_marker_counts
+
+    (state,) = unique_states
+    if state == "hom_ref":
         return None, None, "Homozygous REF markers call", per_marker_counts
-    if alt_fraction > HET_MARKER_ALT_FRACTION_MAX:
+    if state == "hom_alt":
         return None, None, "Homozygous ALT markers call", per_marker_counts
 
+    alt_fraction = total_alt / total_informative
     alt_cn = kiv2_copy_number * alt_fraction
     ref_cn = kiv2_copy_number - alt_cn
     return ref_cn, alt_cn, "Heterozygous markers call", per_marker_counts
@@ -804,7 +819,6 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     ap.add_argument("--kiv2-start", type=int, default=DEFAULT_KIV2_START)
     ap.add_argument("--kiv2-end", type=int, default=DEFAULT_KIV2_END)
     ap.add_argument("--kiv2-repeat-count", type=int, default=DEFAULT_KIV2_REPEAT_COUNT)
-    ap.add_argument("--kiv2-unit-length", type=int, default=DEFAULT_KIV2_UNIT_LEN)
     ap.add_argument(
         "--norm-regions",
         type=_parse_norm_regions,

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -818,7 +818,7 @@ def run(argv: list[str]) -> None:
 
     norm_regions = _parse_norm_regions(args.norm_regions) if args.norm_regions else DEFAULT_NORM_REGIONS
 
-    mode = "rc" if args.cram.endswith(".cram") else "rb"
+    mode = "rc" if args.cram.lower().endswith(".cram") else "rb"
     bam = pysam.AlignmentFile(args.cram, mode, reference_filename=args.reference)
     fasta = pyfaidx.Fasta(args.reference)
 

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -825,19 +825,21 @@ def _write_pcnv_bed(
     kiv2_start: int,
     kiv2_end: int,
 ) -> None:
-    """Per-haplotype rows. Two overlapping rows when phased, one otherwise."""
+    """Per-haplotype rows. Two overlapping rows when phased; no rows when unresolved."""
     total_units = int(round(call.kiv2_copy_number))
     main_region = f"{chrom}:{kiv2_start}-{kiv2_end}"
     phased = call.ref_marker_allele_copy_number is not None and call.alt_marker_allele_copy_number is not None
     with out_path.open("w") as f:
         f.write("#gffTags\n")
-        if phased:
-            per_hap_units = (
-                int(round(call.ref_marker_allele_copy_number)),
-                int(round(call.alt_marker_allele_copy_number)),
-            )
-        else:
-            per_hap_units = (total_units,)
+        if not phased:
+            # Unresolved phasing (e.g. hom-REF/ALT markers, marker disagreement,
+            # or no marker coverage): skip per-haplotype rows entirely rather
+            # than emit a single fallback row with cn == agcn.
+            return
+        per_hap_units = (
+            int(round(call.ref_marker_allele_copy_number)),
+            int(round(call.alt_marker_allele_copy_number)),
+        )
         for units in per_hap_units:
             tags = [
                 f"sample={sample_id}",

--- a/src/core/tests/unit/test_math_utils.py
+++ b/src/core/tests/unit/test_math_utils.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 from ugbio_core import math_utils
 
@@ -16,3 +18,24 @@ def test_unphred():
 
 def test_unphred_str():
     assert np.allclose(math_utils.unphred_str("+5?"), np.array([0.1, 0.01, 0.001]))
+
+
+def test_log_binomial_zero_n_zero_k_is_zero():
+    assert math_utils.log_binomial(0, 0, 0.5) == 0.0
+
+
+def test_log_binomial_known_value():
+    # log(C(4,2) * 0.5^4) = log(6/16)
+    assert math_utils.log_binomial(4, 2, 0.5) == math.log(6 / 16)
+
+
+def test_log_binomial_clamps_extreme_p():
+    # p=0/1 would be log(0) without clamping; result must be finite.
+    assert np.isfinite(math_utils.log_binomial(10, 0, 0.0))
+    assert np.isfinite(math_utils.log_binomial(10, 10, 1.0))
+
+
+def test_log_binomial_invalid_k_returns_neg_inf():
+    assert math_utils.log_binomial(5, -1, 0.5) == -math.inf
+    assert math_utils.log_binomial(5, 6, 0.5) == -math.inf
+    assert math_utils.log_binomial(0, 1, 0.5) == -math.inf

--- a/src/core/tests/unit/test_math_utils.py
+++ b/src/core/tests/unit/test_math_utils.py
@@ -26,7 +26,7 @@ def test_log_binomial_zero_n_zero_k_is_zero():
 
 def test_log_binomial_known_value():
     # log(C(4,2) * 0.5^4) = log(6/16)
-    assert math_utils.log_binomial(4, 2, 0.5) == math.log(6 / 16)
+    assert math.isclose(math_utils.log_binomial(4, 2, 0.5), math.log(6 / 16), rel_tol=1e-12)
 
 
 def test_log_binomial_clamps_extreme_p():

--- a/src/core/ugbio_core/math_utils.py
+++ b/src/core/ugbio_core/math_utils.py
@@ -104,8 +104,11 @@ def log_binomial(n: int, k: int, p: float) -> float:
     """Log-likelihood of observing k successes in n Bernoulli(p) trials.
 
     Probability is clamped to [1e-9, 1 - 1e-9] to avoid -inf at the boundaries.
-    Returns 0.0 when n == 0.
+    Returns 0.0 when n == 0 and k == 0; returns -inf for impossible (k, n) pairs
+    (k < 0, k > n, or n == 0 with k != 0).
     """
+    if k < 0 or k > n:
+        return -math.inf
     if n == 0:
         return 0.0
     p = min(max(p, 1e-9), 1 - 1e-9)

--- a/src/core/ugbio_core/math_utils.py
+++ b/src/core/ugbio_core/math_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import numpy as np
 
 
@@ -96,3 +98,15 @@ def unphred_str(strq: str) -> np.ndarray:
     """
     q = [ord(x) - 33 for x in strq]
     return unphred(q)
+
+
+def log_binomial(n: int, k: int, p: float) -> float:
+    """Log-likelihood of observing k successes in n Bernoulli(p) trials.
+
+    Probability is clamped to [1e-9, 1 - 1e-9] to avoid -inf at the boundaries.
+    Returns 0.0 when n == 0.
+    """
+    if n == 0:
+        return 0.0
+    p = min(max(p, 1e-9), 1 - 1e-9)
+    return math.lgamma(n + 1) - math.lgamma(k + 1) - math.lgamma(n - k + 1) + k * math.log(p) + (n - k) * math.log1p(-p)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New clinical-targeted genotyping/CNV logic on hard-coded hg38 coordinates; incorrect depth or binomial thresholds could mis-call KIV-2 copy number or LPA SNVs, though behavior is heavily unit/system tested.
> 
> **Overview**
> Adds a new **`lpa_caller`** console entry point and **`ugbio_cnv.lpa_caller`** module that targets the LPA KIV-2 VNTR from a single indexed CRAM/BAM: GC-corrected depth for total repeat copy number, linked marker SNVs for haplotype split, and binomial small-variant calling for **LPA:4733G>A** and **LPA:4925G>A**.
> 
> The pipeline writes **`<prefix>.targeted.*`** artifacts—JSON, full and small-variant-only BGZF/tabix VCFs, and parascopy-style **acnv/pcnv** BED—with hg38 site validation, KIV-2 MAPQ=0 pileup behavior, and CLI knobs for norm regions and optional **--no-vcf** / **--no-bed**.
> 
> **`ugbio_core.math_utils`** gains **`log_binomial`** (with unit tests) to support the small-variant likelihood model. Coverage includes a large **`test_lpa_caller.py`** suite, a HG01046 KIV-2 BAM slice (LFS) plus system tests that stub depth estimation for CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b677318db90e6a4ee4cd3f35e77c43fdd794f7ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->