### PR TITLE
Added bcftools; pypgx to 0.27

### DIFF
--- a/src/pypgx/Dockerfile
+++ b/src/pypgx/Dockerfile
@@ -1,18 +1,20 @@
 FROM python:3.12-slim
 
-ARG PYPGX_BRANCH=0.26.0
-ARG PYPGX_BUNDLE_BRANCH=0.26.0
+ARG PYPGX_BRANCH=0.27.0
+ARG PYPGX_BUNDLE_BRANCH=0.27.0
 
 # Install dependencies and create venv
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y default-jre-headless git build-essential wget unzip bcftools free
+    apt-get install --no-install-recommends -y default-jre-headless git build-essential wget unzip bcftools procps
 
 # Install pypgx
 RUN git clone https://github.com/sbslee/pypgx /opt/pypgx && \
     cd /opt/pypgx && \
     git checkout ${PYPGX_BRANCH} && \
     pip install . && \
-    rm -rf /opt/pypgx
+    cd / && \
+    rm -rf /opt/pypgx && \
+    pip install pandas==2.3.3
 
 # Clone the pypgx-bundle repository at the corresponding version
 RUN git clone --branch ${PYPGX_BUNDLE_BRANCH} --depth 1 https://github.com/sbslee/pypgx-bundle /opt/pypgx-bundle

--- a/src/pypgx/Dockerfile
+++ b/src/pypgx/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.12-slim
 
-ARG PYPGX_BRANCH=0.27.0
-ARG PYPGX_BUNDLE_BRANCH=0.27.0
+ARG PYPGX_BRANCH=0.26.0
+ARG PYPGX_BUNDLE_BRANCH=0.26.0
 
 # Install dependencies and create venv
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y default-jre-headless git build-essential wget unzip bcftools
+    apt-get install --no-install-recommends -y default-jre-headless git build-essential wget unzip bcftools free
 
 # Install pypgx
 RUN git clone https://github.com/sbslee/pypgx /opt/pypgx && \

--- a/src/pypgx/Dockerfile
+++ b/src/pypgx/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.12-slim
 
-ARG PYPGX_BRANCH=0.26.0
-ARG PYPGX_BUNDLE_BRANCH=0.26.0
+ARG PYPGX_BRANCH=0.27.0
+ARG PYPGX_BUNDLE_BRANCH=0.27.0
 
 # Install dependencies and create venv
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y default-jre-headless git build-essential wget unzip
+    apt-get install --no-install-recommends -y default-jre-headless git build-essential wget unzip bcftools
 
 # Install pypgx
 RUN git clone https://github.com/sbslee/pypgx /opt/pypgx && \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Container build-only changes (version bump, extra CLI tools, pandas pin) with no application auth or data-path changes in this diff.
> 
> **Overview**
> Upgrades the **pypgx** and **pypgx-bundle** build args from **0.26.0** to **0.27.0** so the container installs the newer release.
> 
> The image now installs **bcftools** and **procps** via apt (alongside existing JRE/git/build tools). After installing pypgx from source, the build explicitly **`pip install pandas==2.3.3`** and adjusts the cleanup step (`cd /` before removing the clone).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083356f5d6396161e08f10ff79f62f3fe10ed02d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->