### PR TITLE
BIOIN-2628 Docker for T1K

### DIFF
--- a/.github/workflows/build-ugbio-member-docker.yml
+++ b/.github/workflows/build-ugbio-member-docker.yml
@@ -20,6 +20,7 @@ on:
           - "single_cell"
           - "srsnv"
           - "pypgx"
+          - "t1k"
         required: true
         default: ""
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ src/
 ├── cloud_utils/  (4 files)  ugbio_cloud_utils  - AWS/GCS integration
 ├── omics/        (25 files) ugbio_omics        - AWS HealthOmics workflows
 ├── freec/        (2 files)  ugbio_freec        - FREEC CNV config
-└── pypgx/        (0 files)  ugbio_pypgx        - Pharmacogenomics (stub)
+├── pypgx/        (0 files)  ugbio_pypgx        - Pharmacogenomics (stub)
+└── t1k/          (0 files)  ugbio_t1k          - T1K HLA/KIR genotyping (stub)
 ```
 
 ### Module Dependency Hierarchy
@@ -231,7 +232,7 @@ gh run list --workflow build-ugbio-member-docker.yml --limit 5
 gh run view <run-id>
 ```
 
-**Available modules**: `core`, `cnv`, `comparison`, `featuremap`, `filtering`, `mrd`, `ppmseq`, `srsnv`, `methylation`, `single_cell`, `cloud_utils`, `omics`, `freec`
+**Available modules**: `core`, `cnv`, `comparison`, `featuremap`, `filtering`, `mrd`, `ppmseq`, `srsnv`, `methylation`, `single_cell`, `cloud_utils`, `omics`, `freec`, `pypgx`, `t1k`
 
 **Docker registries**:
 - **AWS ECR** (internal): `337532070941.dkr.ecr.us-east-1.amazonaws.com/ugbio_<module>:<tag>`
@@ -344,6 +345,76 @@ gh run view <run-id>
 **ugbio_methylation, ugbio_single_cell, ugbio_ppmseq, ugbio_cloud_utils, ugbio_freec**:
 - Specialized analysis domains
 - See pyproject.toml for entry points
+
+**Docker-only stub modules (ugbio_pypgx, ugbio_t1k)**:
+- No Python source — just a `Dockerfile`, `pyproject.toml`, and `README`
+- The Docker image bundles an external bioinformatics tool for use in pipelines
+- The `run_tests` script in the image prints "No tests to run"
+- See [Adding a Docker-only stub module](#adding-a-docker-only-stub-module) for how to create one
+
+## Adding a Docker-only Stub Module
+
+Use this pattern when you want to package an external tool (e.g. T1K, PyPGx) as an ugbio Docker image without adding any Python code to the workspace.
+
+### Step 1 — Create the module directory
+
+```
+src/<name>/
+├── Dockerfile        # Builds the tool from source or installs it
+├── pyproject.toml    # Minimal UV workspace member declaration
+└── README_<name>.md  # One-line description + link to upstream tool
+```
+
+### Step 2 — Minimal `pyproject.toml`
+
+```toml
+[project]
+name = "ugbio_<name>"
+version = "1.27.0"           # Keep in sync with workspace version
+description = "<Tool name>"
+authors = [
+    { name = "Your Name", email = "you@ultimagen.com" },
+]
+readme = "README_<name>.md"
+
+[project.license]
+text = "Apache-2.0"
+```
+
+### Step 3 — Dockerfile conventions
+
+- Base on an appropriate image (e.g. `ubuntu:22.04` or `python:3.12-slim`)
+- Build/install the external tool
+- Add a no-op `run_tests` script so CI passes:
+  ```dockerfile
+  RUN echo '#!/bin/sh\necho "No tests to run"' > /usr/local/bin/run_tests \
+  && chmod +x /usr/local/bin/run_tests
+  ```
+- Drop privileges at the end:
+  ```dockerfile
+  RUN groupadd ugbio && useradd -m ugbio -g ugbio
+  USER ugbio
+  WORKDIR /home/ugbio
+  ```
+
+### Step 4 — Register in the manual Docker build workflow
+
+Add the module name to the `options` list in `.github/workflows/build-ugbio-member-docker.yml`:
+
+```yaml
+        options:
+          - "cnv"
+          ...
+          - "<name>"    # ← add here
+```
+
+The CI matrix (`ugbio_members_matrix.py`) auto-discovers all non-`__` directories under `src/`, so no other changes are needed for the automated test/build matrix.
+
+### Step 5 — Build the Docker image
+
+```bash
+gh workflow run "build-ugbio-member-docker.yml" --ref <branch-name> -f member=<name>
+```
 
 ## Architectural Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,7 @@ src/
 ├── cloud_utils/  (4 files)  ugbio_cloud_utils  - AWS/GCS integration
 ├── omics/        (25 files) ugbio_omics        - AWS HealthOmics workflows
 ├── freec/        (2 files)  ugbio_freec        - FREEC CNV config
-├── pypgx/        (0 files)  ugbio_pypgx        - Pharmacogenomics (stub)
-└── t1k/          (0 files)  ugbio_t1k          - T1K HLA/KIR genotyping (stub)
+└── pypgx/        (0 files)  ugbio_pypgx        - Pharmacogenomics (stub)
 ```
 
 ### Module Dependency Hierarchy
@@ -232,7 +231,7 @@ gh run list --workflow build-ugbio-member-docker.yml --limit 5
 gh run view <run-id>
 ```
 
-**Available modules**: `core`, `cnv`, `comparison`, `featuremap`, `filtering`, `mrd`, `ppmseq`, `srsnv`, `methylation`, `single_cell`, `cloud_utils`, `omics`, `freec`, `pypgx`, `t1k`
+**Available modules**: `core`, `cnv`, `comparison`, `featuremap`, `filtering`, `mrd`, `ppmseq`, `srsnv`, `methylation`, `single_cell`, `cloud_utils`, `omics`, `freec`
 
 **Docker registries**:
 - **AWS ECR** (internal): `337532070941.dkr.ecr.us-east-1.amazonaws.com/ugbio_<module>:<tag>`
@@ -345,76 +344,6 @@ gh run view <run-id>
 **ugbio_methylation, ugbio_single_cell, ugbio_ppmseq, ugbio_cloud_utils, ugbio_freec**:
 - Specialized analysis domains
 - See pyproject.toml for entry points
-
-**Docker-only stub modules (ugbio_pypgx, ugbio_t1k)**:
-- No Python source — just a `Dockerfile`, `pyproject.toml`, and `README`
-- The Docker image bundles an external bioinformatics tool for use in pipelines
-- The `run_tests` script in the image prints "No tests to run"
-- See [Adding a Docker-only stub module](#adding-a-docker-only-stub-module) for how to create one
-
-## Adding a Docker-only Stub Module
-
-Use this pattern when you want to package an external tool (e.g. T1K, PyPGx) as an ugbio Docker image without adding any Python code to the workspace.
-
-### Step 1 — Create the module directory
-
-```
-src/<name>/
-├── Dockerfile        # Builds the tool from source or installs it
-├── pyproject.toml    # Minimal UV workspace member declaration
-└── README_<name>.md  # One-line description + link to upstream tool
-```
-
-### Step 2 — Minimal `pyproject.toml`
-
-```toml
-[project]
-name = "ugbio_<name>"
-version = "1.27.0"           # Keep in sync with workspace version
-description = "<Tool name>"
-authors = [
-    { name = "Your Name", email = "you@ultimagen.com" },
-]
-readme = "README_<name>.md"
-
-[project.license]
-text = "Apache-2.0"
-```
-
-### Step 3 — Dockerfile conventions
-
-- Base on an appropriate image (e.g. `ubuntu:22.04` or `python:3.12-slim`)
-- Build/install the external tool
-- Add a no-op `run_tests` script so CI passes:
-  ```dockerfile
-  RUN echo '#!/bin/sh\necho "No tests to run"' > /usr/local/bin/run_tests \
-  && chmod +x /usr/local/bin/run_tests
-  ```
-- Drop privileges at the end:
-  ```dockerfile
-  RUN groupadd ugbio && useradd -m ugbio -g ugbio
-  USER ugbio
-  WORKDIR /home/ugbio
-  ```
-
-### Step 4 — Register in the manual Docker build workflow
-
-Add the module name to the `options` list in `.github/workflows/build-ugbio-member-docker.yml`:
-
-```yaml
-        options:
-          - "cnv"
-          ...
-          - "<name>"    # ← add here
-```
-
-The CI matrix (`ugbio_members_matrix.py`) auto-discovers all non-`__` directories under `src/`, so no other changes are needed for the automated test/build matrix.
-
-### Step 5 — Build the Docker image
-
-```bash
-gh workflow run "build-ugbio-member-docker.yml" --ref <branch-name> -f member=<name>
-```
 
 ## Architectural Patterns
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,9 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
-dependencies = []
+dependencies = [
+    "jupyter-collaboration>=4.4.1",
+]
 
 [project.license]
 text = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,6 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
-dependencies = [
-    "jupyter-collaboration>=4.4.1",
-]
 
 [project.license]
 text = "Apache-2.0"
@@ -34,6 +31,7 @@ dev = [
     "sigprofilermatrixgenerator>=1.2.14",
     "sigprofilerplotting>=1.3.12",
     "wdl>=1.0.22",
+    "jupyter-collaboration>=4.4.1",
 ]
 pre-commit-group = [
     "pre-commit>=4.0.1",

--- a/src/t1k/Dockerfile
+++ b/src/t1k/Dockerfile
@@ -5,6 +5,7 @@ FROM ubuntu:24.04
 # autoconf and automake are required to build bundled htslib
 RUN apt update && apt install --no-install-recommends -y \
     git \
+    ca-certificates \
     make \
     build-essential \
     autoconf \

--- a/src/t1k/Dockerfile
+++ b/src/t1k/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 # Install dependencies
 # Note: libdeflate-dev, liblzma-dev, libbz2-dev are required by htslib for compression support
 # autoconf and automake are required to build bundled htslib
-RUN apt update && apt install -y \
+RUN apt update && apt install --no-install-recommends -y \
     git \
     make \
     build-essential \
@@ -17,7 +17,9 @@ RUN apt update && apt install -y \
     libcurl4-openssl-dev \
     libssl-dev \
     perl \
-    && apt clean
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
 
 # Clone T1K (using v1.0.9, closest available release to validation version)
 RUN git clone https://github.com/mourisl/T1K.git /T1K \
@@ -36,9 +38,6 @@ RUN cd /T1K \
     && cd .. \
     && make htslib=1 LINKFLAGS="-lpthread -lz -ldeflate -llzma -lbz2 -lcurl -lssl -lcrypto" -j $(nproc)
 
-# After building T1K
-RUN cd /T1K \
-      && make htslib=1 LINKFLAGS="-lpthread -lz -ldeflate -llzma -lbz2 -lcurl -lssl -lcrypto" -j $(nproc)
 
 # Install htslib shared library
 RUN cp /T1K/htslib-1.15.1/libhts.so.3 /usr/local/lib/ \

--- a/src/t1k/Dockerfile
+++ b/src/t1k/Dockerfile
@@ -52,6 +52,10 @@ RUN ln -s /T1K/run-t1k /usr/local/bin/run-t1k \
 # Clean up build dependencies (keep runtime libraries)
 RUN apt --yes remove git make build-essential autoconf automake libtool && apt --yes autoremove && apt clean
 
+# Create a script to run tests from docker CI
+RUN echo '#!/bin/sh\necho "No tests to run"' > /usr/local/bin/run_tests \
+            && chmod +x /usr/local/bin/run_tests
+
 # Non-root user (following terra_pipeline conventions)
 RUN groupadd ugbio && useradd -m ugbio -g ugbio
 USER ugbio

--- a/src/t1k/Dockerfile
+++ b/src/t1k/Dockerfile
@@ -26,9 +26,14 @@ RUN git clone https://github.com/mourisl/T1K.git /T1K \
 
 # Build T1K with CRAM support
 # htslib=1 tells T1K to build bundled htslib-1.15.1 (includes CRAM support)
-# The Makefile will automatically build htslib if libhts.a doesn't exist
-# We add compression library flags to LINKFLAGS for proper linking
+# First we need to download and build htslib with submodules, then build T1K
 RUN cd /T1K \
+    && git clone --depth 1 --branch 1.15.1 --recurse-submodules https://github.com/samtools/htslib.git htslib-1.15.1 \
+    && cd htslib-1.15.1 \
+    && autoreconf -i \
+    && ./configure \
+    && make -j $(nproc) \
+    && cd .. \
     && make htslib=1 LINKFLAGS="-lpthread -lz -ldeflate -llzma -lbz2 -lcurl -lssl -lcrypto" -j $(nproc)
 
 # Symlink executables to PATH

--- a/src/t1k/Dockerfile
+++ b/src/t1k/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:24.04
+
+# Install dependencies
+# Note: libdeflate-dev, liblzma-dev, libbz2-dev are required by htslib for compression support
+# autoconf and automake are required to build bundled htslib
+RUN apt update && apt install -y \
+    git \
+    make \
+    build-essential \
+    autoconf \
+    automake \
+    libtool \
+    libdeflate-dev \
+    liblzma-dev \
+    libbz2-dev \
+    zlib1g-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    perl \
+    && apt clean
+
+# Clone T1K (using v1.0.9, closest available release to validation version)
+RUN git clone https://github.com/mourisl/T1K.git /T1K \
+    && cd /T1K \
+    && git checkout v1.0.9
+
+# Build T1K with CRAM support
+# htslib=1 tells T1K to build bundled htslib-1.15.1 (includes CRAM support)
+# The Makefile will automatically build htslib if libhts.a doesn't exist
+# We add compression library flags to LINKFLAGS for proper linking
+RUN cd /T1K \
+    && make htslib=1 LINKFLAGS="-lpthread -lz -ldeflate -llzma -lbz2 -lcurl -lssl -lcrypto" -j $(nproc)
+
+# Symlink executables to PATH
+RUN ln -s /T1K/run-t1k /usr/local/bin/run-t1k \
+    && ln -s /T1K/t1k-build.pl /usr/local/bin/t1k-build.pl \
+    && ln -s /T1K/bam-extractor /usr/local/bin/bam-extractor
+
+# Clean up build dependencies (keep runtime libraries)
+RUN apt --yes remove git make build-essential autoconf automake libtool && apt --yes autoremove && apt clean
+
+# Non-root user (following terra_pipeline conventions)
+RUN groupadd ugbio && useradd -m ugbio -g ugbio
+USER ugbio
+WORKDIR /home/ugbio

--- a/src/t1k/Dockerfile
+++ b/src/t1k/Dockerfile
@@ -36,6 +36,14 @@ RUN cd /T1K \
     && cd .. \
     && make htslib=1 LINKFLAGS="-lpthread -lz -ldeflate -llzma -lbz2 -lcurl -lssl -lcrypto" -j $(nproc)
 
+# After building T1K
+RUN cd /T1K \
+      && make htslib=1 LINKFLAGS="-lpthread -lz -ldeflate -llzma -lbz2 -lcurl -lssl -lcrypto" -j $(nproc)
+
+# Install htslib shared library
+RUN cp /T1K/htslib-1.15.1/libhts.so.3 /usr/local/lib/ \
+      && ldconfig
+
 # Symlink executables to PATH
 RUN ln -s /T1K/run-t1k /usr/local/bin/run-t1k \
     && ln -s /T1K/t1k-build.pl /usr/local/bin/t1k-build.pl \

--- a/src/t1k/README_t1k.md
+++ b/src/t1k/README_t1k.md
@@ -1,0 +1,3 @@
+# ugbio T1K
+
+A docker for running [T1K](https://github.com/mourisl/T1K) — a fast and accurate tool for genotyping HLA and KIR loci from sequencing data.

--- a/src/t1k/pyproject.toml
+++ b/src/t1k/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "ugbio_t1k"
+version = "1.27.0"
+description = "T1K - HLA and KIR genotyping"
+authors = [
+    { name = "Ilya Soifer", email = "ilya.soifer@ultimagen.com" },
+]
+readme = "README_t1k.md"
+
+[project.license]
+text = "Apache-2.0"

--- a/src/t1k/pyproject.toml
+++ b/src/t1k/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ugbio_t1k"
-version = "1.27.0"
+version = "1.27.2-0"
 description = "T1K - HLA and KIR genotyping"
 authors = [
     { name = "Ilya Soifer", email = "ilya.soifer@ultimagen.com" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds an isolated container build and workflow option with no changes to runtime pipelines or shared auth/data paths; stub test script means image correctness is not validated in CI.
> 
> **Overview**
> Adds a new **`t1k`** workspace member and wires it into the manual **Build ugbio docker** workflow so CI can build and push `ugbio_t1k`.
> 
> The **`src/t1k/Dockerfile`** builds [T1K](https://github.com/mourisl/T1K) **v1.0.9** on Ubuntu 24.04 with bundled **htslib 1.15.1** for **CRAM** support, exposes `run-t1k`, `t1k-build.pl`, and `bam-extractor`, runs as non-root **`ugbio`**, and stubs **`run_tests`** for the shared Docker CI pattern. A minimal **`ugbio_t1k`** `pyproject.toml` and README document the image.
> 
> Root **`pyproject.toml`** drops the empty project `dependencies` list and adds **`jupyter-collaboration`** to the dev dependency group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b55b3a7268a0cc5db02f7d764bcf7b628a06b5b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->