### PR TITLE
BIOIN-2856: Add merge_snvfind_stats utility for scattered featuremap pipeline

### DIFF
--- a/src/featuremap/pyproject.toml
+++ b/src/featuremap/pyproject.toml
@@ -25,6 +25,7 @@ featuremap_to_dataframe = "ugbio_featuremap.featuremap_to_dataframe:main"
 filter_featuremap = "ugbio_featuremap.filter_dataframe:main"
 somatic_snvfind_classifier = "ugbio_featuremap.somatic_snvfind_classifier:main"
 prepare_annotation_vcfs = "ugbio_featuremap.prepare_annotation_vcfs:main"
+merge_snvfind_stats = "ugbio_featuremap.merge_snvfind_stats:main"
 
 [tool.uv.sources.ugbio_core]
 workspace = true

--- a/src/featuremap/tests/unit/test_merge_snvfind_stats.py
+++ b/src/featuremap/tests/unit/test_merge_snvfind_stats.py
@@ -1,0 +1,316 @@
+"""Unit tests for merge_snvfind_stats module."""
+
+import json
+
+import pytest
+from ugbio_featuremap.merge_snvfind_stats import merge_snvfind_stats
+
+
+@pytest.fixture
+def simple_stats_shard_1(tmp_path):
+    data = {
+        "filters": {
+            "raw": {"funnel": 100000},
+            "coverage_ge_min": {
+                "name": "coverage_ge_min",
+                "type": "region",
+                "field": "DP",
+                "op": "ge",
+                "value": 20,
+                "funnel": 80000,
+                "pass": 80000,
+            },
+            "mapq_ge_60": {
+                "name": "mapq_ge_60",
+                "type": "mapping",
+                "field": "MAPQ",
+                "op": "ge",
+                "value": 60,
+                "funnel": 70000,
+                "pass": 90000,
+            },
+        },
+        "combinations": {"000": 5000, "001": 3000, "010": 2000, "011": 10000, "100": 1000, "111": 70000},
+        "combinations_total": 100000,
+    }
+    path = tmp_path / "shard1.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+@pytest.fixture
+def simple_stats_shard_2(tmp_path):
+    data = {
+        "filters": {
+            "raw": {"funnel": 50000},
+            "coverage_ge_min": {
+                "name": "coverage_ge_min",
+                "type": "region",
+                "field": "DP",
+                "op": "ge",
+                "value": 20,
+                "funnel": 40000,
+                "pass": 40000,
+            },
+            "mapq_ge_60": {
+                "name": "mapq_ge_60",
+                "type": "mapping",
+                "field": "MAPQ",
+                "op": "ge",
+                "value": 60,
+                "funnel": 35000,
+                "pass": 45000,
+            },
+        },
+        "combinations": {"000": 2500, "001": 1500, "010": 1000, "011": 5000, "100": 500, "111": 35000},
+        "combinations_total": 50000,
+    }
+    path = tmp_path / "shard2.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def test_merge_two_simple_shards(tmp_path, simple_stats_shard_1, simple_stats_shard_2):
+    output = tmp_path / "merged.json"
+    merge_snvfind_stats([simple_stats_shard_1, simple_stats_shard_2], output)
+
+    result = json.loads(output.read_text())
+
+    assert result["filters"]["raw"]["funnel"] == 150000
+    assert result["filters"]["coverage_ge_min"]["funnel"] == 120000
+    assert result["filters"]["coverage_ge_min"]["pass"] == 120000
+    assert result["filters"]["mapq_ge_60"]["funnel"] == 105000
+    assert result["filters"]["mapq_ge_60"]["pass"] == 135000
+
+    assert result["combinations"]["000"] == 7500
+    assert result["combinations"]["111"] == 105000
+    assert result["combinations_total"] == 150000
+
+    assert result["filters"]["coverage_ge_min"]["name"] == "coverage_ge_min"
+    assert result["filters"]["coverage_ge_min"]["value"] == 20
+
+
+def test_merge_single_input(tmp_path, simple_stats_shard_1):
+    output = tmp_path / "merged.json"
+    merge_snvfind_stats([simple_stats_shard_1], output)
+
+    result = json.loads(output.read_text())
+    original = json.loads(simple_stats_shard_1.read_text())
+
+    assert result["filters"]["raw"]["funnel"] == original["filters"]["raw"]["funnel"]
+    assert result["combinations_total"] == original["combinations_total"]
+
+
+def test_merge_unified_format(tmp_path):
+    shard_data = {
+        "filters_full_output": {
+            "filters": {
+                "raw": {"funnel": 62000000},
+                "coverage_ge_min": {
+                    "name": "coverage_ge_min",
+                    "type": "region",
+                    "field": "DP",
+                    "op": "ge",
+                    "value": 20,
+                    "funnel": 44000000,
+                    "pass": 44000000,
+                },
+            },
+            "combinations": {"00": 18000000, "01": 0, "10": 0, "11": 44000000},
+            "combinations_total": 62000000,
+        },
+        "filters_random_sample": {
+            "filters": {
+                "raw": {"funnel": 2700},
+                "coverage_ge_min": {
+                    "name": "coverage_ge_min",
+                    "type": "region",
+                    "field": "DP",
+                    "op": "ge",
+                    "value": 20,
+                    "funnel": 1900,
+                    "pass": 1900,
+                },
+            },
+            "combinations": {"00": 800, "01": 0, "10": 0, "11": 1900},
+            "combinations_total": 2700,
+        },
+    }
+
+    shard1 = tmp_path / "shard1.json"
+    shard1.write_text(json.dumps(shard_data))
+
+    shard2_data = {
+        "filters_full_output": {
+            "filters": {
+                "raw": {"funnel": 30000000},
+                "coverage_ge_min": {
+                    "name": "coverage_ge_min",
+                    "type": "region",
+                    "field": "DP",
+                    "op": "ge",
+                    "value": 20,
+                    "funnel": 22000000,
+                    "pass": 22000000,
+                },
+            },
+            "combinations": {"00": 8000000, "01": 0, "10": 0, "11": 22000000},
+            "combinations_total": 30000000,
+        },
+        "filters_random_sample": {
+            "filters": {
+                "raw": {"funnel": 1300},
+                "coverage_ge_min": {
+                    "name": "coverage_ge_min",
+                    "type": "region",
+                    "field": "DP",
+                    "op": "ge",
+                    "value": 20,
+                    "funnel": 900,
+                    "pass": 900,
+                },
+            },
+            "combinations": {"00": 400, "01": 0, "10": 0, "11": 900},
+            "combinations_total": 1300,
+        },
+    }
+    shard2 = tmp_path / "shard2.json"
+    shard2.write_text(json.dumps(shard2_data))
+
+    output = tmp_path / "merged.json"
+    merge_snvfind_stats([shard1, shard2], output)
+
+    result = json.loads(output.read_text())
+
+    assert result["filters_full_output"]["filters"]["raw"]["funnel"] == 92000000
+    assert result["filters_full_output"]["filters"]["coverage_ge_min"]["funnel"] == 66000000
+    assert result["filters_full_output"]["combinations_total"] == 92000000
+    assert result["filters_full_output"]["combinations"]["11"] == 66000000
+
+    assert result["filters_random_sample"]["filters"]["raw"]["funnel"] == 4000
+    assert result["filters_random_sample"]["filters"]["coverage_ge_min"]["funnel"] == 2800
+    assert result["filters_random_sample"]["combinations_total"] == 4000
+
+
+def test_merge_mismatched_filters_raises(tmp_path):
+    shard1 = tmp_path / "shard1.json"
+    shard1.write_text(
+        json.dumps(
+            {
+                "filters": {
+                    "raw": {"funnel": 100},
+                    "filter_a": {
+                        "name": "filter_a",
+                        "type": "region",
+                        "field": "X",
+                        "op": "ge",
+                        "value": 1,
+                        "funnel": 50,
+                        "pass": 50,
+                    },
+                },
+                "combinations": {},
+                "combinations_total": 100,
+            }
+        )
+    )
+
+    shard2 = tmp_path / "shard2.json"
+    shard2.write_text(
+        json.dumps(
+            {
+                "filters": {
+                    "raw": {"funnel": 100},
+                    "filter_b": {
+                        "name": "filter_b",
+                        "type": "region",
+                        "field": "Y",
+                        "op": "ge",
+                        "value": 1,
+                        "funnel": 50,
+                        "pass": 50,
+                    },
+                },
+                "combinations": {},
+                "combinations_total": 100,
+            }
+        )
+    )
+
+    output = tmp_path / "merged.json"
+    with pytest.raises(ValueError, match="Filter mismatch"):
+        merge_snvfind_stats([shard1, shard2], output)
+
+
+def test_merge_empty_input_raises(tmp_path):
+    output = tmp_path / "merged.json"
+    with pytest.raises(ValueError, match="No input files"):
+        merge_snvfind_stats([], output)
+
+
+def test_merge_three_shards(tmp_path):
+    shards = []
+    for i in range(3):
+        data = {
+            "filters": {
+                "raw": {"funnel": 10000 * (i + 1)},
+                "cov": {
+                    "name": "cov",
+                    "type": "region",
+                    "field": "DP",
+                    "op": "ge",
+                    "value": 20,
+                    "funnel": 8000 * (i + 1),
+                    "pass": 8000 * (i + 1),
+                },
+            },
+            "combinations": {"00": 2000 * (i + 1), "11": 8000 * (i + 1)},
+            "combinations_total": 10000 * (i + 1),
+        }
+        path = tmp_path / f"shard{i}.json"
+        path.write_text(json.dumps(data))
+        shards.append(path)
+
+    output = tmp_path / "merged.json"
+    merge_snvfind_stats(shards, output)
+
+    result = json.loads(output.read_text())
+    # 10000 + 20000 + 30000 = 60000
+    assert result["filters"]["raw"]["funnel"] == 60000
+    # 8000 + 16000 + 24000 = 48000
+    assert result["filters"]["cov"]["funnel"] == 48000
+    assert result["combinations_total"] == 60000
+
+
+def test_merge_combinations_with_new_keys(tmp_path):
+    shard1 = tmp_path / "shard1.json"
+    shard1.write_text(
+        json.dumps(
+            {
+                "filters": {"raw": {"funnel": 100}},
+                "combinations": {"00": 50, "01": 30, "10": 20},
+                "combinations_total": 100,
+            }
+        )
+    )
+
+    shard2 = tmp_path / "shard2.json"
+    shard2.write_text(
+        json.dumps(
+            {
+                "filters": {"raw": {"funnel": 80}},
+                "combinations": {"00": 40, "11": 40},
+                "combinations_total": 80,
+            }
+        )
+    )
+
+    output = tmp_path / "merged.json"
+    merge_snvfind_stats([shard1, shard2], output)
+
+    result = json.loads(output.read_text())
+    assert result["combinations"]["00"] == 90
+    assert result["combinations"]["01"] == 30
+    assert result["combinations"]["10"] == 20
+    assert result["combinations"]["11"] == 40
+    assert result["combinations_total"] == 180

--- a/src/featuremap/tests/unit/test_merge_snvfind_stats.py
+++ b/src/featuremap/tests/unit/test_merge_snvfind_stats.py
@@ -3,7 +3,7 @@
 import json
 
 import pytest
-from ugbio_featuremap.merge_snvfind_stats import merge_snvfind_stats
+from ugbio_featuremap.merge_snvfind_stats import merge_snvfind_stats, merge_trinuc_freq
 
 
 @pytest.fixture
@@ -314,3 +314,47 @@ def test_merge_combinations_with_new_keys(tmp_path):
     assert result["combinations"]["10"] == 20
     assert result["combinations"]["11"] == 40
     assert result["combinations_total"] == 180
+
+
+def test_merge_trinuc_freq(tmp_path):
+    shard1 = tmp_path / "shard1.csv"
+    shard1.write_text(
+        "A[A>C]A\t0.0121235971\t4383\t0.0091489761\t0.7546420497\n"
+        "A[A>G]A\t0.0121235971\t5176\t0.0108042666\t0.8911766482\n"
+        "A[A>T]A\t0.0121235971\t3736\t0.0077984428\t0.6432449686\n"
+    )
+
+    shard2 = tmp_path / "shard2.csv"
+    shard2.write_text(
+        "A[A>C]A\t0.0121235971\t4000\t0.0090000000\t0.7400000000\n"
+        "A[A>G]A\t0.0121235971\t5000\t0.0110000000\t0.9000000000\n"
+        "A[A>T]A\t0.0121235971\t3500\t0.0080000000\t0.6500000000\n"
+    )
+
+    output = tmp_path / "merged.csv"
+    merge_trinuc_freq([shard1, shard2], output)
+
+    lines = output.read_text().strip().split("\n")
+    assert len(lines) == 3
+
+    parts = lines[0].split("\t")
+    assert parts[0] == "A[A>C]A"
+    assert int(parts[2]) == 8383  # 4383 + 4000
+    total = 8383 + 10176 + 7236  # sum of all counts
+    expected_freq = 8383 / total
+    assert abs(float(parts[3]) - expected_freq) < 1e-6
+
+
+def test_merge_trinuc_freq_single_shard(tmp_path):
+    shard1 = tmp_path / "shard1.csv"
+    shard1.write_text("A[A>C]A\t0.0121235971\t4383\t0.0091489761\t0.7546420497\n")
+
+    output = tmp_path / "merged.csv"
+    merge_trinuc_freq([shard1], output)
+
+    lines = output.read_text().strip().split("\n")
+    assert len(lines) == 1
+    parts = lines[0].split("\t")
+    assert parts[0] == "A[A>C]A"
+    assert int(parts[2]) == 4383
+    assert abs(float(parts[3]) - 1.0) < 1e-6  # single trinuc = freq 1.0

--- a/src/featuremap/ugbio_featuremap/merge_snvfind_stats.py
+++ b/src/featuremap/ugbio_featuremap/merge_snvfind_stats.py
@@ -1,0 +1,137 @@
+"""Merge per-shard snvfind stats JSON files into a single unified stats file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from ugbio_core.logger import logger
+
+
+def _sum_filters(sections: list[dict[str, Any]], filter_names: list[str]) -> dict[str, dict[str, Any]]:
+    """Sum funnel/pass values across shards for each filter."""
+    merged: dict[str, dict[str, Any]] = {}
+    for name in filter_names:
+        entry = dict(sections[0]["filters"][name])
+        entry["funnel"] = 0
+        if "pass" in entry:
+            entry["pass"] = 0
+        merged[name] = entry
+
+    for section in sections:
+        section_filters = section["filters"]
+        if list(section_filters.keys()) != filter_names:
+            raise ValueError(
+                f"Filter mismatch across shards: expected {filter_names}, got {list(section_filters.keys())}"
+            )
+        for name in filter_names:
+            merged[name]["funnel"] += section_filters[name]["funnel"]
+            if "pass" in section_filters[name]:
+                merged[name]["pass"] += section_filters[name]["pass"]
+
+    return merged
+
+
+def _sum_combinations(sections: list[dict[str, Any]]) -> tuple[dict[str, int], int]:
+    """Sum combination counts across shards."""
+    merged: dict[str, int] = {}
+    total = 0
+    for section in sections:
+        if "combinations" in section:
+            for pattern, count in section["combinations"].items():
+                merged[pattern] = merged.get(pattern, 0) + count
+        if "combinations_total" in section:
+            total += section["combinations_total"]
+    return merged, total
+
+
+def _merge_stats_section(sections: list[dict[str, Any]]) -> dict[str, Any]:
+    """
+    Merge multiple stats sections by summing numeric fields.
+
+    Each section has:
+        filters: dict of filter_name -> {funnel: N, pass: N, name, type, field, op, value, ...}
+        combinations: dict of binary_pattern -> count
+        combinations_total: int
+    """
+    if not sections:
+        raise ValueError("No sections to merge")
+
+    filter_names = list(sections[0]["filters"].keys())
+    merged_filters = _sum_filters(sections, filter_names)
+    merged_combinations, merged_total = _sum_combinations(sections)
+
+    result: dict[str, Any] = {"filters": merged_filters}
+    if merged_combinations:
+        result["combinations"] = merged_combinations
+        result["combinations_total"] = merged_total
+
+    return result
+
+
+def merge_snvfind_stats(input_files: list[str | Path], output_file: str | Path) -> None:
+    """
+    Merge multiple snvfind stats JSON files into one.
+
+    Handles the unified format (with filters_full_output/filters_random_sample sections)
+    and the simple format (section directly at top level).
+
+    Parameters
+    ----------
+    input_files
+        Paths to per-shard stats JSON files
+    output_file
+        Path to write merged JSON
+    """
+    all_data = []
+    for f in input_files:
+        with open(f, encoding="utf-8") as fh:
+            all_data.append(json.load(fh))
+
+    if not all_data:
+        raise ValueError("No input files provided")
+
+    first = all_data[0]
+    is_unified = "filters_full_output" in first
+
+    if is_unified:
+        full_output_sections = [d["filters_full_output"] for d in all_data]
+        random_sample_sections = [d["filters_random_sample"] for d in all_data]
+        merged = {
+            "filters_full_output": _merge_stats_section(full_output_sections),
+            "filters_random_sample": _merge_stats_section(random_sample_sections),
+        }
+    else:
+        merged = _merge_stats_section(all_data)
+
+    output_path = Path(output_file)
+    with output_path.open("w", encoding="utf-8") as fh:
+        json.dump(merged, fh, indent=2)
+
+    logger.info("Merged %d stats files into %s", len(all_data), output_path)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Merge per-shard snvfind stats JSONs")
+    parser.add_argument(
+        "--input",
+        required=True,
+        action="append",
+        dest="inputs",
+        help="Input stats JSON file (repeat for each shard)",
+    )
+    parser.add_argument("--output", required=True, help="Output merged JSON file path")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv)
+    merge_snvfind_stats(args.inputs, args.output)
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv[1:])

--- a/src/featuremap/ugbio_featuremap/merge_snvfind_stats.py
+++ b/src/featuremap/ugbio_featuremap/merge_snvfind_stats.py
@@ -10,27 +10,37 @@ from typing import Any
 
 from ugbio_core.logger import logger
 
+from ugbio_featuremap.filter_dataframe import KEY_FILTERS, TYPE_FUNNEL, TYPE_PASS
+
+KEY_COMBINATIONS = "combinations"
+KEY_COMBINATIONS_TOTAL = "combinations_total"
+
+
+def _has_pass_in_any_shard(sections: list[dict[str, Any]], name: str) -> bool:
+    """Check if any shard has a 'pass' field for a given filter."""
+    return any(TYPE_PASS in section[KEY_FILTERS][name] for section in sections)
+
 
 def _sum_filters(sections: list[dict[str, Any]], filter_names: list[str]) -> dict[str, dict[str, Any]]:
     """Sum funnel/pass values across shards for each filter."""
     merged: dict[str, dict[str, Any]] = {}
     for name in filter_names:
-        entry = dict(sections[0]["filters"][name])
-        entry["funnel"] = 0
-        if "pass" in entry:
-            entry["pass"] = 0
+        entry = dict(sections[0][KEY_FILTERS][name])
+        entry[TYPE_FUNNEL] = 0
+        if _has_pass_in_any_shard(sections, name):
+            entry[TYPE_PASS] = 0
         merged[name] = entry
 
     for section in sections:
-        section_filters = section["filters"]
+        section_filters = section[KEY_FILTERS]
         if list(section_filters.keys()) != filter_names:
             raise ValueError(
                 f"Filter mismatch across shards: expected {filter_names}, got {list(section_filters.keys())}"
             )
         for name in filter_names:
-            merged[name]["funnel"] += section_filters[name]["funnel"]
-            if "pass" in section_filters[name]:
-                merged[name]["pass"] += section_filters[name]["pass"]
+            merged[name][TYPE_FUNNEL] += section_filters[name][TYPE_FUNNEL]
+            if TYPE_PASS in merged[name]:
+                merged[name][TYPE_PASS] += section_filters[name].get(TYPE_PASS, 0)
 
     return merged
 
@@ -40,11 +50,11 @@ def _sum_combinations(sections: list[dict[str, Any]]) -> tuple[dict[str, int], i
     merged: dict[str, int] = {}
     total = 0
     for section in sections:
-        if "combinations" in section:
-            for pattern, count in section["combinations"].items():
+        if KEY_COMBINATIONS in section:
+            for pattern, count in section[KEY_COMBINATIONS].items():
                 merged[pattern] = merged.get(pattern, 0) + count
-        if "combinations_total" in section:
-            total += section["combinations_total"]
+        if KEY_COMBINATIONS_TOTAL in section:
+            total += section[KEY_COMBINATIONS_TOTAL]
     return merged, total
 
 
@@ -60,16 +70,15 @@ def _merge_stats_section(sections: list[dict[str, Any]]) -> dict[str, Any]:
     if not sections:
         raise ValueError("No sections to merge")
 
-    filter_names = list(sections[0]["filters"].keys())
+    filter_names = list(sections[0][KEY_FILTERS].keys())
     merged_filters = _sum_filters(sections, filter_names)
     merged_combinations, merged_total = _sum_combinations(sections)
 
-    result: dict[str, Any] = {"filters": merged_filters}
-    if merged_combinations:
-        result["combinations"] = merged_combinations
-        result["combinations_total"] = merged_total
-
-    return result
+    return {
+        KEY_FILTERS: merged_filters,
+        KEY_COMBINATIONS: merged_combinations,
+        KEY_COMBINATIONS_TOTAL: merged_total,
+    }
 
 
 def merge_snvfind_stats(input_files: list[str | Path], output_file: str | Path) -> None:

--- a/src/featuremap/ugbio_featuremap/merge_snvfind_stats.py
+++ b/src/featuremap/ugbio_featuremap/merge_snvfind_stats.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -113,8 +114,50 @@ def merge_snvfind_stats(input_files: list[str | Path], output_file: str | Path) 
     logger.info("Merged %d stats files into %s", len(all_data), output_path)
 
 
+def merge_trinuc_freq(input_files: list[str | Path], output_file: str | Path) -> None:
+    """
+    Merge per-shard trinucleotide frequency CSVs.
+
+    Each CSV is tab-separated with columns: trinuc_context, ref_freq, count, observed_freq, ratio.
+    Merge sums the count column and recomputes observed_freq and ratio.
+
+    Parameters
+    ----------
+    input_files
+        Paths to per-shard trinuc freq CSV files
+    output_file
+        Path to write merged CSV
+    """
+    counts: dict[str, int] = defaultdict(int)
+    ref_freqs: dict[str, float] = {}
+
+    for f in input_files:
+        with open(f, encoding="utf-8") as fh:
+            for raw_line in fh:
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                parts = stripped.split("\t")
+                trinuc = parts[0]
+                ref_freq = float(parts[1])
+                count = int(parts[2])
+                counts[trinuc] += count
+                ref_freqs[trinuc] = ref_freq
+
+    total_count = sum(counts.values())
+    output_path = Path(output_file)
+    with output_path.open("w", encoding="utf-8") as fh:
+        for trinuc, ref_freq in ref_freqs.items():
+            count = counts[trinuc]
+            observed_freq = count / total_count if total_count > 0 else 0.0
+            ratio = observed_freq / ref_freq if ref_freq > 0 else 0.0
+            fh.write(f"{trinuc}\t{ref_freq:.10f}\t{count}\t{observed_freq:.10f}\t{ratio:.10f}\n")
+
+    logger.info("Merged %d trinuc freq files into %s", len(input_files), output_path)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Merge per-shard snvfind stats JSONs")
+    parser = argparse.ArgumentParser(description="Merge per-shard snvfind stats JSONs and trinuc freq CSVs")
     parser.add_argument(
         "--input",
         required=True,
@@ -123,12 +166,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Input stats JSON file (repeat for each shard)",
     )
     parser.add_argument("--output", required=True, help="Output merged JSON file path")
+    parser.add_argument(
+        "--trinuc-freq-input",
+        action="append",
+        dest="trinuc_freq_inputs",
+        help="Input trinuc freq CSV file (repeat for each shard, optional)",
+    )
+    parser.add_argument("--trinuc-freq-output", dest="trinuc_freq_output", help="Output merged trinuc freq CSV path")
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
     merge_snvfind_stats(args.inputs, args.output)
+    if args.trinuc_freq_inputs and args.trinuc_freq_output:
+        merge_trinuc_freq(args.trinuc_freq_inputs, args.trinuc_freq_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- New CLI tool `merge_snvfind_stats` that merges per-shard snvfind stats JSON files into a single unified stats file
- Sums funnel/pass/combination counts across shards with validation that filter sets match
- Supports both simple format and unified format (with `filters_full_output`/`filters_random_sample` sections)
- Added as entry point in `pyproject.toml`

## Test plan
- [x] Unit tests (7 tests covering: 2-shard merge, 3-shard merge, single input passthrough, unified format, mismatched filters error, empty input error, combination key merging)
- [x] Integration test via terra_pipeline PR #2225 (scattered featuremap pipeline)

## Related
- terra_pipeline PR: https://github.com/Ultimagen/terra_pipeline/pull/2225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive offline aggregation utility with validation; no changes to existing filter or classification logic beyond a new entry point and tests.
> 
> **Overview**
> Adds a **`merge_snvfind_stats`** CLI and library for combining per-shard **snvfind** outputs from scattered featuremap runs.
> 
> **Stats JSON:** Merges multiple shard JSON files by summing **funnel**, **pass**, **combinations**, and **combinations_total**, while copying non-numeric filter metadata from the first shard. Supports a **simple** top-level layout and a **unified** layout with separate **`filters_full_output`** and **`filters_random_sample`** sections. Raises if shard filter keys differ or no inputs are given.
> 
> **Trinuc frequency CSVs (optional):** **`merge_trinuc_freq`** sums per-context counts across tab-separated shard files and recomputes **observed_freq** and **ratio**; the CLI can run this via **`--trinuc-freq-input`** / **`--trinuc-freq-output`** alongside **`--input`** / **`--output`**.
> 
> Registers the **`merge_snvfind_stats`** console script in **`pyproject.toml`**. Unit tests cover multi-shard merges, unified format, validation errors, combination key union, and trinuc merging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 324e87cee1aa9b156dc38631ab6c154dffe0253a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->