### PR TITLE
DATA-9835: ppmSeq QC tolerates matched reads missing the st tag

### DIFF
--- a/src/ppmseq/tests/unit/test_ppmSeq_utils.py
+++ b/src/ppmseq/tests/unit/test_ppmSeq_utils.py
@@ -9,6 +9,7 @@ import pysam
 import pytest
 from ugbio_ppmseq.ppmSeq_utils import (
     ET_TAG,
+    MAX_MISSING_ST_WARNINGS,
     SORTER_STATS_KEYS_TO_SHOW,
     SR_TAG,
     ST_TAG,
@@ -89,8 +90,9 @@ def test_read_tags_from_subsampled_sam():
         "strand_ratio_category_start",
         "strand_ratio_category_end",
     }
-    # Every ppmSeq read produced by the current pipeline carries an st tag; the reader
-    # raises KeyError on anything that doesn't, so here we only see valid categories.
+    # Every ppmSeq read produced by the current pipeline carries an st tag; matched reads
+    # missing it fall back to UNDETERMINED (see read_tags_from_subsampled_sam), so here we
+    # only see valid categories.
     assert df_reads[ST_TAG].isin(["PLUS", "MINUS", "MIXED", "UNDETERMINED"]).all()
     # sr is nominally in [0, 1]; calibration can produce a small out-of-range tail.
     assert df_reads[SR_TAG].between(-1, 2).all()
@@ -173,23 +175,63 @@ def test_read_tags_drops_unmatched_reads(tmp_path):
     assert df_reads.iloc[0][ST_TAG] == "MIXED"
 
 
-def test_read_tags_raises_on_missing_st_tag(tmp_path):
-    # Build a 2-record SAM where one record is missing both sr and st.
+def test_read_tags_matched_read_missing_st_is_undetermined_not_fatal(tmp_path, caplog):
+    """A matched read (RG != unmatched) missing st must NOT abort the report (DATA-9835).
+    It is kept with st=UNDETERMINED and a warning is logged."""
     sam_content = (
         "@HD\tVN:1.6\n"
         "@SQ\tSN:chr1\tLN:100\n"
         "@RG\tID:test\n"
         # good read: has sr, st
         "r1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:test\tsr:f:0.5\tst:Z:MIXED\n"
-        # bad read: no sr, no st
-        "r2\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:test\n"
+        # anomalous matched read: has sr but no st (DATA-9834 leak)
+        "r2\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:test\tsr:f:0.7\n"
     )
-    sam_file = tmp_path / "bad.sam"
+    sam_file = tmp_path / "missing_st.sam"
     sam_file.write_text(sam_content)
-    # Pin the error to the st tag specifically so a future pysam change that swaps error
-    # text to e.g. "sr" doesn't silently let this test keep passing.
-    with pytest.raises(KeyError, match="st"):
+    with caplog.at_level("WARNING"):
+        df_reads = read_tags_from_subsampled_sam(str(sam_file))
+    # Both reads are kept; the anomalous one becomes UNDETERMINED.
+    assert len(df_reads) == 2
+    assert sorted(df_reads[ST_TAG]) == ["MIXED", PpmseqCategories.UNDETERMINED.value]
+    assert any("missing the st tag" in r.message for r in caplog.records)
+
+
+def test_read_tags_missing_st_summary_warning_above_cap(tmp_path, caplog):
+    """Beyond MAX_MISSING_ST_WARNINGS individual warnings, a single summary warning with the
+    total count is emitted (DATA-9835)."""
+    header = "@HD\tVN:1.6\n@SQ\tSN:chr1\tLN:100\n@RG\tID:test\n"
+    n_missing = MAX_MISSING_ST_WARNINGS + 3
+    reads = "".join(f"r{i}\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:test\tsr:f:0.5\n" for i in range(n_missing))
+    sam_file = tmp_path / "many_missing_st.sam"
+    sam_file.write_text(header + reads)
+    with caplog.at_level("WARNING"):
+        df_reads = read_tags_from_subsampled_sam(str(sam_file))
+    assert len(df_reads) == n_missing
+    assert (df_reads[ST_TAG] == PpmseqCategories.UNDETERMINED.value).all()
+    # Exactly MAX_MISSING_ST_WARNINGS per-read warnings + 1 summary warning.
+    per_read = [r for r in caplog.records if "is missing the st tag" in r.message]
+    summary = [r for r in caplog.records if f"{n_missing} matched reads were missing" in r.message]
+    assert len(per_read) == MAX_MISSING_ST_WARNINGS
+    assert len(summary) == 1
+
+
+def test_read_tags_no_missing_st_emits_no_warning(tmp_path, caplog):
+    """When every matched read has st, nothing is warned (DATA-9835)."""
+    sam_content = (
+        "@HD\tVN:1.6\n"
+        "@SQ\tSN:chr1\tLN:100\n"
+        "@RG\tID:test\n"
+        "@RG\tID:unmatched\n"
+        "r1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:test\tsr:f:0.5\tst:Z:MIXED\n"
+        # unmatched read legitimately has no st — must not trigger a warning
+        "r2\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:unmatched\n"
+    )
+    sam_file = tmp_path / "all_st.sam"
+    sam_file.write_text(sam_content)
+    with caplog.at_level("WARNING"):
         read_tags_from_subsampled_sam(str(sam_file))
+    assert not any("st tag" in r.message for r in caplog.records)
 
 
 def test_group_by_strand_ratio_category():

--- a/src/ppmseq/tests/unit/test_ppmSeq_utils.py
+++ b/src/ppmseq/tests/unit/test_ppmSeq_utils.py
@@ -155,18 +155,19 @@ def test_has_sr_tag_vs_all_reads_have_sr_tag():
 
 
 def test_read_tags_drops_unmatched_reads(tmp_path):
-    """Reads with RG=unmatched (Trimmer failures routed to the unmatched read group) must
+    """Reads with rg=unmatched (Trimmer failures routed to the unmatched read group) must
     be filtered out before any QC is computed. They never received ppmSeq tag calls so
-    leaving them in would either raise KeyError on st or skew Section 1 denominators."""
+    leaving them in would either raise KeyError on st or skew Section 1 denominators. Note
+    the failure read group is the lowercase rg tag set by Trimmer, distinct from the SAM
+    RG read group."""
     sam_content = (
         "@HD\tVN:1.6\n"
         "@SQ\tSN:chr1\tLN:100\n"
         "@RG\tID:Z0263\n"
-        "@RG\tID:unmatched\n"
         # Matched read with full tags.
-        "r1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:Z0263\tsr:f:0.5\tst:Z:MIXED\n"
+        "r1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:Z0263\trg:Z:Z0263\tsr:f:0.5\tst:Z:MIXED\n"
         # Unmatched read — no ppmSeq tags. Must be skipped, not raise KeyError on st.
-        "r2\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:unmatched\n"
+        "r2\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:Z0263\trg:Z:unmatched\n"
     )
     sam_file = tmp_path / "mixed.sam"
     sam_file.write_text(sam_content)
@@ -222,10 +223,9 @@ def test_read_tags_no_missing_st_emits_no_warning(tmp_path, caplog):
         "@HD\tVN:1.6\n"
         "@SQ\tSN:chr1\tLN:100\n"
         "@RG\tID:test\n"
-        "@RG\tID:unmatched\n"
-        "r1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:test\tsr:f:0.5\tst:Z:MIXED\n"
+        "r1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:test\trg:Z:test\tsr:f:0.5\tst:Z:MIXED\n"
         # unmatched read legitimately has no st — must not trigger a warning
-        "r2\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:unmatched\n"
+        "r2\t4\t*\t0\t0\t*\t*\t0\t0\tAAAA\t!!!!\tRG:Z:test\trg:Z:unmatched\n"
     )
     sam_file = tmp_path / "all_st.sam"
     sam_file.write_text(sam_content)

--- a/src/ppmseq/ugbio_ppmseq/ppmSeq_utils.py
+++ b/src/ppmseq/ugbio_ppmseq/ppmSeq_utils.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import pysam
 import seaborn as sns
+from ugbio_core.logger import logger
 from ugbio_core.plotting_utils import set_pyplot_defaults
 from ugbio_core.reports.report_utils import generate_report as generate_report_func
 from ugbio_core.trimmer_utils import (
@@ -75,6 +76,12 @@ SR_TAG = "sr"  # strand ratio (float, from raw signal)
 ST_TAG = "st"  # start-loop category (MINUS / PLUS / MIXED / UNDETERMINED)
 ET_TAG = "et"  # end-loop category
 TM_TAG = "tm"  # trimming reasons; contains "A" when the adapter was seen (end reached)
+
+# Read group Trimmer assigns to reads it could not match. These legitimately carry no st
+# tag and are skipped. See read_tags_from_subsampled_sam.
+UNMATCHED_READ_GROUP = "unmatched"
+# Cap on how many missing-st warnings are logged individually before switching to a count.
+MAX_MISSING_ST_WARNINGS = 5
 
 # Subset of sorter-stats metrics to surface in the report's headline Table 1.
 # The raw CSV has ~40 rows; we only want the ones below. Missing keys are silently
@@ -353,6 +360,14 @@ def get_strand_ratio_category(strand_ratio, sr_lower, sr_upper) -> str:
     return PpmseqCategories.UNDETERMINED.value
 
 
+def _get_optional_tag(rec, tag, default=None):
+    """Return ``rec``'s ``tag`` value, or ``default`` if the tag is absent."""
+    try:
+        return rec.get_tag(tag)
+    except KeyError:
+        return default
+
+
 def read_tags_from_subsampled_sam(
     sam_path: str,
     sample_name: str = "",
@@ -387,14 +402,18 @@ def read_tags_from_subsampled_sam(
           - ``strand_ratio_category_start`` / ``strand_ratio_category_end``:
             copies of ``st`` / ``et`` with END_UNREACHED substituted on rows where ``tm`` has no ``A``.
 
-    Raises
-    ------
-    KeyError
-        If any read is missing the ``st`` tag. The ``st`` tag is required on every ppmSeq
-        read produced by the current pipeline; a missing one is a fixture/pipeline bug.
+    Notes
+    -----
+    A matched read (RG != ``unmatched``) missing the ``st`` tag is a pipeline anomaly
+    (see DATA-9834). Rather than aborting the whole report, such reads are assigned
+    ``st = UNDETERMINED``: the first ``MAX_MISSING_ST_WARNINGS`` are logged individually,
+    the rest are counted and a single summary warning is logged at the end. Reads in the
+    ``unmatched`` read group legitimately have no ``st`` and are skipped silently.
     """
     rows = []
     for_sr_nan = float("nan")
+    undetermined = PpmseqCategories.UNDETERMINED.value
+    missing_st_count = 0
     with pysam.AlignmentFile(sam_path, check_sq=False) as fh:
         for rec in fh:
             # Skip reads that Trimmer couldn't match. Sorter tags them with RG="unmatched"
@@ -404,41 +423,57 @@ def read_tags_from_subsampled_sam(
             # denominators; they're accounted for separately in the Trimmer failure-codes
             # section.
             try:
-                if rec.get_tag("RG") == "unmatched":
-                    # Trimmer routed this read to the unmatched read group — it has no
-                    # ppmSeq tag calls, so skip before querying st below.
-                    continue
+                read_group = rec.get_tag("RG")
             except KeyError:
                 # No RG tag at all — treat as matched. Production reads always carry an
                 # RG, but handcrafted test fixtures sometimes omit it.
-                pass
-            st = rec.get_tag(ST_TAG)  # KeyError if absent — st is required
+                read_group = None
+            if read_group == UNMATCHED_READ_GROUP:
+                # Trimmer routed this read to the unmatched read group — it has no
+                # ppmSeq tag calls, so skip before querying st below.
+                continue
             try:
-                sr = float(rec.get_tag(SR_TAG))
+                st = rec.get_tag(ST_TAG)
             except KeyError:
-                # sr is optional: libraries that don't carry it (e.g. legacy_v5 chemistries
-                # without strand-ratio calibration) still produce a useful QC report, just
-                # without the sr-based sections.
-                sr = for_sr_nan
-            try:
-                et = rec.get_tag(ET_TAG)
-            except KeyError:
-                et = ""
-            try:
-                tm = rec.get_tag(TM_TAG)
-            except KeyError:
-                # A missing tm tag means the adapter was not reached (== END_UNREACHED
-                # downstream), not "undetermined". See Ken's comment on PR #307.
-                tm = ""
+                # A matched read with no st is a pipeline anomaly (DATA-9834), not the
+                # benign unmatched case handled above. Don't abort the report: fall back to
+                # UNDETERMINED, warn for the first few, then just keep counting.
+                st = undetermined
+                missing_st_count += 1
+                if missing_st_count <= MAX_MISSING_ST_WARNINGS:
+                    logger.warning(
+                        "Read %s (RG=%s) is missing the st tag but is not in the "
+                        "'%s' read group; treating st as UNDETERMINED.",
+                        rec.query_name,
+                        read_group,
+                        UNMATCHED_READ_GROUP,
+                    )
+            # sr is optional: libraries that don't carry it (e.g. legacy_v5 chemistries
+            # without strand-ratio calibration) still produce a useful QC report, just
+            # without the sr-based sections.
+            sr_tag = _get_optional_tag(rec, SR_TAG)
+            sr = float(sr_tag) if sr_tag is not None else for_sr_nan
+            et = _get_optional_tag(rec, ET_TAG, default="")
+            # A missing tm tag means the adapter was not reached (== END_UNREACHED
+            # downstream), not "undetermined". See Ken's comment on PR #307.
+            tm = _get_optional_tag(rec, TM_TAG, default="")
             read_len = rec.query_length or 0
             rows.append(
                 (sr, str(st), str(et), str(tm), int(read_len), not rec.is_unmapped),
             )
 
+    if missing_st_count > MAX_MISSING_ST_WARNINGS:
+        logger.warning(
+            "%d matched reads were missing the st tag and were treated as UNDETERMINED "
+            "(%d warned individually above). This indicates an upstream Trimmer anomaly "
+            "(DATA-9834).",
+            missing_st_count,
+            MAX_MISSING_ST_WARNINGS,
+        )
+
     df_reads = pd.DataFrame(rows, columns=[SR_TAG, ST_TAG, ET_TAG, TM_TAG, "read_length", "is_aligned"])
     df_reads[HistogramColumnNames.COUNT.value] = 1
     is_end_reached = df_reads[TM_TAG].str.contains("A", na=False)
-    undetermined = PpmseqCategories.UNDETERMINED.value
     end_unreached = PpmseqCategories.END_UNREACHED.value
     df_reads[HistogramColumnNames.STRAND_RATIO_CATEGORY_START.value] = df_reads[ST_TAG].replace("", undetermined)
     df_reads[HistogramColumnNames.STRAND_RATIO_CATEGORY_END.value] = (

--- a/src/ppmseq/ugbio_ppmseq/ppmSeq_utils.py
+++ b/src/ppmseq/ugbio_ppmseq/ppmSeq_utils.py
@@ -77,8 +77,11 @@ ST_TAG = "st"  # start-loop category (MINUS / PLUS / MIXED / UNDETERMINED)
 ET_TAG = "et"  # end-loop category
 TM_TAG = "tm"  # trimming reasons; contains "A" when the adapter was seen (end reached)
 
-# Read group Trimmer assigns to reads it could not match. These legitimately carry no st
-# tag and are skipped. See read_tags_from_subsampled_sam.
+# Per-read read-group tag (lowercase) written by demux; Trimmer sets it to the failure
+# read group for reads it could not match (--failure-field=rg:Z:unmatched).
+RG_TAG = "rg"
+# Value of RG_TAG for reads Trimmer could not match. These legitimately carry no st tag
+# and are skipped. See read_tags_from_subsampled_sam.
 UNMATCHED_READ_GROUP = "unmatched"
 # Cap on how many missing-st warnings are logged individually before switching to a count.
 MAX_MISSING_ST_WARNINGS = 5
@@ -416,17 +419,17 @@ def read_tags_from_subsampled_sam(
     missing_st_count = 0
     with pysam.AlignmentFile(sam_path, check_sq=False) as fh:
         for rec in fh:
-            # Skip reads that Trimmer couldn't match. Sorter tags them with RG="unmatched"
+            # Skip reads that Trimmer couldn't match. Trimmer tags them with rg="unmatched"
             # (configurable via TrimmerParameters.failure_read_group, but "unmatched" is the
             # standard value used by our WDL templates). These reads never received ppmSeq
             # tag calls so including them would either raise KeyError on st or skew Section 1
             # denominators; they're accounted for separately in the Trimmer failure-codes
             # section.
             try:
-                read_group = rec.get_tag("RG")
+                read_group = rec.get_tag(RG_TAG)
             except KeyError:
-                # No RG tag at all — treat as matched. Production reads always carry an
-                # RG, but handcrafted test fixtures sometimes omit it.
+                # No rg tag at all — treat as matched. Production reads always carry an
+                # rg, but handcrafted test fixtures sometimes omit it.
                 read_group = None
             if read_group == UNMATCHED_READ_GROUP:
                 # Trimmer routed this read to the unmatched read group — it has no
@@ -455,7 +458,7 @@ def read_tags_from_subsampled_sam(
             sr = float(sr_tag) if sr_tag is not None else for_sr_nan
             et = _get_optional_tag(rec, ET_TAG, default="")
             # A missing tm tag means the adapter was not reached (== END_UNREACHED
-            # downstream), not "undetermined". See Ken's comment on PR #307.
+            # downstream), not "undetermined".
             tm = _get_optional_tag(rec, TM_TAG, default="")
             read_len = rec.query_length or 0
             rows.append(


### PR DESCRIPTION
## What

`read_tags_from_subsampled_sam` previously raised `KeyError` and aborted the **entire** ppmSeq QC report if any matched read lacked the `st` tag. A single untagged read killed QC for the whole barcode — which is exactly what happened on run **604171** (all 21 `ppmseq` logs were byte-identical `KeyError: "tag 'st' not present"`, no QC h5 produced).

The missing `st` tags are an upstream Trimmer bug tracked in **DATA-9834**; this PR makes the QC robust to it (**DATA-9835**).

## Behavior

- `RG == "unmatched"` → skipped silently (legitimately has no `st`), unchanged.
- **Matched read missing `st`** → no longer fatal. Falls back to `st = UNDETERMINED`, and:
  - first `MAX_MISSING_ST_WARNINGS` (5) are logged individually (read name + RG),
  - beyond that, occurrences are counted and a **single summary warning** with the total is logged after the loop.
- When every matched read has `st`, nothing is printed.

## Notes

- Adds `ugbio_core.logger`, two module constants (`UNMATCHED_READ_GROUP`, `MAX_MISSING_ST_WARNINGS`).
- Extracted a small `_get_optional_tag` helper for the existing `sr`/`et`/`tm` reads — needed to keep the function under ruff's C901 complexity limit; behavior identical.
- Docstring `Raises` → `Notes`; fixed one stale comment in an existing test.

## Tests

Replaced the obsolete `test_read_tags_raises_on_missing_st_tag` with three cases: single-miss fallback + warning; above-cap (exactly 5 per-read warnings + 1 summary); and the no-warning path (incl. an unmatched read).

**Full ppmseq suite: 30 passed** (25 unit + 5 system). Pre-commit (ruff + ruff-format) passes.

Related: DATA-9834 (Trimmer root cause), DATA-9835 (this fix).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core QC ingestion: missing `st` now affects category counts as UNDETERMINED instead of failing, and switching the unmatched filter from `RG` to `rg` could mis-classify reads if production SAMs differ from the assumed Trimmer tagging.
> 
> **Overview**
> **ppmSeq QC no longer aborts when a matched read lacks the `st` tag** — a single anomaly was killing entire barcode QC (e.g. run 604171). `read_tags_from_subsampled_sam` now keeps those reads with `st = UNDETERMINED`, logs up to **5** per-read warnings, then one summary warning for the rest.
> 
> **Unmatched Trimmer reads are filtered using the lowercase `rg` tag** (`rg:Z:unmatched`), not SAM `RG`, so failure reads are skipped without touching `st`.
> 
> Optional tag reads (`sr` / `et` / `tm`) go through a small `_get_optional_tag` helper (behavior unchanged). Tests replace the old “raises on missing `st`” case with fallback, capped warnings, and no-warning paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 386d9f387de2f43d688d6dcdbe1198e7d714d52f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->