### PR TITLE
DATA-9857 Add artifact-name pass-through to release-and-build-docker

### DIFF
--- a/.github/workflows/release-and-build-docker.yml
+++ b/.github/workflows/release-and-build-docker.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: ""
+      artifact-name:
+        description: "Artifact name to download before building (passed to docker-build-push). If omitted, no artifact is downloaded"
+        required: false
+        type: string
+        default: ""
       base-branch:
         description: "Base branch (defaults to main)"
         required: false
@@ -120,6 +125,7 @@ jobs:
       docker-context: ${{ inputs.docker-context }}
       docker-target: ${{ inputs.docker-target }}
       docker-build-args: ${{ inputs.docker-build-args }}
+      artifact-name: ${{ inputs.artifact-name }}
       base-branch: ${{ inputs.base-branch }}
       project-version: ${{ needs.release.outputs.new_version }}
       runner: ${{ inputs.runner }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI workflow wiring only; optional input with empty default leaves existing release-and-build flows unchanged.
> 
> **Overview**
> The reusable **`release-and-build-docker`** workflow now accepts an optional **`artifact-name`** input and forwards it to **`docker-build-push`**, so callers can trigger a semver release and Docker build while supplying a GitHub Actions artifact to download before the image build.
> 
> When **`artifact-name`** is omitted (default empty string), behavior is unchanged—no artifact download step runs in the downstream workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a761950c92b8ccf0f60f124647dc607fd8606de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->