### PR TITLE
do not rebuild fasta index by default in LPA caller

### DIFF
--- a/src/cnv/tests/system/test_lpa_caller_system.py
+++ b/src/cnv/tests/system/test_lpa_caller_system.py
@@ -106,7 +106,7 @@ def test_run_end_to_end_on_kiv2_bam(hg01046_bam: Path, tmp_path: Path, monkeypat
     # is sufficient.
     stub_fasta = tmp_path / "chr6_stub.fa"
     stub_fasta.write_text(">chr6\nN\n")
-    pyfaidx.FastaFile(str(stub_fasta)).close()  # create .fai index
+    pyfaidx.Fasta(str(stub_fasta)).close()  # create .fai index
     # Feed the KIV-2 copy number directly and skip REF-base validation (both
     # require the full hg38 reference we deliberately don't ship here).
     monkeypatch.setattr(

--- a/src/cnv/tests/system/test_lpa_caller_system.py
+++ b/src/cnv/tests/system/test_lpa_caller_system.py
@@ -14,6 +14,7 @@ against just the (~4 MB) KIV-2 slice.
 import json
 from pathlib import Path
 
+import pyfaidx
 import pysam
 import pytest
 from ugbio_cnv import lpa_caller as lpa_caller_mod
@@ -105,7 +106,7 @@ def test_run_end_to_end_on_kiv2_bam(hg01046_bam: Path, tmp_path: Path, monkeypat
     # is sufficient.
     stub_fasta = tmp_path / "chr6_stub.fa"
     stub_fasta.write_text(">chr6\nN\n")
-
+    pyfaidx.FastaFile(str(stub_fasta)).close()  # create .fai index
     # Feed the KIV-2 copy number directly and skip REF-base validation (both
     # require the full hg38 reference we deliberately don't ship here).
     monkeypatch.setattr(

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -963,7 +963,7 @@ def run(argv: list[str]) -> None:
         open_kwargs["index_filename"] = args.crai
     bam = pysam.AlignmentFile(args.cram, mode, **open_kwargs)
     try:
-        fasta = pyfaidx.Fasta(args.reference, rebuild=False)
+        fasta = pyfaidx.Fasta(args.reference, rebuild=False, build_index=False)
         try:
             markers = [_build_marker(spec) for spec in DEFAULT_MARKER_VARIANTS]
             small_variants = [_build_marker(spec) for spec in DEFAULT_SMALL_VARIANTS]

--- a/src/cnv/ugbio_cnv/lpa_caller.py
+++ b/src/cnv/ugbio_cnv/lpa_caller.py
@@ -963,7 +963,7 @@ def run(argv: list[str]) -> None:
         open_kwargs["index_filename"] = args.crai
     bam = pysam.AlignmentFile(args.cram, mode, **open_kwargs)
     try:
-        fasta = pyfaidx.Fasta(args.reference)
+        fasta = pyfaidx.Fasta(args.reference, rebuild=False)
         try:
             markers = [_build_marker(spec) for spec in DEFAULT_MARKER_VARIANTS]
             small_variants = [_build_marker(spec) for spec in DEFAULT_SMALL_VARIANTS]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small reference-loading change with a matching test fix; production runs must already ship a valid `.fai` beside the reference.
> 
> **Overview**
> The LPA caller now opens the reference with **`pyfaidx.Fasta(..., rebuild=False, build_index=False)`**, so it uses an existing `.fai` and does not rebuild or create an index on startup.
> 
> The HG01046 end-to-end system test **writes a `.fai` for the stub FASTA** before invoking the CLI, since the caller no longer auto-builds one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337921f9f3968f17d331ca15447f6bea77a7275f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->