### PR TITLE
Consensus tool analysis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,7 @@
 *.rds filter=lfs diff=lfs merge=lfs -text
 *.bigWig filter=lfs diff=lfs merge=lfs -text
 *seqdata0 filter=lfs diff=lfs merge=lfs -text
+
+# consensus test resources: large sorter JSON and gzipped bedGraph fixtures
+src/consensus/tests/resources/*.json filter=lfs diff=lfs merge=lfs -text
+src/consensus/tests/resources/*.bedGraph.gz filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build-ugbio-member-docker.yml
+++ b/.github/workflows/build-ugbio-member-docker.yml
@@ -8,6 +8,7 @@ on:
         type: choice
         options:
           - "cnv"
+          - "consensus"
           - "core"
           - "comparison"
           - "featuremap"

--- a/src/consensus/Dockerfile
+++ b/src/consensus/Dockerfile
@@ -1,0 +1,30 @@
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
+ARG BASE_IMAGE
+ARG OUT_DIR=/tmp/ugbio
+FROM python:3.11-bullseye AS build
+
+ARG OUT_DIR
+ARG MODULE_DIR=consensus
+RUN mkdir -p $OUT_DIR
+
+COPY ./src/ ./src/
+
+#build ugbio_core + ugbio_cloud_utils + module
+RUN python -m pip install build
+RUN python -m build --outdir $OUT_DIR --wheel ./src/core
+RUN python -m build --outdir $OUT_DIR --wheel ./src/cloud_utils
+RUN python -m build --outdir $OUT_DIR --wheel ./src/$MODULE_DIR
+
+##################################################################
+FROM ${BASE_IMAGE}
+
+ARG OUT_DIR
+
+RUN groupadd ugbio && useradd -m ugbio -g ugbio
+
+COPY --from=build ${OUT_DIR} ${OUT_DIR}
+RUN pip install ${OUT_DIR}/*.whl && rm -rf ${OUT_DIR}
+
+USER ugbio
+
+WORKDIR /home/ugbio

--- a/src/consensus/Dockerfile
+++ b/src/consensus/Dockerfile
@@ -1,29 +1,36 @@
 # BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
 ARG BASE_IMAGE
+ARG BASE_BUILD_IMAGE
 ARG OUT_DIR=/tmp/ugbio
-FROM python:3.11-bullseye AS build
+FROM $BASE_BUILD_IMAGE AS build
 
 ARG OUT_DIR
 ARG MODULE_DIR=consensus
 RUN mkdir -p $OUT_DIR
 
+# Create virtual environment for pip install
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
 COPY ./src/ ./src/
 
 #build ugbio_core + ugbio_cloud_utils + module
-RUN python -m pip install build
+RUN pip install build
 RUN python -m build --outdir $OUT_DIR --wheel ./src/core
 RUN python -m build --outdir $OUT_DIR --wheel ./src/cloud_utils
 RUN python -m build --outdir $OUT_DIR --wheel ./src/$MODULE_DIR
 
+# Install wheels — C extensions compile here, not in runtime
+RUN pip install ${OUT_DIR}/*.whl
+
 ##################################################################
 FROM ${BASE_IMAGE}
 
-ARG OUT_DIR
-
 RUN groupadd ugbio && useradd -m ugbio -g ugbio
 
-COPY --from=build ${OUT_DIR} ${OUT_DIR}
-RUN pip install ${OUT_DIR}/*.whl && rm -rf ${OUT_DIR}
+# Copy pre-built virtual environment from build stage (no compilation in runtime)
+COPY --from=build /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 USER ugbio
 

--- a/src/consensus/README.consensus.md
+++ b/src/consensus/README.consensus.md
@@ -1,0 +1,88 @@
+# ugbio_consensus
+
+Performance & duplex reports for the **ReadFuserAlignSort** (consensus tool)
+pipeline at Ultima Genomics.
+
+The consensus step (`read_fuser`) fuses the reads of each UMI/MI family into a
+single consensus read and records, on that read, an `rs:B:i` tag:
+
+```
+rs = [n_forward_strand_reads, n_reverse_strand_reads]
+```
+
+i.e. how many original reads on the forward (+) and reverse (−) strand were
+fused. From this single tag the report classifies every consensus read and
+measures family size **directly** (no MI re-grouping needed):
+
+| Category | `rs` condition | Family size |
+|----------|----------------|-------------|
+| both-strands **duplex** | both entries > 0 | `n_fwd + n_rev` |
+| **single-strand** duplicate | exactly one entry is 0 | the non-zero entry |
+| **singleton** / pass-through | no `rs` tag | 1 |
+
+`sum(rs)` equals the length of the `rn` (fused read-name) list, so the two tag
+encodings agree on family size.
+
+## What the report summarises (per sample)
+
+- **Sorter QC** — alignment, duplication and coverage metrics from
+  `sorter_stats_csv` (post-consensus).
+- **Duplex family metrics** — average MI-family size *and* covered depth for
+  duplex families and for single-strand duplicate families, from the `rs` tag.
+  These are scanned over one chromosome (`--duplex-chrom`, default `chr20`) — a
+  representative sample that avoids reading the whole (very large) CRAM. When a
+  targets BED is given, the scan is restricted to the targeted intervals on that
+  chromosome.
+- **On-target metrics (optional)** — when a `--targets` BED is supplied
+  (e.g. an exome capture BED): on-target rate and on-target mean coverage from
+  the `bedgraph_mapq0` coverage track. Omit `--targets` for genome-wide coverage
+  only. The report is target-agnostic; the exome case is simply "targets given".
+- **Consensus tool performance** — when a `--consensus-log` is supplied, the
+  counters parsed from the consensus tool stdout log.
+
+All inputs are **local files** — the report does no S3/DB access.
+
+## Usage
+
+```bash
+# Single sample, with an exome targets BED (Quotient case)
+consensus_report \
+    --name Z0315 \
+    --cram Z0315.cram --crai Z0315.cram.crai \
+    --sorter-stats-csv Z0315.csv --sorter-stats-json Z0315.json \
+    --bedgraph Z0315_0.bedGraph.gz --consensus-log Z0315.consensus.stdout.log \
+    --reference /data/Runs/genomes/hg38/ref_gen/Homo_sapiens_assembly38.fasta \
+    --targets Twist_Alliance_Clinical_Research_Exome_hg38.bed \
+    --output report.html
+
+# Multiple samples: one repeatable --sample key=value block per sample
+consensus_report \
+    --sample name=Z0315 cram=Z0315.cram sorter_stats_csv=Z0315.csv \
+        sorter_stats_json=Z0315.json bedgraph=Z0315_0.bedGraph.gz \
+    --sample name=Z0316 cram=Z0316.cram sorter_stats_csv=Z0316.csv \
+        sorter_stats_json=Z0316.json bedgraph=Z0316_0.bedGraph.gz \
+    --reference ref.fasta --targets exome.bed --output run_report.html
+
+# b37 reference: scan chromosome 20 under its b37 name
+consensus_report ... --duplex-chrom 20 --output report.html
+```
+
+Outputs (alongside `--output`):
+
+- `<output>.html` — the self-contained HTML report.
+- `<output>_per_sample.csv` — full per-sample metrics table (provenance).
+- `<output>_manifest.csv` — resolved input paths (provenance).
+
+## Modules
+
+| Module | Role |
+|--------|------|
+| `duplex_metrics.py` | Parse `rs:B:i`, classify families, family size + coverage per category (with an `MI`-tag fallback). |
+| `on_target.py` | Genome-wide and optional on-target coverage from a bedGraph + targets BED. |
+| `consensus_log.py` | Parse the consensus tool stdout log for performance counters. |
+| `consensus_report.py` | CLI orchestration: read local inputs, compute metrics, write the HTML report + CSVs. |
+
+## Requirements
+
+- `bedtools` and `samtools` on `PATH` (used for BED handling and CRAM decoding).
+- The reference FASTA matching the run's `reference_genome`.

--- a/src/consensus/pyproject.toml
+++ b/src/consensus/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "ugbio_consensus"
+version = "1.27.0-0"
+requires-python = ">=3.11"
+description = "Ultima Genomics consensus (ReadFuserAlignSort) performance & duplex reports"
+authors = [
+    { name = "Gat Krieger", email = "gat.krieger@ultimagen.com" },
+]
+readme = "README.consensus.md"
+dependencies = [
+    "ugbio_core[vcfbed]",
+    "ugbio_cloud_utils",
+    "pysam>=0.22.0",
+    "boto3",
+]
+
+[project.license]
+text = "Apache-2.0"
+
+[project.scripts]
+run_tests = "pytest:main"
+consensus_report = "ugbio_consensus.consensus_report:main"
+
+[tool.uv.sources.ugbio_core]
+workspace = true
+
+[tool.uv.sources.ugbio_cloud_utils]
+workspace = true
+
+[build-system]
+requires = [
+    "setuptools>=61.0",
+]
+build-backend = "setuptools.build_meta"

--- a/src/consensus/tests/resources/consensus.chr1_13400000_13403000.bam
+++ b/src/consensus/tests/resources/consensus.chr1_13400000_13403000.bam
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c40161fa52299717386d5a5bb663162f7a5c1bff40b0799c035fd2a93de34d7a
+size 887759

--- a/src/consensus/tests/resources/consensus.chr1_13400000_13403000.bam
+++ b/src/consensus/tests/resources/consensus.chr1_13400000_13403000.bam
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c40161fa52299717386d5a5bb663162f7a5c1bff40b0799c035fd2a93de34d7a
-size 887759
+oid sha256:eab20eb43f0ace6755d4eeca485d1201312308a57a11512882f1fe88a44cd841
+size 899871

--- a/src/consensus/tests/resources/consensus.chr1_13400000_13403000.bam.bai
+++ b/src/consensus/tests/resources/consensus.chr1_13400000_13403000.bam.bai
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11c53022ae9dd6895b96b364c7984ea47933e1a779e4030196f3d973367192a7
-size 33672
+oid sha256:02e573145b8ae0be9574a62f39f26b1690eb6f1dba02c31aa451dee3cb36efd7
+size 829984

--- a/src/consensus/tests/resources/consensus.chr1_13400000_13403000.bam.bai
+++ b/src/consensus/tests/resources/consensus.chr1_13400000_13403000.bam.bai
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11c53022ae9dd6895b96b364c7984ea47933e1a779e4030196f3d973367192a7
+size 33672

--- a/src/consensus/tests/resources/consensus.chr1_13400000_13403000.stdout.log
+++ b/src/consensus/tests/resources/consensus.chr1_13400000_13403000.stdout.log
@@ -1,2 +1,2 @@
 done process_all_records
-stats=Stats { alt_prob_too_high: 0, hmer_too_long: 52, no_clear_hmer_choice: 9, not_same_contig: 0, other_error: 20, dup_sets_merged: 533, unchanged_segments: 4791 }
+stats=Stats { alt_prob_too_high: 0, hmer_too_long: 52, no_clear_hmer_choice: 9, not_same_contig: 0, other_error: 20, dup_sets_merged: 533, unchanged_segments: 4791, consensus_forward_reads: 559, consensus_reverse_reads: 572, duplex_consensus: 215, single_strand_consensus: 318 }

--- a/src/consensus/tests/resources/consensus.chr1_13400000_13403000.stdout.log
+++ b/src/consensus/tests/resources/consensus.chr1_13400000_13403000.stdout.log
@@ -1,0 +1,2 @@
+done process_all_records
+stats=Stats { alt_prob_too_high: 0, hmer_too_long: 52, no_clear_hmer_choice: 9, not_same_contig: 0, other_error: 20, dup_sets_merged: 533, unchanged_segments: 4791 }

--- a/src/consensus/tests/resources/coverage.chr1_13400000_13403000.bedGraph.gz
+++ b/src/consensus/tests/resources/coverage.chr1_13400000_13403000.bedGraph.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4295c31ef32f758fb9aece453df2dc3b3908053c0958237476f0fb811e074f10
+size 18319

--- a/src/consensus/tests/resources/sorter_stats.chr1_13400000_13403000.csv
+++ b/src/consensus/tests/resources/sorter_stats.chr1_13400000_13403000.csv
@@ -1,0 +1,38 @@
+PF_Barcode_reads,5278
+PCT_PF_aligned,97.72
+PCT_PF_Reads_aligned,100.0
+PCT_SOFTCLIPPED_bases,1.97
+PCT_PF_HQ_aligned,95.2
+PCT_PF_Q20_bases,90.63
+PCT_PF_Q30_bases,78.33
+Mean_quality,33.74
+Mismatch_Rate,0.33
+Indel_Rate,0.6
+Mean_Read_Length,143.59
+Median_Read_Length,137
+Mean_Aligned_Read_Length,143.59
+Failed_QC_reads,0
+PCT_Failed_QC_reads,0.0
+MAPQ >= 1,5111
+MAPQ >= 10,5021
+MAPQ >= 20,4928
+MAPQ >= 30,4878
+PCT_Chimeras,0.39
+Mean_cvg,0.0
+median_cvg,0.0
+%>=1x,0.0
+%>=10x,0.0
+%>=20x,0.0
+%>=50x,0.0
+%>=100x,0.0
+%>=500x,0.0
+%>=1000x,0.0
+% duplicates,0.0
+% optical duplicates false-detection,0.0
+% optical duplicates ring-overlap,0.0
+F80,0
+F90,0
+F95,0
+F80@30x,(0)
+F90@30x,(0)
+F95@30x,(0)

--- a/src/consensus/tests/resources/sorter_stats.chr1_13400000_13403000.json
+++ b/src/consensus/tests/resources/sorter_stats.chr1_13400000_13403000.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fd1a4db89aa772686495df34ccf1decdbeffd03fd3a2a64adf7370e314050feb
+size 1371030

--- a/src/consensus/tests/system/test_consensus_report_system.py
+++ b/src/consensus/tests/system/test_consensus_report_system.py
@@ -3,8 +3,9 @@
 The fixtures are the ReadFuserAlignSort nightly regression output for the region
 ``chr1:13400000-13403000`` (sample ``502285-L11546-Z0236``), subset to a
 self-contained BAM so the CRAM's hg38 reference is not needed to decode it. The
-BAM keeps the consensus ``rs:B:i`` tags, so the duplex/family path is exercised
-for real; ``--duplex-chrom chr1`` scopes the scan to this region's chromosome.
+BAM keeps the consensus ``fs:i``/``rs:i`` strand tags, so the duplex/family path
+is exercised for real; ``--duplex-chrom all`` scans the whole input with no
+region limitation.
 """
 
 from pathlib import Path
@@ -32,7 +33,7 @@ def region_inputs(resources_dir):
 
 
 def test_consensus_report_on_chr1_region(region_inputs, tmp_path):
-    """Full CLI run: HTML + sidecar CSVs, with real duplex metrics from rs tags."""
+    """Full CLI run: HTML + sidecar CSVs, with real duplex metrics from fs/rs tags."""
     output = tmp_path / "report.html"
     metrics = consensus_report.run(
         [
@@ -52,8 +53,9 @@ def test_consensus_report_on_chr1_region(region_inputs, tmp_path):
             # BAM embeds its sequence, so no external reference is needed to decode it.
             "--reference",
             "/dev/null",
+            # Scan the whole input, no region limitation.
             "--duplex-chrom",
-            "chr1",
+            "all",
             "--output",
             str(output),
         ]
@@ -76,14 +78,17 @@ def test_consensus_report_on_chr1_region(region_inputs, tmp_path):
     row = metrics.iloc[0]
     assert row["sample"] == "Z0236_chr1_test"
 
-    # 531 rs-tagged consensus reads live in this region; classified into
-    # duplex / single-strand families, the rest passed through as singletons.
-    assert row["duplex_n_reads"] == 214
-    assert row["single_strand_n_reads"] == 317
-    assert row["duplex_avg_family_size"] == pytest.approx(2.1448598, rel=1e-4)
-    assert row["single_strand_avg_family_size"] == pytest.approx(2.0914826, rel=1e-4)
+    # --duplex-chrom all scans the whole CRAM, so all 533 merged consensus reads
+    # are classified: 215 both-strands duplex + 318 single-strand (the rest of the
+    # BAM passes through as singletons). This matches the whole-run dup_sets_merged
+    # total from the consensus log (533) below.
+    assert row["duplex_n_reads"] == 215
+    assert row["single_strand_n_reads"] == 318
+    assert row["duplex_n_reads"] + row["single_strand_n_reads"] == row["consensus_dup_sets_merged"]
+    assert row["duplex_avg_family_size"] == pytest.approx(2.1441860, rel=1e-4)
+    assert row["single_strand_avg_family_size"] == pytest.approx(2.1069182, rel=1e-4)
 
-    # Consensus stdout log parsed into the table.
+    # Consensus stdout log parsed into the table: whole-run dup-set totals.
     assert row["consensus_dup_sets_merged"] == 533
     assert row["consensus_unchanged_segments"] == 4791
 

--- a/src/consensus/tests/system/test_consensus_report_system.py
+++ b/src/consensus/tests/system/test_consensus_report_system.py
@@ -1,0 +1,92 @@
+"""End-to-end ``consensus_report`` run on a real ReadFuserAlignSort output subset.
+
+The fixtures are the ReadFuserAlignSort nightly regression output for the region
+``chr1:13400000-13403000`` (sample ``502285-L11546-Z0236``), subset to a
+self-contained BAM so the CRAM's hg38 reference is not needed to decode it. The
+BAM keeps the consensus ``rs:B:i`` tags, so the duplex/family path is exercised
+for real; ``--duplex-chrom chr1`` scopes the scan to this region's chromosome.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from ugbio_consensus import consensus_report
+
+
+@pytest.fixture
+def resources_dir():
+    return Path(__file__).parent.parent / "resources"
+
+
+@pytest.fixture
+def region_inputs(resources_dir):
+    """Local input files for the chr1:13400000-13403000 test region."""
+    return {
+        "cram": resources_dir / "consensus.chr1_13400000_13403000.bam",
+        "sorter_stats_csv": resources_dir / "sorter_stats.chr1_13400000_13403000.csv",
+        "sorter_stats_json": resources_dir / "sorter_stats.chr1_13400000_13403000.json",
+        "bedgraph": resources_dir / "coverage.chr1_13400000_13403000.bedGraph.gz",
+        "consensus_log": resources_dir / "consensus.chr1_13400000_13403000.stdout.log",
+    }
+
+
+def test_consensus_report_on_chr1_region(region_inputs, tmp_path):
+    """Full CLI run: HTML + sidecar CSVs, with real duplex metrics from rs tags."""
+    output = tmp_path / "report.html"
+    metrics = consensus_report.run(
+        [
+            "consensus_report",
+            "--name",
+            "Z0236_chr1_test",
+            "--cram",
+            str(region_inputs["cram"]),
+            "--sorter-stats-csv",
+            str(region_inputs["sorter_stats_csv"]),
+            "--sorter-stats-json",
+            str(region_inputs["sorter_stats_json"]),
+            "--bedgraph",
+            str(region_inputs["bedgraph"]),
+            "--consensus-log",
+            str(region_inputs["consensus_log"]),
+            # BAM embeds its sequence, so no external reference is needed to decode it.
+            "--reference",
+            "/dev/null",
+            "--duplex-chrom",
+            "chr1",
+            "--output",
+            str(output),
+        ]
+    )
+
+    # --- Outputs written ---
+    assert output.exists()
+    per_sample_csv = tmp_path / "report_per_sample.csv"
+    manifest_csv = tmp_path / "report_manifest.csv"
+    assert per_sample_csv.exists()
+    assert manifest_csv.exists()
+
+    html = output.read_text()
+    assert "Both-strands duplex" in html
+    assert "Consensus tool performance" in html
+
+    # --- One sample, expected duplex/consensus values for this fixed region ---
+    assert isinstance(metrics, pd.DataFrame)
+    assert len(metrics) == 1
+    row = metrics.iloc[0]
+    assert row["sample"] == "Z0236_chr1_test"
+
+    # 531 rs-tagged consensus reads live in this region; classified into
+    # duplex / single-strand families, the rest passed through as singletons.
+    assert row["duplex_n_reads"] == 214
+    assert row["single_strand_n_reads"] == 317
+    assert row["duplex_avg_family_size"] == pytest.approx(2.1448598, rel=1e-4)
+    assert row["single_strand_avg_family_size"] == pytest.approx(2.0914826, rel=1e-4)
+
+    # Consensus stdout log parsed into the table.
+    assert row["consensus_dup_sets_merged"] == 533
+    assert row["consensus_unchanged_segments"] == 4791
+
+    # Coverage came from the bedGraph (genome-wide; no targets BED -> on-target is null).
+    assert row["genome_mean_cvg"] > 0
+    assert pd.isna(row["on_target_rate"])

--- a/src/consensus/tests/unit/test_consensus_log.py
+++ b/src/consensus/tests/unit/test_consensus_log.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from ugbio_consensus.consensus_log import parse_consensus_log
+
+_LOG = """There are dark flows : [c]
+total=200020, 23660 unhandled, 176360 dup_set_members
+total=400040, 53512 unhandled, 346528 dup_set_members
+total=1000000, 100000 unhandled, 900000 dup_set_members
+done process_all_records
+stats=Stats { alt_prob_too_high: 0, hmer_too_long: 5712685, no_clear_hmer_choice: 14009063, \
+not_same_contig: 4, other_error: 1006093, dup_sets_merged: 216196151, unchanged_segments: 297230665 }
+"""
+
+
+def _write_log(tmp_path: Path) -> str:
+    p = tmp_path / "consensus.stdout.log"
+    p.write_text(_LOG, encoding="utf-8")
+    return str(p)
+
+
+def test_parse_uses_last_total_line(tmp_path):
+    metrics = parse_consensus_log(_write_log(tmp_path))
+    assert metrics["total_reads"] == 1_000_000
+    assert metrics["unhandled"] == 100_000
+    assert metrics["dup_set_members"] == 900_000
+
+
+def test_parse_derived_rates(tmp_path):
+    metrics = parse_consensus_log(_write_log(tmp_path))
+    assert metrics["PCT_unhandled"] == 10.0
+    assert metrics["PCT_dup_set_members"] == 90.0
+
+
+def test_parse_stats_counters(tmp_path):
+    metrics = parse_consensus_log(_write_log(tmp_path))
+    assert metrics["hmer_too_long"] == 5_712_685
+    assert metrics["no_clear_hmer_choice"] == 14_009_063
+    assert metrics["dup_sets_merged"] == 216_196_151
+    assert metrics["unchanged_segments"] == 297_230_665
+    assert metrics["alt_prob_too_high"] == 0
+
+
+def test_parse_missing_pieces_are_absent(tmp_path):
+    p = tmp_path / "only_stats.log"
+    p.write_text("stats=Stats { hmer_too_long: 5 }\n", encoding="utf-8")
+    metrics = parse_consensus_log(str(p))
+    assert metrics == {"hmer_too_long": 5}
+    assert "total_reads" not in metrics

--- a/src/consensus/tests/unit/test_duplex_metrics.py
+++ b/src/consensus/tests/unit/test_duplex_metrics.py
@@ -1,0 +1,29 @@
+from ugbio_consensus import duplex_metrics
+from ugbio_consensus.duplex_metrics import DUPLEX, SINGLE_STRAND, SINGLETON, classify_family
+
+
+def test_classify_duplex():
+    assert classify_family(4, 4) == DUPLEX
+    assert classify_family(1, 6) == DUPLEX
+
+
+def test_classify_single_strand():
+    assert classify_family(5, 0) == SINGLE_STRAND
+    assert classify_family(0, 3) == SINGLE_STRAND
+
+
+def test_classify_singleton():
+    assert classify_family(1, 0) == SINGLETON
+    assert classify_family(0, 1) == SINGLETON
+    assert classify_family(0, 0) == SINGLETON
+
+
+def test_merge_intervals_disjoint():
+    merged = duplex_metrics._merge_intervals(
+        [("chr1", 100, 200), ("chr1", 150, 250), ("chr1", 400, 500), ("chr2", 0, 50)]
+    )
+    assert merged == [("chr1", 100, 250), ("chr1", 400, 500), ("chr2", 0, 50)]
+
+
+def test_categories_order():
+    assert duplex_metrics.CATEGORIES == (DUPLEX, SINGLE_STRAND, SINGLETON)

--- a/src/consensus/tests/unit/test_on_target.py
+++ b/src/consensus/tests/unit/test_on_target.py
@@ -1,0 +1,59 @@
+"""On-target / coverage computation from a small synthetic bedGraph + BED."""
+
+import gzip
+
+import pytest
+from ugbio_consensus.on_target import (
+    bed_covered_size,
+    compute_coverage_from_bedgraph,
+    sorted_bed,
+)
+
+# bedGraph: chrom start end depth
+_BEDGRAPH = "chr1\t0\t100\t10\nchr1\t100\t200\t20\nchr1\t200\t300\t5\n"
+# targets: chr1:100-200 -> the middle (depth-20) block, fully on target
+_TARGETS = "chr1\t100\t200\n"
+
+
+@pytest.fixture
+def bedgraph(tmp_path):
+    p = tmp_path / "cov.bedGraph.gz"
+    with gzip.open(p, "wt") as fh:
+        fh.write(_BEDGRAPH)
+    return str(p)
+
+
+@pytest.fixture
+def targets_sorted(tmp_path):
+    raw = tmp_path / "targets.bed"
+    raw.write_text(_TARGETS, encoding="utf-8")
+    return sorted_bed(str(raw), str(tmp_path / "targets.sorted.bed")), str(raw)
+
+
+def test_bed_covered_size(targets_sorted):
+    _, raw = targets_sorted
+    assert bed_covered_size(raw) == 100
+
+
+def test_genome_wide_only(bedgraph):
+    # total weighted bases = 100*10 + 100*20 + 100*5 = 3500
+    res = compute_coverage_from_bedgraph(bedgraph, genome_size=1000)
+    assert res.total_bases_seq == 3500
+    assert res.on_target_bases_seq is None
+    assert res.on_target_rate is None
+    assert res.genome_mean_cvg == pytest.approx(3.5)
+
+
+def test_on_target(bedgraph, targets_sorted):
+    sorted_path, _ = targets_sorted
+    # on-target weighted bases = 100*20 = 2000; total = 3500
+    res = compute_coverage_from_bedgraph(bedgraph, genome_size=1000, targets_bed_sorted=sorted_path, target_size=100)
+    assert res.on_target_bases_seq == 2000
+    assert res.on_target_rate == pytest.approx(2000 / 3500)
+    assert res.target_mean_cvg == pytest.approx(20.0)
+
+
+def test_target_size_required(bedgraph, targets_sorted):
+    sorted_path, _ = targets_sorted
+    with pytest.raises(ValueError, match="target_size is required"):
+        compute_coverage_from_bedgraph(bedgraph, genome_size=1000, targets_bed_sorted=sorted_path)

--- a/src/consensus/tests/unit/test_report_assembly.py
+++ b/src/consensus/tests/unit/test_report_assembly.py
@@ -1,0 +1,71 @@
+"""Report table/figure assembly from a synthetic per-sample metrics table."""
+
+import pandas as pd
+import pytest
+from ugbio_consensus import consensus_report, duplex_metrics
+
+
+@pytest.fixture
+def metrics_df():
+    return pd.DataFrame(
+        [
+            {
+                "sample": "S1",
+                "PCT_duplicates": 34.85,
+                "Mean_cvg": 19.49,
+                "genome_mean_cvg": 10.5,
+                "on_target_rate": 0.286,
+                "target_mean_cvg": 236.2,
+                f"{duplex_metrics.DUPLEX}_avg_family_size": 13.0,
+                f"{duplex_metrics.SINGLE_STRAND}_avg_family_size": 6.0,
+                f"{duplex_metrics.DUPLEX}_coverage": 12.4,
+                f"{duplex_metrics.SINGLE_STRAND}_coverage": 16.9,
+                "consensus_PCT_unhandled": 9.8,
+                "consensus_PCT_dup_set_members": 90.2,
+            },
+            {
+                "sample": "S2",
+                "PCT_duplicates": 36.0,
+                "Mean_cvg": 21.0,
+                "genome_mean_cvg": 11.0,
+                "on_target_rate": 0.30,
+                "target_mean_cvg": 250.0,
+                f"{duplex_metrics.DUPLEX}_avg_family_size": 14.0,
+                f"{duplex_metrics.SINGLE_STRAND}_avg_family_size": 6.5,
+                f"{duplex_metrics.DUPLEX}_coverage": 13.0,
+                f"{duplex_metrics.SINGLE_STRAND}_coverage": 17.5,
+                "consensus_PCT_unhandled": 10.2,
+                "consensus_PCT_dup_set_members": 89.8,
+            },
+        ]
+    )
+
+
+def test_summarize_medians(metrics_df):
+    summary = consensus_report.summarize(metrics_df)
+    assert summary["PCT_duplicates"] == pytest.approx(35.425)
+    assert summary[f"{duplex_metrics.DUPLEX}_avg_family_size"] == pytest.approx(13.5)
+
+
+def test_generate_report_html(metrics_df, tmp_path):
+    out = tmp_path / "report.html"
+    result = consensus_report.generate_report(metrics_df, str(out), title="My Consensus Report")
+    assert result == str(out)
+    content = out.read_text()
+    assert "My Consensus Report" in content
+    assert "plotly" in content.lower()
+    # duplex, on-target and consensus-performance sections all present
+    assert "Both-strands duplex" in content
+    assert "On-target rate" in content
+    assert "Consensus tool performance" in content
+    assert "rs:B:i" in content
+
+
+def test_consensus_table_absent_without_log(metrics_df):
+    without_log = metrics_df.drop(columns=["consensus_PCT_unhandled", "consensus_PCT_dup_set_members"])
+    assert consensus_report._consensus_metrics_table(without_log) is None
+
+
+def test_on_target_figure_absent_without_targets(metrics_df):
+    without_targets = metrics_df.assign(on_target_rate=None)
+    assert consensus_report.build_on_target_figure(without_targets) is None

--- a/src/consensus/tests/unit/test_report_assembly.py
+++ b/src/consensus/tests/unit/test_report_assembly.py
@@ -58,7 +58,7 @@ def test_generate_report_html(metrics_df, tmp_path):
     assert "Both-strands duplex" in content
     assert "On-target rate" in content
     assert "Consensus tool performance" in content
-    assert "rs:B:i" in content
+    assert "fs:i" in content and "rs:i" in content
 
 
 def test_consensus_table_absent_without_log(metrics_df):

--- a/src/consensus/tests/unit/test_rs_tag_collection.py
+++ b/src/consensus/tests/unit/test_rs_tag_collection.py
@@ -1,4 +1,4 @@
-"""Build a tiny in-memory BAM with rs/MI tags and check family classification & coverage."""
+"""Build a tiny in-memory BAM with fs/rs/MI tags and check family classification & coverage."""
 
 import numpy as np
 import pysam
@@ -10,7 +10,11 @@ CHROM_LEN = 1000
 READ_LEN = 100
 
 
-def _make_read(header, name, pos, rs, *, reverse=False, mi=None):
+def _make_read(header, name, pos, strands, *, reverse=False, mi=None):
+    """Build a read with scalar ``fs:i``/``rs:i`` strand tags.
+
+    ``strands`` is ``(n_forward, n_reverse)`` or ``None`` (no strand tags).
+    """
     a = pysam.AlignedSegment(header)
     a.query_name = name
     a.query_sequence = "A" * READ_LEN
@@ -21,8 +25,10 @@ def _make_read(header, name, pos, rs, *, reverse=False, mi=None):
     a.cigartuples = [(0, READ_LEN)]  # 100M
     a.query_qualities = pysam.qualitystring_to_array("I" * READ_LEN)
     tags = []
-    if rs is not None:
-        tags.append(("rs", list(rs), "i"))  # array of ints -> rs:B:i
+    if strands is not None:
+        n_fwd, n_rev = strands
+        tags.append(("fs", n_fwd, "i"))  # scalar -> fs:i
+        tags.append(("rs", n_rev, "i"))  # scalar -> rs:i
     if mi is not None:
         tags.append(("MI", mi))
     a.set_tags(tags)

--- a/src/consensus/tests/unit/test_rs_tag_collection.py
+++ b/src/consensus/tests/unit/test_rs_tag_collection.py
@@ -1,0 +1,93 @@
+"""Build a tiny in-memory BAM with rs/MI tags and check family classification & coverage."""
+
+import numpy as np
+import pysam
+import pytest
+from ugbio_consensus import duplex_metrics
+
+CHROM = "chr1"
+CHROM_LEN = 1000
+READ_LEN = 100
+
+
+def _make_read(header, name, pos, rs, *, reverse=False, mi=None):
+    a = pysam.AlignedSegment(header)
+    a.query_name = name
+    a.query_sequence = "A" * READ_LEN
+    a.flag = 16 if reverse else 0
+    a.reference_id = 0
+    a.reference_start = pos
+    a.mapping_quality = 60
+    a.cigartuples = [(0, READ_LEN)]  # 100M
+    a.query_qualities = pysam.qualitystring_to_array("I" * READ_LEN)
+    tags = []
+    if rs is not None:
+        tags.append(("rs", list(rs), "i"))  # array of ints -> rs:B:i
+    if mi is not None:
+        tags.append(("MI", mi))
+    a.set_tags(tags)
+    return a
+
+
+@pytest.fixture
+def bam_path(tmp_path):
+    header = {"HD": {"VN": "1.6"}, "SQ": [{"SN": CHROM, "LN": CHROM_LEN}]}
+    path = tmp_path / "consensus.bam"
+    # 2 duplex (sizes 8, 4), 2 single-strand (sizes 5, 3), 1 singleton (no rs tag)
+    reads = [
+        _make_read(pysam.AlignmentHeader.from_dict(header), "duplex1", 100, (4, 4), mi=1),
+        _make_read(pysam.AlignmentHeader.from_dict(header), "duplex2", 120, (1, 3), mi=2),
+        _make_read(pysam.AlignmentHeader.from_dict(header), "ss1", 140, (5, 0), reverse=False, mi=3),
+        _make_read(pysam.AlignmentHeader.from_dict(header), "ss2", 160, (0, 3), reverse=True, mi=4),
+        _make_read(pysam.AlignmentHeader.from_dict(header), "single1", 180, None),
+    ]
+    with pysam.AlignmentFile(str(path), "wb", header=header) as out:
+        for r in reads:
+            out.write(r)
+    pysam.index(str(path))
+    return str(path)
+
+
+def test_family_classification_counts(bam_path):
+    res = duplex_metrics.collect_family_metrics_from_rs_tags(bam_path, [(CHROM, 0, CHROM_LEN)], reference=None)
+    per = res["per_category"]
+    assert per.loc[duplex_metrics.DUPLEX, "n_reads"] == 2
+    assert per.loc[duplex_metrics.SINGLE_STRAND, "n_reads"] == 2
+    assert per.loc[duplex_metrics.SINGLETON, "n_reads"] == 1
+
+
+def test_family_sizes(bam_path):
+    res = duplex_metrics.collect_family_metrics_from_rs_tags(bam_path, [(CHROM, 0, CHROM_LEN)], reference=None)
+    per = res["per_category"]
+    # duplex sizes 8 and 4 -> avg 6; single-strand 5 and 3 -> avg 4; singleton -> 1
+    assert per.loc[duplex_metrics.DUPLEX, "avg_family_size"] == pytest.approx(6.0)
+    assert per.loc[duplex_metrics.SINGLE_STRAND, "avg_family_size"] == pytest.approx(4.0)
+    assert per.loc[duplex_metrics.SINGLETON, "avg_family_size"] == pytest.approx(1.0)
+
+
+def test_coverage_sums(bam_path):
+    res = duplex_metrics.collect_family_metrics_from_rs_tags(bam_path, [(CHROM, 0, CHROM_LEN)], reference=None)
+    per = res["per_category"]
+    # each category's reads each cover READ_LEN bases over the CHROM_LEN interval
+    assert per.loc[duplex_metrics.DUPLEX, "coverage"] == pytest.approx(2 * READ_LEN / CHROM_LEN)
+    assert per.loc[duplex_metrics.SINGLE_STRAND, "coverage"] == pytest.approx(2 * READ_LEN / CHROM_LEN)
+    assert res["total_interval_bp"] == CHROM_LEN
+
+
+def test_whole_chromosome_end_none(bam_path):
+    # end=None means "to the end of the contig"; resolved from the header (CHROM_LEN).
+    res = duplex_metrics.collect_family_metrics_from_rs_tags(bam_path, [(CHROM, 0, None)], reference=None)
+    per = res["per_category"]
+    assert res["total_interval_bp"] == CHROM_LEN
+    assert per.loc[duplex_metrics.DUPLEX, "n_reads"] == 2
+    assert per.loc[duplex_metrics.SINGLE_STRAND, "n_reads"] == 2
+    assert per.loc[duplex_metrics.SINGLETON, "n_reads"] == 1
+
+
+def test_mi_fallback_matches(bam_path):
+    res = duplex_metrics.collect_family_metrics_from_mi_tags(bam_path, [(CHROM, 0, CHROM_LEN)], reference=None)
+    # MI grouping sees 4 tagged reads, each its own MI, all singletons by MI membership
+    # (one read per MI) -> all classified as singleton. This documents that the rs path
+    # is the accurate one for consensus reads; MI fallback needs multi-read MI groups.
+    assert res["n_families"] == 4
+    assert np.isnan(res["per_category"].loc[duplex_metrics.DUPLEX, "avg_family_size"])

--- a/src/consensus/ugbio_consensus/consensus_log.py
+++ b/src/consensus/ugbio_consensus/consensus_log.py
@@ -1,0 +1,77 @@
+"""
+Parse the consensus tool's stdout log for performance metrics.
+
+The ``read_fuser`` consensus step writes a progress/stats log (the
+``consensus_stdout`` output). It has two informative parts:
+
+* periodic progress lines::
+
+      total=<n_reads>, <n> unhandled, <n> dup_set_members
+
+  the **last** of which gives the cumulative totals for the whole run; and
+
+* a final summary line::
+
+      stats=Stats { alt_prob_too_high: 0, hmer_too_long: 5712685,
+                    no_clear_hmer_choice: 14009063, not_same_contig: 4,
+                    other_error: 1006093, dup_sets_merged: 216196151,
+                    unchanged_segments: 297230665 }
+
+  counting why segments were merged / left unchanged / skipped.
+
+This module extracts both into a flat dict of integers plus a couple of derived
+rates (unhandled fraction, merge fraction), so the report can show how the
+consensus tool performed.
+"""
+
+from __future__ import annotations
+
+import re
+
+_TOTAL_RE = re.compile(r"total=(\d+),\s*(\d+)\s*unhandled,\s*(\d+)\s*dup_set_members")
+_STATS_RE = re.compile(r"stats=Stats\s*\{([^}]*)\}")
+_KV_RE = re.compile(r"(\w+):\s*(\d+)")
+
+
+def parse_consensus_log(log_path: str) -> dict:
+    """Extract consensus-tool performance metrics from a stdout log.
+
+    Parameters
+    ----------
+    log_path : str
+        Local path to the ``consensus_stdout`` log.
+
+    Returns
+    -------
+    dict
+        Flat metrics. Progress totals: ``total_reads``, ``unhandled``,
+        ``dup_set_members``. Stats-line counters are passed through verbatim
+        (e.g. ``hmer_too_long``, ``no_clear_hmer_choice``, ``dup_sets_merged``,
+        ``unchanged_segments`` ...). Derived: ``PCT_unhandled`` (unhandled /
+        total_reads * 100) and ``PCT_dup_set_members`` (dup_set_members /
+        total_reads * 100). Missing pieces are simply absent from the dict.
+    """
+    metrics: dict = {}
+    last_total: tuple[int, int, int] | None = None
+
+    with open(log_path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            m = _TOTAL_RE.search(line)
+            if m:
+                last_total = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+                continue
+            s = _STATS_RE.search(line)
+            if s:
+                for key, value in _KV_RE.findall(s.group(1)):
+                    metrics[key] = int(value)
+
+    if last_total is not None:
+        total_reads, unhandled, dup_set_members = last_total
+        metrics["total_reads"] = total_reads
+        metrics["unhandled"] = unhandled
+        metrics["dup_set_members"] = dup_set_members
+        if total_reads:
+            metrics["PCT_unhandled"] = 100 * unhandled / total_reads
+            metrics["PCT_dup_set_members"] = 100 * dup_set_members / total_reads
+
+    return metrics

--- a/src/consensus/ugbio_consensus/consensus_report.py
+++ b/src/consensus/ugbio_consensus/consensus_report.py
@@ -1,0 +1,756 @@
+"""
+ReadFuserAlignSort (consensus tool) performance & duplex HTML report.
+
+Generates a self-contained HTML report summarising, for one or more samples of a
+ReadFuserAlignSort run, the performance of the consensus tool and its duplex
+behaviour. All inputs are **local files** supplied by the user (no S3/DB access).
+
+Per sample the report covers:
+
+* **Sorter QC** - alignment / duplication / coverage metrics parsed from the
+  local ``sorter_stats_csv`` (post-consensus).
+* **Duplex family metrics** - average MI-family size and covered depth for
+  *both-strands duplex* families and for *single-strand duplicate* families,
+  measured directly from the consensus reads' ``rs:B:i`` tag
+  (``[n_forward, n_reverse]``) - see :mod:`ugbio_consensus.duplex_metrics`.
+* **On-target metrics (optional)** - when a ``--targets`` BED is supplied
+  (e.g. an exome capture BED), on-target rate and on-target mean coverage from
+  the local coverage bedGraph; otherwise genome-wide coverage only.
+
+The report is target-agnostic: the Quotient exome case is just the run where a
+targets BED happens to be provided.
+
+CLI
+---
+Single sample::
+
+    consensus_report \\
+        --cram Z0315.cram --sorter-stats-csv Z0315.csv \\
+        --sorter-stats-json Z0315.json --bedgraph Z0315_0.bedGraph.gz \\
+        --reference Homo_sapiens_assembly38.fasta \\
+        --targets exome.bed --output report.html
+
+Multiple samples (one ``--sample`` block per sample)::
+
+    consensus_report \\
+        --sample name=Z0315 cram=Z0315.cram sorter_stats_csv=Z0315.csv \\
+            sorter_stats_json=Z0315.json bedgraph=Z0315_0.bedGraph.gz \\
+        --sample name=Z0316 cram=Z0316.cram sorter_stats_csv=Z0316.csv \\
+            sorter_stats_json=Z0316.json bedgraph=Z0316_0.bedGraph.gz \\
+        --reference ref.fasta --targets exome.bed --output run_report.html
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from argparse import ArgumentParser, Namespace
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+from ugbio_core.logger import logger
+from ugbio_core.sorter_utils import read_sorter_statistics_csv
+
+from ugbio_consensus import duplex_metrics
+from ugbio_consensus.consensus_log import parse_consensus_log
+from ugbio_consensus.on_target import bed_covered_size, compute_coverage_from_bedgraph, sorted_bed
+
+# Sorter-stats metrics surfaced in the QC table (present in RFAS output CSVs).
+DEFAULT_QC_METRICS = [
+    "PF_Barcode_reads",
+    "PCT_PF_Reads_aligned",
+    "PCT_SOFTCLIPPED_bases",
+    "Mean_Read_Length",
+    "Mismatch_Rate",
+    "Indel_Rate",
+    "PCT_Chimeras",
+    "Mean_cvg",
+    "PCT_duplicates",
+]
+
+# Chromosome scanned for the rs-tag duplex analysis. One whole chromosome gives a
+# stable, representative family-size / duplex estimate without reading the whole
+# (very large) CRAM. chr20 is a common QC-representative autosome; override with
+# --duplex-chrom (e.g. "20" for a b37 reference). When a targets BED is provided,
+# the scan is restricted to the parts of this chromosome inside the targets.
+DEFAULT_DUPLEX_CHROM = "chr20"
+
+_CATEGORY_LABEL = {
+    duplex_metrics.DUPLEX: "Both-strands duplex",
+    duplex_metrics.SINGLE_STRAND: "Single-strand duplicate",
+    duplex_metrics.SINGLETON: "Singleton / pass-through",
+}
+_CATEGORY_COLOR = {
+    duplex_metrics.DUPLEX: "#2c7fb8",
+    duplex_metrics.SINGLE_STRAND: "#f03b20",
+    duplex_metrics.SINGLETON: "#bdbdbd",
+}
+
+
+@dataclass
+class SampleInputs:
+    """Local input files for a single sample.
+
+    Attributes
+    ----------
+    name : str
+        Sample name used as the row/label (e.g. ``Z0315``).
+    cram : str
+        Local path to the consensus CRAM (indexed; ``.crai`` alongside or via
+        ``crai``).
+    sorter_stats_csv : str
+        Local path to the sorter stats CSV.
+    sorter_stats_json : str
+        Local path to the sorter stats JSON.
+    bedgraph : str | None
+        Local path to the MAPQ>=0 coverage bedGraph (needed for coverage /
+        on-target metrics). ``None`` to skip coverage.
+    consensus_log : str | None
+        Local path to the consensus tool stdout log (``consensus_stdout``), for
+        consensus-tool performance metrics. ``None`` to skip.
+    crai : str | None
+        Explicit ``.crai`` path (defaults to ``<cram>.crai``).
+    """
+
+    name: str
+    cram: str
+    sorter_stats_csv: str
+    sorter_stats_json: str
+    bedgraph: str | None = None
+    consensus_log: str | None = None
+    crai: str | None = None
+
+    def crai_path(self) -> str | None:
+        if self.crai:
+            return self.crai
+        default = self.cram + ".crai"
+        return default if os.path.exists(default) else None
+
+
+def genome_size_from_sorter_json(sorter_stats_json: str) -> int:
+    """Return the callable genome size (bp) from a sorter JSON coverage histogram.
+
+    ``base_coverage["Genome"]`` is a histogram of depth -> #bases; its sum is the
+    number of callable bases, used as the denominator for genome-wide mean depth.
+
+    Parameters
+    ----------
+    sorter_stats_json : str
+        Local path to the sorter stats JSON.
+
+    Returns
+    -------
+    int
+        Callable genome size in bp.
+    """
+    with open(sorter_stats_json, encoding="utf-8") as fh:
+        stats = json.load(fh)
+    return int(sum(stats["base_coverage"]["Genome"]))
+
+
+def read_targets_bed(targets_bed: str, tmp_dir: str) -> tuple[str, int]:
+    """Prepare a sorted targets BED and return ``(sorted_bed_path, target_size_bp)``.
+
+    Parameters
+    ----------
+    targets_bed : str
+        Path to the targets BED.
+    tmp_dir : str
+        Scratch directory for the sorted copy.
+
+    Returns
+    -------
+    tuple[str, int]
+        Sorted BED path and merged target size in bp.
+    """
+    os.makedirs(tmp_dir, exist_ok=True)
+    sorted_path = sorted_bed(targets_bed, os.path.join(tmp_dir, "targets_sorted.bed"))
+    return sorted_path, bed_covered_size(targets_bed)
+
+
+def bed_intervals_on_chrom(bed_path: str, chrom: str) -> list[tuple[str, int, int]]:
+    """Read the BED intervals that lie on ``chrom`` as ``(chrom, start, end)`` tuples.
+
+    Used to restrict the duplex scan to the parts of a single chromosome that are
+    inside the targets BED.
+
+    Parameters
+    ----------
+    bed_path : str
+        Path to the targets BED.
+    chrom : str
+        Chromosome to keep (e.g. ``chr20``).
+
+    Returns
+    -------
+    list[tuple[str, int, int]]
+        BED intervals on ``chrom`` (may be empty if the chromosome is not targeted).
+    """
+    intervals = []
+    with open(bed_path, encoding="utf-8") as fh:
+        for line in fh:
+            if not line.strip() or line.startswith(("#", "track", "browser")):
+                continue
+            fields = line.split("\t")
+            if fields[0] == chrom:
+                intervals.append((fields[0], int(fields[1]), int(fields[2])))
+    return intervals
+
+
+def analyze_sample(  # noqa: PLR0913
+    sample: SampleInputs,
+    reference: str,
+    *,
+    targets_sorted_bed: str | None = None,
+    target_size: int | None = None,
+    duplex_intervals: list[tuple[str, int | None, int | None]],
+    max_duplex_reads: int | None = None,
+) -> dict:
+    """Compute the full metric set for one sample from its local inputs.
+
+    Parameters
+    ----------
+    sample : SampleInputs
+        Local input paths for the sample.
+    reference : str
+        Reference FASTA path (to decode the CRAM).
+    targets_sorted_bed : str | None, optional
+        Sorted targets BED; enables on-target metrics.
+    target_size : int | None, optional
+        Merged target size in bp (required with ``targets_sorted_bed``).
+    duplex_intervals : list[tuple[str, int, int | None]]
+        Regions to scan for the rs-tag duplex analysis (an ``end`` of ``None``
+        means "to the end of the contig"). Built by :func:`build_metrics_table`:
+        the whole duplex chromosome, or its intersection with the targets BED.
+    max_duplex_reads : int | None, optional
+        Cap on reads scanned for duplex metrics (sampling large targets).
+
+    Returns
+    -------
+    dict
+        Flat metric record for the sample (QC + duplex + coverage).
+    """
+    logger.info("Analyzing sample %s", sample.name)
+    record: dict = {"sample": sample.name}
+
+    # --- Sorter QC metrics (post-consensus) ---
+    qc = read_sorter_statistics_csv(sample.sorter_stats_csv)
+    for metric in DEFAULT_QC_METRICS:
+        record[metric] = qc.get(metric)
+
+    # --- Coverage (genome-wide, and on-target if a targets BED was given) ---
+    genome_size = genome_size_from_sorter_json(sample.sorter_stats_json)
+    if sample.bedgraph:
+        cov = compute_coverage_from_bedgraph(
+            sample.bedgraph,
+            genome_size,
+            targets_bed_sorted=targets_sorted_bed,
+            target_size=target_size,
+        )
+        record["genome_mean_cvg"] = cov.genome_mean_cvg
+        record["on_target_rate"] = cov.on_target_rate
+        record["target_mean_cvg"] = cov.target_mean_cvg
+    else:
+        record["genome_mean_cvg"] = None
+        record["on_target_rate"] = None
+        record["target_mean_cvg"] = None
+
+    # --- Duplex / consensus family metrics from the rs:B:i tag ---
+    fam = duplex_metrics.collect_family_metrics_from_rs_tags(
+        sample.cram,
+        duplex_intervals,
+        reference,
+        index_path=sample.crai_path(),
+        max_reads=max_duplex_reads,
+    )
+    per_cat = fam["per_category"]
+    for category in duplex_metrics.CATEGORIES:
+        record[f"{category}_avg_family_size"] = per_cat.loc[category, "avg_family_size"]
+        record[f"{category}_coverage"] = per_cat.loc[category, "coverage"]
+        record[f"{category}_n_reads"] = per_cat.loc[category, "n_reads"]
+    record["duplex_scan_reads"] = fam["n_reads_scanned"]
+    record["duplex_scan_bp"] = fam["total_interval_bp"]
+
+    # --- Consensus-tool performance metrics from the stdout log (optional) ---
+    if sample.consensus_log:
+        for key, value in parse_consensus_log(sample.consensus_log).items():
+            record[f"consensus_{key}"] = value
+
+    return record
+
+
+def build_metrics_table(  # noqa: PLR0913
+    samples: list[SampleInputs],
+    reference: str,
+    *,
+    work_dir: str,
+    targets_bed: str | None = None,
+    duplex_chrom: str = DEFAULT_DUPLEX_CHROM,
+    max_duplex_reads: int | None = None,
+) -> pd.DataFrame:
+    """Analyze every sample and return a tidy per-sample metrics table.
+
+    Parameters
+    ----------
+    samples : list[SampleInputs]
+        Local sample inputs.
+    reference : str
+        Reference FASTA path.
+    work_dir : str
+        Scratch directory (for the sorted targets BED).
+    targets_bed : str | None, optional
+        Optional targets BED enabling on-target metrics. When given, the duplex
+        scan is restricted to the parts of ``duplex_chrom`` inside the targets.
+    duplex_chrom : str, optional
+        Chromosome scanned for the rs-tag duplex analysis (default
+        :data:`DEFAULT_DUPLEX_CHROM`). Without a targets BED the whole chromosome
+        is scanned; with one, only its targeted intervals.
+    max_duplex_reads : int | None, optional
+        Cap on reads scanned per sample for duplex metrics.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per sample, sorted by ``sample``.
+    """
+    targets_sorted, target_size = (None, None)
+    if targets_bed:
+        targets_sorted, target_size = read_targets_bed(targets_bed, os.path.join(work_dir, "targets"))
+        logger.info("Targets BED: %s (%.1f Mb)", targets_bed, target_size / 1e6)
+        # Restrict the duplex scan to the targeted intervals on duplex_chrom.
+        duplex_intervals = bed_intervals_on_chrom(targets_bed, duplex_chrom)
+        if not duplex_intervals:
+            logger.warning("No targets on %s; duplex scan will find no reads", duplex_chrom)
+        logger.info("Duplex scan: %d targeted intervals on %s", len(duplex_intervals), duplex_chrom)
+    else:
+        # Whole chromosome (end=None -> resolved to contig length from the CRAM header).
+        duplex_intervals = [(duplex_chrom, 0, None)]
+        logger.info("Duplex scan: whole chromosome %s", duplex_chrom)
+
+    records = [
+        analyze_sample(
+            s,
+            reference,
+            targets_sorted_bed=targets_sorted,
+            target_size=target_size,
+            duplex_intervals=duplex_intervals,
+            max_duplex_reads=max_duplex_reads,
+        )
+        for s in samples
+    ]
+    return pd.DataFrame(records).sort_values("sample").reset_index(drop=True)
+
+
+def summarize(df: pd.DataFrame) -> pd.Series:
+    """Median across samples for the headline consensus/duplex metrics.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Per-sample table from :func:`build_metrics_table`.
+
+    Returns
+    -------
+    pd.Series
+        Median of the key metrics (family sizes, coverages, on-target rate, dup %).
+    """
+    cols = [
+        "PCT_duplicates",
+        "Mean_cvg",
+        "on_target_rate",
+        "target_mean_cvg",
+        f"{duplex_metrics.DUPLEX}_avg_family_size",
+        f"{duplex_metrics.SINGLE_STRAND}_avg_family_size",
+        f"{duplex_metrics.DUPLEX}_coverage",
+        f"{duplex_metrics.SINGLE_STRAND}_coverage",
+    ]
+    present = [c for c in cols if c in df.columns]
+    return df[present].median(numeric_only=True)
+
+
+# --------------------------------------------------------------------------- #
+# HTML report assembly
+# --------------------------------------------------------------------------- #
+def _bar_by_sample(df: pd.DataFrame, columns: dict[str, str], title: str, ylabel: str) -> go.Figure:
+    """Grouped bar chart: one trace per metric column, x = samples."""
+    fig = go.Figure()
+    for col, label in columns.items():
+        if col not in df.columns:
+            continue
+        color = None
+        for cat, ccolor in _CATEGORY_COLOR.items():
+            if col.startswith(cat):
+                color = ccolor
+        fig.add_bar(x=df["sample"], y=df[col], name=label, marker_color=color)
+    fig.update_layout(
+        title=title,
+        yaxis_title=ylabel,
+        barmode="group",
+        template="plotly_white",
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        legend={"orientation": "h", "yanchor": "bottom", "y": -0.3},
+        height=430,
+    )
+    return fig
+
+
+def build_family_size_figure(df: pd.DataFrame) -> go.Figure:
+    """Average MI-family size per sample: duplex vs single-strand."""
+    return _bar_by_sample(
+        df,
+        {
+            f"{duplex_metrics.DUPLEX}_avg_family_size": _CATEGORY_LABEL[duplex_metrics.DUPLEX],
+            f"{duplex_metrics.SINGLE_STRAND}_avg_family_size": _CATEGORY_LABEL[duplex_metrics.SINGLE_STRAND],
+        },
+        "Average MI-family size (from rs:B:i tag)",
+        "Average family size (reads)",
+    )
+
+
+def build_duplex_coverage_figure(df: pd.DataFrame) -> go.Figure:
+    """Consensus-read coverage per sample: duplex vs single-strand."""
+    return _bar_by_sample(
+        df,
+        {
+            f"{duplex_metrics.DUPLEX}_coverage": _CATEGORY_LABEL[duplex_metrics.DUPLEX],
+            f"{duplex_metrics.SINGLE_STRAND}_coverage": _CATEGORY_LABEL[duplex_metrics.SINGLE_STRAND],
+        },
+        "Duplex coverage (consensus-read depth over scanned regions)",
+        "Coverage (x)",
+    )
+
+
+def build_coverage_figure(df: pd.DataFrame) -> go.Figure | None:
+    """Coverage per sample: genome-wide, on-target, and sorter Mean_cvg."""
+    if "genome_mean_cvg" not in df.columns or df["genome_mean_cvg"].isna().all():
+        return None
+    fig = go.Figure()
+    fig.add_bar(x=df["sample"], y=df["genome_mean_cvg"], name="Genome mean cvg", marker_color="#636363")
+    if "target_mean_cvg" in df.columns and df["target_mean_cvg"].notna().any():
+        fig.add_bar(x=df["sample"], y=df["target_mean_cvg"], name="On-target mean cvg", marker_color="#31a354")
+    fig.update_layout(
+        title="Coverage per sample",
+        yaxis_title="Mean coverage (x)",
+        barmode="group",
+        template="plotly_white",
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        legend={"orientation": "h", "yanchor": "bottom", "y": -0.3},
+        height=430,
+    )
+    return fig
+
+
+def build_on_target_figure(df: pd.DataFrame) -> go.Figure | None:
+    """On-target rate per sample (only when a targets BED was used)."""
+    if "on_target_rate" not in df.columns or df["on_target_rate"].isna().all():
+        return None
+    fig = go.Figure()
+    fig.add_bar(
+        x=df["sample"],
+        y=df["on_target_rate"] * 100,
+        marker_color="#31a354",
+        text=[f"{v:.1f}%" if pd.notna(v) else "" for v in df["on_target_rate"] * 100],
+        textposition="outside",
+    )
+    fig.update_layout(
+        title="On-target rate per sample",
+        yaxis_title="On-target rate (%)",
+        template="plotly_white",
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        height=430,
+    )
+    return fig
+
+
+def _consensus_metrics_table(df: pd.DataFrame) -> pd.DataFrame | None:
+    """Extract the ``consensus_*`` columns into a samples-as-rows table.
+
+    Returns ``None`` when no consensus stdout log was provided for any sample.
+    """
+    cols = [c for c in df.columns if c.startswith("consensus_")]
+    if not cols:
+        return None
+    out = df[["sample", *cols]].copy()
+    out.columns = ["sample", *[c.removeprefix("consensus_") for c in cols]]
+    return out
+
+
+def build_consensus_performance_figure(df: pd.DataFrame) -> go.Figure | None:
+    """Consensus tool performance rates per sample (from the stdout log).
+
+    Shows the fraction of records left unhandled and the fraction that were
+    duplicate-set members, i.e. how much of the input the consensus step
+    collapsed vs passed through.
+    """
+    rate_cols = {
+        "consensus_PCT_dup_set_members": "Dup-set members (%)",
+        "consensus_PCT_unhandled": "Unhandled (%)",
+    }
+    present = {c: label for c, label in rate_cols.items() if c in df.columns and df[c].notna().any()}
+    if not present:
+        return None
+    fig = go.Figure()
+    for col, label in present.items():
+        fig.add_bar(x=df["sample"], y=df[col], name=label)
+    fig.update_layout(
+        title="Consensus tool performance (from stdout log)",
+        yaxis_title="% of records",
+        barmode="group",
+        template="plotly_white",
+        paper_bgcolor="white",
+        plot_bgcolor="white",
+        legend={"orientation": "h", "yanchor": "bottom", "y": -0.3},
+        height=430,
+    )
+    return fig
+
+
+_SCIENTIFIC_NOTATION_THRESHOLD = 1e6
+
+
+def _fmt(value: object) -> str:
+    """Format a scalar for the HTML table."""
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return "-"
+    if isinstance(value, float):
+        if abs(value) >= _SCIENTIFIC_NOTATION_THRESHOLD:
+            return f"{value:.3e}"
+        if 0 < abs(value) < 1:
+            return f"{value:.3f}"
+        return f"{value:.2f}"
+    return str(value)
+
+
+def _build_table_html(df: pd.DataFrame, title: str) -> str:
+    """Render a DataFrame as a styled, vertical HTML table.
+
+    Metric names run down the first column and each sample is its own value
+    column (the frame is transposed on its ``sample`` column). A frame without a
+    ``sample`` column (e.g. the summary metric/value table) is already vertical
+    and is rendered as-is.
+    """
+    if "sample" in df.columns:
+        table = df.set_index("sample").T
+        table.index.name = "metric"
+        col_headers = list(table.columns)
+        row_labels = list(table.index)
+        value_rows = [list(table.loc[label]) for label in row_labels]
+        header = "<th style='padding:6px 10px;text-align:left'>metric</th>" + "".join(
+            f"<th style='padding:6px 10px;text-align:left'>{c}</th>" for c in col_headers
+        )
+    else:
+        # Already-vertical frame (e.g. metric / median): first column is the label.
+        row_labels = list(df.iloc[:, 0])
+        value_rows = [list(row) for row in df.iloc[:, 1:].to_numpy()]
+        header = "".join(f"<th style='padding:6px 10px;text-align:left'>{c}</th>" for c in df.columns)
+
+    rows = ""
+    for label, values in zip(row_labels, value_rows, strict=True):
+        cells = "".join(f"<td style='padding:6px 10px;border-top:1px solid #eee'>{_fmt(v)}</td>" for v in values)
+        rows += (
+            f"<tr><th style='padding:6px 10px;text-align:left;border-top:1px solid #eee;"
+            f"background:#fafafa'>{label}</th>{cells}</tr>"
+        )
+    return (
+        f"<h2 style='font-size:22px;color:#000000'>{title}</h2>"
+        "<table style='border-collapse:collapse;font-size:13px;margin-bottom:24px'>"
+        f"<thead style='background:#f3f3f3'><tr>{header}</tr></thead><tbody>{rows}</tbody></table>"
+    )
+
+
+def _assemble_html(title: str, tables_html: list[str], figures: list[go.Figure]) -> str:
+    """Assemble a self-contained HTML report from tables and figures."""
+    parts = [
+        "<!DOCTYPE html><html><head><meta charset='utf-8'>",
+        f"<title>{title}</title>",
+        "</head><body style='font-family: Arial, sans-serif; max-width: 1200px; margin: 0 auto; "
+        "padding: 20px; background:#ffffff; color:#000000;'>",
+        f"<h1 style='font-size:34px;'>{title}</h1>",
+        "<p style='color:#000000'>Consensus tool (ReadFuserAlignSort) performance and duplex metrics. "
+        "Family size and duplex classification are derived from the per-read <code>rs:B:i</code> tag "
+        "(<code>[n_forward, n_reverse]</code>).</p>",
+    ]
+    parts.extend(tables_html)
+    for i, fig in enumerate(figures):
+        include_plotlyjs = "cdn" if i == 0 else False
+        parts.append(fig.to_html(full_html=False, include_plotlyjs=include_plotlyjs))
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
+def generate_report(df: pd.DataFrame, output_html: str, *, title: str = "Consensus Tool Report") -> str:
+    """Build the HTML report from a per-sample metrics table.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Per-sample table from :func:`build_metrics_table`.
+    output_html : str
+        Output HTML path.
+    title : str, optional
+        Report title.
+
+    Returns
+    -------
+    str
+        Path to the written HTML report.
+    """
+    summary = summarize(df).rename("median (all samples)").to_frame().reset_index()
+    summary.columns = ["metric", "median (all samples)"]
+
+    # consensus_* metrics get their own table below; drop them from the per-sample
+    # table so they are not shown twice.
+    per_sample_df = df[[c for c in df.columns if not c.startswith("consensus_")]]
+    tables = [
+        _build_table_html(summary, "Summary (median across samples)"),
+        _build_table_html(per_sample_df, "Per-sample metrics"),
+    ]
+    consensus_table = _consensus_metrics_table(df)
+    if consensus_table is not None:
+        tables.append(_build_table_html(consensus_table, "Consensus tool performance (from stdout log)"))
+    figures = [
+        f
+        for f in (
+            build_family_size_figure(df),
+            build_duplex_coverage_figure(df),
+            build_coverage_figure(df),
+            build_on_target_figure(df),
+            build_consensus_performance_figure(df),
+        )
+        if f is not None
+    ]
+    html = _assemble_html(title, tables, figures)
+    Path(output_html).parent.mkdir(parents=True, exist_ok=True)
+    Path(output_html).write_text(html, encoding="utf-8")
+    logger.info("Report written to %s", output_html)
+    return output_html
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _parse_sample_block(tokens: list[str]) -> SampleInputs:
+    """Parse a ``--sample key=value ...`` block into a :class:`SampleInputs`."""
+    kv = {}
+    for token in tokens:
+        if "=" not in token:
+            raise ValueError(f"--sample expects key=value tokens, got '{token}'")
+        key, value = token.split("=", 1)
+        kv[key.strip()] = value.strip()
+    missing = {"name", "cram", "sorter_stats_csv", "sorter_stats_json"} - kv.keys()
+    if missing:
+        raise ValueError(f"--sample block missing required keys: {sorted(missing)}")
+    return SampleInputs(
+        name=kv["name"],
+        cram=kv["cram"],
+        sorter_stats_csv=kv["sorter_stats_csv"],
+        sorter_stats_json=kv["sorter_stats_json"],
+        bedgraph=kv.get("bedgraph"),
+        consensus_log=kv.get("consensus_log"),
+        crai=kv.get("crai"),
+    )
+
+
+def _samples_from_args(args: Namespace) -> list[SampleInputs]:
+    """Build the sample list from either the single-sample flags or --sample blocks."""
+    if args.sample:
+        return [_parse_sample_block(block) for block in args.sample]
+    if not (args.cram and args.sorter_stats_csv and args.sorter_stats_json):
+        raise SystemExit(
+            "Provide either --sample blocks, or --cram/--sorter-stats-csv/--sorter-stats-json for one sample."
+        )
+    name = args.name or Path(args.cram).stem
+    return [
+        SampleInputs(
+            name=name,
+            cram=args.cram,
+            sorter_stats_csv=args.sorter_stats_csv,
+            sorter_stats_json=args.sorter_stats_json,
+            bedgraph=args.bedgraph,
+            consensus_log=args.consensus_log,
+            crai=args.crai,
+        )
+    ]
+
+
+def parse_args(argv: list[str]) -> Namespace:
+    ap = ArgumentParser(description="ReadFuserAlignSort consensus performance & duplex HTML report (local inputs)")
+    ap.add_argument("--reference", required=True, help="Reference FASTA (to decode the CRAM)")
+    ap.add_argument("--output", required=True, help="Output HTML report path")
+    ap.add_argument("--targets", help="Optional targets BED for on-target metrics (e.g. exome)")
+    ap.add_argument(
+        "--duplex-chrom",
+        dest="duplex_chrom",
+        default=DEFAULT_DUPLEX_CHROM,
+        help=(
+            f"Chromosome scanned for duplex/MI-family metrics (default {DEFAULT_DUPLEX_CHROM}; "
+            "e.g. '20' for b37). With --targets, restricted to its targeted intervals on this chromosome."
+        ),
+    )
+    ap.add_argument("--max-duplex-reads", type=int, help="Cap reads scanned per sample for duplex metrics")
+    ap.add_argument("--title", default="Consensus Tool Report", help="Report title")
+    ap.add_argument("--work-dir", help="Scratch dir (default: alongside --output)")
+
+    # Single-sample flags
+    ap.add_argument("--name", help="Sample name (single-sample mode; default: CRAM stem)")
+    ap.add_argument("--cram", help="Consensus CRAM (single-sample mode)")
+    ap.add_argument("--sorter-stats-csv", dest="sorter_stats_csv", help="Sorter stats CSV (single-sample mode)")
+    ap.add_argument("--sorter-stats-json", dest="sorter_stats_json", help="Sorter stats JSON (single-sample mode)")
+    ap.add_argument("--bedgraph", help="Coverage bedGraph, MAPQ>=0 (single-sample mode)")
+    ap.add_argument("--consensus-log", dest="consensus_log", help="Consensus tool stdout log (single-sample mode)")
+    ap.add_argument("--crai", help="Explicit .crai index (single-sample mode)")
+
+    # Multi-sample: repeatable key=value block
+    ap.add_argument(
+        "--sample",
+        nargs="+",
+        action="append",
+        metavar="key=value",
+        help=(
+            "Repeatable sample block: name= cram= sorter_stats_csv= sorter_stats_json= "
+            "[bedgraph=] [consensus_log=] [crai=]"
+        ),
+    )
+    return ap.parse_args(argv)
+
+
+def run(argv: list[str]) -> pd.DataFrame:
+    args = parse_args(argv[1:])
+    samples = _samples_from_args(args)
+    logger.info("Analyzing %d sample(s)", len(samples))
+
+    work_dir = args.work_dir or os.path.join(os.path.dirname(os.path.abspath(args.output)), "consensus_report_work")
+    os.makedirs(work_dir, exist_ok=True)
+
+    metrics = build_metrics_table(
+        samples,
+        args.reference,
+        work_dir=work_dir,
+        targets_bed=args.targets,
+        duplex_chrom=args.duplex_chrom,
+        max_duplex_reads=args.max_duplex_reads,
+    )
+
+    # Write the per-sample table as a sidecar CSV, plus the manifest, for provenance.
+    csv_path = os.path.splitext(args.output)[0] + "_per_sample.csv"
+    metrics.to_csv(csv_path, index=False)
+    pd.DataFrame([asdict(s) for s in samples]).to_csv(os.path.splitext(args.output)[0] + "_manifest.csv", index=False)
+
+    generate_report(metrics, args.output, title=args.title)
+    logger.info("Summary (median across %d samples):\n%s", len(metrics), summarize(metrics).to_string())
+    return metrics
+
+
+def main():
+    run(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/consensus/ugbio_consensus/consensus_report.py
+++ b/src/consensus/ugbio_consensus/consensus_report.py
@@ -11,8 +11,8 @@ Per sample the report covers:
   local ``sorter_stats_csv`` (post-consensus).
 * **Duplex family metrics** - average MI-family size and covered depth for
   *both-strands duplex* families and for *single-strand duplicate* families,
-  measured directly from the consensus reads' ``rs:B:i`` tag
-  (``[n_forward, n_reverse]``) - see :mod:`ugbio_consensus.duplex_metrics`.
+  measured directly from the consensus reads' ``fs:i``/``rs:i`` strand tags
+  (forward / reverse read counts) - see :mod:`ugbio_consensus.duplex_metrics`.
 * **On-target metrics (optional)** - when a ``--targets`` BED is supplied
   (e.g. an exome capture BED), on-target rate and on-target mean coverage from
   the local coverage bedGraph; otherwise genome-wide coverage only.
@@ -72,12 +72,17 @@ DEFAULT_QC_METRICS = [
     "PCT_duplicates",
 ]
 
-# Chromosome scanned for the rs-tag duplex analysis. One whole chromosome gives a
+# Chromosome scanned for the strand-tag (fs/rs) duplex analysis. One whole chromosome gives a
 # stable, representative family-size / duplex estimate without reading the whole
 # (very large) CRAM. chr20 is a common QC-representative autosome; override with
 # --duplex-chrom (e.g. "20" for a b37 reference). When a targets BED is provided,
 # the scan is restricted to the parts of this chromosome inside the targets.
 DEFAULT_DUPLEX_CHROM = "chr20"
+
+# Sentinel value for --duplex-chrom meaning "scan the whole CRAM, no region limit"
+# (every contig, full length). Useful for small inputs where reading the whole
+# file is cheap and the report should count every consensus read.
+DUPLEX_CHROM_ALL = "all"
 
 _CATEGORY_LABEL = {
     duplex_metrics.DUPLEX: "Both-strands duplex",
@@ -223,7 +228,7 @@ def analyze_sample(  # noqa: PLR0913
     target_size : int | None, optional
         Merged target size in bp (required with ``targets_sorted_bed``).
     duplex_intervals : list[tuple[str, int, int | None]]
-        Regions to scan for the rs-tag duplex analysis (an ``end`` of ``None``
+        Regions to scan for the strand-tag (fs/rs) duplex analysis (an ``end`` of ``None``
         means "to the end of the contig"). Built by :func:`build_metrics_table`:
         the whole duplex chromosome, or its intersection with the targets BED.
     max_duplex_reads : int | None, optional
@@ -259,7 +264,7 @@ def analyze_sample(  # noqa: PLR0913
         record["on_target_rate"] = None
         record["target_mean_cvg"] = None
 
-    # --- Duplex / consensus family metrics from the rs:B:i tag ---
+    # --- Duplex / consensus family metrics from the fs/rs strand tags ---
     fam = duplex_metrics.collect_family_metrics_from_rs_tags(
         sample.cram,
         duplex_intervals,
@@ -306,9 +311,11 @@ def build_metrics_table(  # noqa: PLR0913
         Optional targets BED enabling on-target metrics. When given, the duplex
         scan is restricted to the parts of ``duplex_chrom`` inside the targets.
     duplex_chrom : str, optional
-        Chromosome scanned for the rs-tag duplex analysis (default
+        Chromosome scanned for the strand-tag (fs/rs) duplex analysis (default
         :data:`DEFAULT_DUPLEX_CHROM`). Without a targets BED the whole chromosome
-        is scanned; with one, only its targeted intervals.
+        is scanned; with one, only its targeted intervals. Pass
+        :data:`DUPLEX_CHROM_ALL` (``"all"``) to scan the whole CRAM (every contig,
+        no region limit).
     max_duplex_reads : int | None, optional
         Cap on reads scanned per sample for duplex metrics.
 
@@ -317,6 +324,7 @@ def build_metrics_table(  # noqa: PLR0913
     pd.DataFrame
         One row per sample, sorted by ``sample``.
     """
+    scan_all = duplex_chrom == DUPLEX_CHROM_ALL
     targets_sorted, target_size = (None, None)
     if targets_bed:
         targets_sorted, target_size = read_targets_bed(targets_bed, os.path.join(work_dir, "targets"))
@@ -326,6 +334,10 @@ def build_metrics_table(  # noqa: PLR0913
         if not duplex_intervals:
             logger.warning("No targets on %s; duplex scan will find no reads", duplex_chrom)
         logger.info("Duplex scan: %d targeted intervals on %s", len(duplex_intervals), duplex_chrom)
+    elif scan_all:
+        # Whole CRAM: every contig, no region limitation (intervals=None).
+        duplex_intervals = None
+        logger.info("Duplex scan: whole CRAM (all contigs)")
     else:
         # Whole chromosome (end=None -> resolved to contig length from the CRAM header).
         duplex_intervals = [(duplex_chrom, 0, None)]
@@ -407,7 +419,7 @@ def build_family_size_figure(df: pd.DataFrame) -> go.Figure:
             f"{duplex_metrics.DUPLEX}_avg_family_size": _CATEGORY_LABEL[duplex_metrics.DUPLEX],
             f"{duplex_metrics.SINGLE_STRAND}_avg_family_size": _CATEGORY_LABEL[duplex_metrics.SINGLE_STRAND],
         },
-        "Average MI-family size (from rs:B:i tag)",
+        "Average MI-family size (from fs/rs strand tags)",
         "Average family size (reads)",
     )
 
@@ -574,8 +586,8 @@ def _assemble_html(title: str, tables_html: list[str], figures: list[go.Figure])
         "padding: 20px; background:#ffffff; color:#000000;'>",
         f"<h1 style='font-size:34px;'>{title}</h1>",
         "<p style='color:#000000'>Consensus tool (ReadFuserAlignSort) performance and duplex metrics. "
-        "Family size and duplex classification are derived from the per-read <code>rs:B:i</code> tag "
-        "(<code>[n_forward, n_reverse]</code>).</p>",
+        "Family size and duplex classification are derived from the per-read <code>fs:i</code> / "
+        "<code>rs:i</code> strand tags (forward / reverse read counts).</p>",
     ]
     parts.extend(tables_html)
     for i, fig in enumerate(figures):
@@ -691,7 +703,8 @@ def parse_args(argv: list[str]) -> Namespace:
         default=DEFAULT_DUPLEX_CHROM,
         help=(
             f"Chromosome scanned for duplex/MI-family metrics (default {DEFAULT_DUPLEX_CHROM}; "
-            "e.g. '20' for b37). With --targets, restricted to its targeted intervals on this chromosome."
+            f"e.g. '20' for b37). Use '{DUPLEX_CHROM_ALL}' to scan the whole CRAM (all contigs, "
+            "no region limit). With --targets, restricted to its targeted intervals on this chromosome."
         ),
     )
     ap.add_argument("--max-duplex-reads", type=int, help="Cap reads scanned per sample for duplex metrics")

--- a/src/consensus/ugbio_consensus/duplex_metrics.py
+++ b/src/consensus/ugbio_consensus/duplex_metrics.py
@@ -1,0 +1,344 @@
+"""
+Duplex / consensus family metrics from a ReadFuserAlignSort output CRAM.
+
+The consensus tool (``read_fuser``) writes, on each consensus read, an ``rs:B:i``
+tag holding two integers::
+
+    rs = [n_forward_strand_reads, n_reverse_strand_reads]
+
+i.e. the number of original reads on the forward (+) and reverse (-) strand that
+were fused into that consensus read. This lets us classify every consensus read
+and measure family size *directly*, without re-grouping reads by their ``MI``
+(molecular identifier) tag:
+
+* **both-strands duplex** - both entries > 0 (the molecule was observed on both
+  strands); family size = ``n_forward + n_reverse``.
+* **single-strand duplicate** - exactly one entry is 0; family size = the
+  non-zero entry.
+* **singleton / pass-through** - no ``rs`` tag (a read the consensus step passed
+  through unchanged); family size = 1.
+
+``sum(rs)`` equals the length of the ``rn`` (fused read-name list) tag, so the
+two encodings agree on family size.
+
+The historical MI-tag approach (grouping reads by ``MI`` and inspecting the set
+of strands) is kept in :func:`collect_family_metrics_from_mi_tags` for CRAMs
+produced without the ``rs`` tag.
+"""
+
+from __future__ import annotations
+
+import bisect
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
+import pysam
+
+# Family categories, in a fixed order for stable table/column layout.
+DUPLEX = "duplex"
+SINGLE_STRAND = "single_strand"
+SINGLETON = "singleton"
+CATEGORIES = (DUPLEX, SINGLE_STRAND, SINGLETON)
+
+
+def parse_rs_tag(read: pysam.AlignedSegment) -> tuple[int, int] | None:
+    """Return ``(n_forward, n_reverse)`` from a consensus read's ``rs`` tag.
+
+    Parameters
+    ----------
+    read : pysam.AlignedSegment
+        A single alignment record.
+
+    Returns
+    -------
+    tuple[int, int] | None
+        ``(n_forward, n_reverse)`` if the read carries a well-formed 2-element
+        ``rs`` tag, otherwise ``None`` (no tag, or a malformed/scalar value).
+    """
+    if not read.has_tag("rs"):
+        return None
+    rs = read.get_tag("rs")
+    try:
+        n_fwd, n_rev = int(rs[0]), int(rs[1])
+    except (TypeError, IndexError, ValueError):
+        # Rare scalar / malformed rs value - caller counts these as unclassified.
+        return None
+    return n_fwd, n_rev
+
+
+def classify_family(n_fwd: int, n_rev: int) -> str:
+    """Classify a consensus family from its per-strand read counts.
+
+    Parameters
+    ----------
+    n_fwd : int
+        Number of forward-strand reads fused into the consensus read.
+    n_rev : int
+        Number of reverse-strand reads fused into the consensus read.
+
+    Returns
+    -------
+    str
+        :data:`DUPLEX` if both strands contributed, :data:`SINGLE_STRAND` if only
+        one strand did, :data:`SINGLETON` if the total is a single read.
+    """
+    total = n_fwd + n_rev
+    if total <= 1:
+        return SINGLETON
+    if n_fwd > 0 and n_rev > 0:
+        return DUPLEX
+    return SINGLE_STRAND
+
+
+def _merge_intervals(intervals: list[tuple[str, int, int]]) -> list[tuple[str, int, int]]:
+    """Merge overlapping/adjacent ``(chrom, start, end)`` intervals.
+
+    Merging makes them disjoint so a base is never counted twice when summing
+    per-category coverage across intervals.
+    """
+    merged: list[tuple[str, int, int]] = []
+    for chrom, start, end in sorted(intervals):
+        if merged and merged[-1][0] == chrom and start <= merged[-1][2]:
+            prev_chrom, prev_start, prev_end = merged[-1]
+            merged[-1] = (prev_chrom, prev_start, max(prev_end, end))
+        else:
+            merged.append((chrom, start, end))
+    return merged
+
+
+def _overlap_with_intervals(read, starts: list[int], intervals: list[tuple[str, int, int]]) -> int:
+    """Return the read's aligned bases that fall inside the merged intervals.
+
+    ``starts`` is the sorted list of interval start coordinates (for the read's
+    chromosome) enabling a bisect lookup; ``intervals`` are the matching disjoint
+    ``(chrom, start, end)`` tuples. A read may straddle interval boundaries, so we
+    sum the clipped overlap against the interval at/just-before the read start and
+    the following one.
+    """
+    total = 0
+    idx = bisect.bisect_right(starts, read.reference_end) - 1
+    # Walk back over the (few) intervals that could overlap this read.
+    while idx >= 0:
+        _chrom, i_start, i_end = intervals[idx]
+        if i_end <= read.reference_start:
+            break
+        total += max(0, min(read.reference_end, i_end) - max(read.reference_start, i_start))
+        idx -= 1
+    return total
+
+
+def _iter_primary_reads_by_chrom(samfile, merged, max_reads):
+    """Yield ``(chrom_intervals, read)`` for primary reads, one linear fetch per chromosome.
+
+    Rather than a separate ``fetch`` per interval (thousands of tiny CRAM reads
+    thrash container decoding), we fetch each chromosome once over its covered
+    span and hand back the chromosome's merged intervals for in-memory overlap
+    testing. Skips secondary/supplementary/unmapped reads and stops after
+    ``max_reads`` primary reads (``None`` = no cap).
+    """
+    scanned = 0
+    by_chrom: dict[str, list[tuple[str, int, int]]] = defaultdict(list)
+    for chrom, start, end in merged:
+        by_chrom[chrom].append((chrom, start, end))
+
+    for chrom, chrom_intervals in by_chrom.items():
+        span_start = chrom_intervals[0][1]
+        span_end = chrom_intervals[-1][2]
+        for read in samfile.fetch(chrom, span_start, span_end):
+            if read.is_secondary or read.is_supplementary or read.is_unmapped:
+                continue
+            scanned += 1
+            yield chrom_intervals, read
+            if max_reads is not None and scanned >= max_reads:
+                return
+
+
+def _classify_read(read: pysam.AlignedSegment) -> tuple[str, int] | None:
+    """Return ``(category, family_size)`` for a read, or ``None`` if unclassifiable.
+
+    ``None`` means the read carries an ``rs`` tag we could not parse (malformed /
+    scalar); a read with no ``rs`` tag is treated as a singleton.
+    """
+    rs = parse_rs_tag(read)
+    if rs is None:
+        if read.has_tag("rs"):
+            return None  # malformed/scalar rs
+        return SINGLETON, 1
+    n_fwd, n_rev = rs
+    return classify_family(n_fwd, n_rev), max(n_fwd + n_rev, 1)
+
+
+def collect_family_metrics_from_rs_tags(
+    cram_path: str,
+    intervals: list[tuple[str, int, int]],
+    reference: str,
+    *,
+    index_path: str | None = None,
+    max_reads: int | None = None,
+) -> dict:
+    """Classify consensus reads and measure family size and coverage over ``intervals``.
+
+    For each primary read overlapping the (merged) intervals we read its ``rs``
+    tag, classify the family, record family size, and add its aligned span
+    (clipped to the interval) to that category's covered-base total. Family-size
+    statistics count each read once, at the interval containing its start, so
+    reads spanning an interval boundary are not double-counted.
+
+    Parameters
+    ----------
+    cram_path : str
+        Path or ``s3://`` URI of the consensus CRAM.
+    intervals : list[tuple[str, int, int | None]]
+        ``(chrom, start, end)`` regions to analyse (e.g. target-BED rows, or a
+        whole chromosome). An ``end`` of ``None`` means "to the end of the
+        contig" and is resolved from the CRAM header.
+    reference : str
+        Path to the reference FASTA (required to decode a CRAM).
+    index_path : str | None, optional
+        Explicit ``.crai`` path (useful when reading from S3 with a local index).
+    max_reads : int | None, optional
+        Stop after this many primary reads (for quick sampling). ``None`` = all.
+
+    Returns
+    -------
+    dict
+        Keys: ``per_category`` (DataFrame indexed by category with columns
+        ``n_reads``, ``avg_family_size``, ``median_family_size``,
+        ``covered_bases``, ``coverage``), ``total_interval_bp``,
+        ``n_reads_scanned``, ``n_unclassified`` (reads with a malformed ``rs``),
+        and ``family_sizes`` (dict category -> np.ndarray of sizes).
+    """
+    family_sizes: dict[str, list[int]] = {c: [] for c in CATEGORIES}
+    covered_bases: dict[str, int] = dict.fromkeys(CATEGORIES, 0)
+    n_reads_scanned = 0
+    n_unclassified = 0
+    total_bp = 0
+
+    open_kwargs = {"reference_filename": reference}
+    if index_path is not None:
+        open_kwargs["index_filename"] = index_path
+
+    with pysam.AlignmentFile(cram_path, "rc", **open_kwargs) as samfile:
+        # Resolve open-ended intervals ("to end of contig") from the header, then merge.
+        resolved = [
+            (chrom, start, samfile.get_reference_length(chrom) if end is None else end)
+            for chrom, start, end in intervals
+        ]
+        merged = _merge_intervals(resolved)
+        total_bp = sum(end - start for _, start, end in merged)
+        # Per-chromosome sorted interval starts for the bisect overlap lookup.
+        starts_by_chrom: dict[str, list[int]] = defaultdict(list)
+        for chrom, start, _end in merged:
+            starts_by_chrom[chrom].append(start)
+
+        for chrom_intervals, read in _iter_primary_reads_by_chrom(samfile, merged, max_reads):
+            n_reads_scanned += 1
+
+            # Coverage: aligned bases inside the (disjoint) intervals on this chromosome.
+            starts = starts_by_chrom[chrom_intervals[0][0]]
+            overlap = _overlap_with_intervals(read, starts, chrom_intervals)
+            if overlap <= 0:
+                continue
+
+            classified = _classify_read(read)
+            if classified is None:
+                # Malformed/scalar rs - excluded from family stats.
+                n_unclassified += 1
+                continue
+            category, size = classified
+
+            covered_bases[category] += overlap
+            # Count each family once, at the read start (avoids double-counting straddlers).
+            family_sizes[category].append(size)
+
+    rows = {}
+    for category in CATEGORIES:
+        sizes = np.array(family_sizes[category], dtype=float)
+        rows[category] = {
+            "n_reads": len(sizes),
+            "avg_family_size": float(np.mean(sizes)) if sizes.size else np.nan,
+            "median_family_size": float(np.median(sizes)) if sizes.size else np.nan,
+            "covered_bases": covered_bases[category],
+            "coverage": covered_bases[category] / total_bp if total_bp else np.nan,
+        }
+    per_category = pd.DataFrame.from_dict(rows, orient="index")
+    per_category.index.name = "category"
+
+    return {
+        "per_category": per_category,
+        "total_interval_bp": total_bp,
+        "n_reads_scanned": n_reads_scanned,
+        "n_unclassified": n_unclassified,
+        "family_sizes": {c: np.array(family_sizes[c]) for c in CATEGORIES},
+    }
+
+
+def collect_family_metrics_from_mi_tags(
+    cram_path: str,
+    intervals: list[tuple[str, int, int]],
+    reference: str,
+    *,
+    index_path: str | None = None,
+) -> dict:
+    """Fallback: classify families by grouping reads on the ``MI`` tag.
+
+    Use only for consensus/duplicate-marked CRAMs that lack the ``rs`` tag. A
+    family is *duplex* if its reads span both strands, *single_strand* if all
+    reads share one strand, and *singleton* if it has a single read. This mirrors
+    the historical MI-tag analysis; :func:`collect_family_metrics_from_rs_tags`
+    is preferred (exact, per-read, and yields coverage).
+
+    Parameters
+    ----------
+    cram_path : str
+        Path or ``s3://`` URI of the CRAM.
+    intervals : list[tuple[str, int, int]]
+        ``(chrom, start, end)`` regions to analyse.
+    reference : str
+        Path to the reference FASTA.
+    index_path : str | None, optional
+        Explicit ``.crai`` path.
+
+    Returns
+    -------
+    dict
+        Keys: ``per_category`` (DataFrame with ``n_families`` and
+        ``avg_family_size`` per category) and ``n_families``.
+    """
+    merged = _merge_intervals(intervals)
+    mi_strands: dict[object, list[str]] = defaultdict(list)
+
+    open_kwargs = {"reference_filename": reference}
+    if index_path is not None:
+        open_kwargs["index_filename"] = index_path
+
+    with pysam.AlignmentFile(cram_path, "rc", **open_kwargs) as samfile:
+        for chrom, start, end in merged:
+            for read in samfile.fetch(chrom, start, end):
+                if read.is_secondary or read.is_supplementary or read.is_unmapped:
+                    continue
+                if not read.has_tag("MI"):
+                    continue
+                mi_strands[read.get_tag("MI")].append("-" if read.is_reverse else "+")
+
+    sizes: dict[str, list[int]] = {c: [] for c in CATEGORIES}
+    for strands in mi_strands.values():
+        if len(strands) == 1:
+            sizes[SINGLETON].append(1)
+        elif len(set(strands)) == 1:
+            sizes[SINGLE_STRAND].append(len(strands))
+        else:
+            sizes[DUPLEX].append(len(strands))
+
+    rows = {}
+    for category in CATEGORIES:
+        arr = np.array(sizes[category], dtype=float)
+        rows[category] = {
+            "n_families": len(arr),
+            "avg_family_size": float(np.mean(arr)) if arr.size else np.nan,
+        }
+    per_category = pd.DataFrame.from_dict(rows, orient="index")
+    per_category.index.name = "category"
+
+    return {"per_category": per_category, "n_families": len(mi_strands)}

--- a/src/consensus/ugbio_consensus/duplex_metrics.py
+++ b/src/consensus/ugbio_consensus/duplex_metrics.py
@@ -1,29 +1,30 @@
 """
 Duplex / consensus family metrics from a ReadFuserAlignSort output CRAM.
 
-The consensus tool (``read_fuser``) writes, on each consensus read, an ``rs:B:i``
-tag holding two integers::
+The consensus tool (``read_fuser``) writes, on each consensus read, two scalar
+integer tags recording how many original reads on each strand were fused into it::
 
-    rs = [n_forward_strand_reads, n_reverse_strand_reads]
+    fs:i:<n_forward_strand_reads>
+    rs:i:<n_reverse_strand_reads>
 
-i.e. the number of original reads on the forward (+) and reverse (-) strand that
-were fused into that consensus read. This lets us classify every consensus read
-and measure family size *directly*, without re-grouping reads by their ``MI``
-(molecular identifier) tag:
+i.e. the number of original reads on the forward (+, ``fs``) and reverse (-,
+``rs``) strand. This lets us classify every consensus read and measure family
+size *directly*, without re-grouping reads by their ``MI`` (molecular identifier)
+tag:
 
-* **both-strands duplex** - both entries > 0 (the molecule was observed on both
+* **both-strands duplex** - both counts > 0 (the molecule was observed on both
   strands); family size = ``n_forward + n_reverse``.
-* **single-strand duplicate** - exactly one entry is 0; family size = the
-  non-zero entry.
-* **singleton / pass-through** - no ``rs`` tag (a read the consensus step passed
-  through unchanged); family size = 1.
+* **single-strand duplicate** - exactly one count is 0; family size = the
+  non-zero count.
+* **singleton / pass-through** - no ``fs``/``rs`` tags (a read the consensus step
+  passed through unchanged); family size = 1.
 
-``sum(rs)`` equals the length of the ``rn`` (fused read-name list) tag, so the
+``fs + rs`` equals the length of the ``rn`` (fused read-name list) tag, so the
 two encodings agree on family size.
 
 The historical MI-tag approach (grouping reads by ``MI`` and inspecting the set
 of strands) is kept in :func:`collect_family_metrics_from_mi_tags` for CRAMs
-produced without the ``rs`` tag.
+produced without any strand tags.
 """
 
 from __future__ import annotations
@@ -42,8 +43,11 @@ SINGLETON = "singleton"
 CATEGORIES = (DUPLEX, SINGLE_STRAND, SINGLETON)
 
 
-def parse_rs_tag(read: pysam.AlignedSegment) -> tuple[int, int] | None:
-    """Return ``(n_forward, n_reverse)`` from a consensus read's ``rs`` tag.
+def parse_strand_tags(read: pysam.AlignedSegment) -> tuple[int, int] | None:
+    """Return ``(n_forward, n_reverse)`` from a consensus read's strand tags.
+
+    read_fuser writes two scalar integer tags on each consensus read:
+    ``fs:i:<n_forward>`` and ``rs:i:<n_reverse>``.
 
     Parameters
     ----------
@@ -53,16 +57,15 @@ def parse_rs_tag(read: pysam.AlignedSegment) -> tuple[int, int] | None:
     Returns
     -------
     tuple[int, int] | None
-        ``(n_forward, n_reverse)`` if the read carries a well-formed 2-element
-        ``rs`` tag, otherwise ``None`` (no tag, or a malformed/scalar value).
+        ``(n_forward, n_reverse)`` if the read carries a well-formed ``fs`` tag,
+        otherwise ``None`` (no strand tags, or a malformed value).
     """
-    if not read.has_tag("rs"):
+    if not read.has_tag("fs"):
         return None
-    rs = read.get_tag("rs")
     try:
-        n_fwd, n_rev = int(rs[0]), int(rs[1])
-    except (TypeError, IndexError, ValueError):
-        # Rare scalar / malformed rs value - caller counts these as unclassified.
+        n_fwd = int(read.get_tag("fs"))
+        n_rev = int(read.get_tag("rs")) if read.has_tag("rs") else 0
+    except (TypeError, ValueError):
         return None
     return n_fwd, n_rev
 
@@ -157,21 +160,21 @@ def _iter_primary_reads_by_chrom(samfile, merged, max_reads):
 def _classify_read(read: pysam.AlignedSegment) -> tuple[str, int] | None:
     """Return ``(category, family_size)`` for a read, or ``None`` if unclassifiable.
 
-    ``None`` means the read carries an ``rs`` tag we could not parse (malformed /
-    scalar); a read with no ``rs`` tag is treated as a singleton.
+    ``None`` means the read carries strand tags we could not parse (malformed); a
+    read with no strand tags is treated as a singleton.
     """
-    rs = parse_rs_tag(read)
-    if rs is None:
-        if read.has_tag("rs"):
-            return None  # malformed/scalar rs
+    strands = parse_strand_tags(read)
+    if strands is None:
+        if read.has_tag("fs"):
+            return None  # malformed strand tags
         return SINGLETON, 1
-    n_fwd, n_rev = rs
+    n_fwd, n_rev = strands
     return classify_family(n_fwd, n_rev), max(n_fwd + n_rev, 1)
 
 
 def collect_family_metrics_from_rs_tags(
     cram_path: str,
-    intervals: list[tuple[str, int, int]],
+    intervals: list[tuple[str, int, int]] | None,
     reference: str,
     *,
     index_path: str | None = None,
@@ -179,8 +182,8 @@ def collect_family_metrics_from_rs_tags(
 ) -> dict:
     """Classify consensus reads and measure family size and coverage over ``intervals``.
 
-    For each primary read overlapping the (merged) intervals we read its ``rs``
-    tag, classify the family, record family size, and add its aligned span
+    For each primary read overlapping the (merged) intervals we read its strand
+    tags (``fs``/``rs``), classify the family, record family size, and add its aligned span
     (clipped to the interval) to that category's covered-base total. Family-size
     statistics count each read once, at the interval containing its start, so
     reads spanning an interval boundary are not double-counted.
@@ -189,10 +192,12 @@ def collect_family_metrics_from_rs_tags(
     ----------
     cram_path : str
         Path or ``s3://`` URI of the consensus CRAM.
-    intervals : list[tuple[str, int, int | None]]
+    intervals : list[tuple[str, int, int | None]] | None
         ``(chrom, start, end)`` regions to analyse (e.g. target-BED rows, or a
         whole chromosome). An ``end`` of ``None`` means "to the end of the
-        contig" and is resolved from the CRAM header.
+        contig" and is resolved from the CRAM header. Pass ``None`` to scan the
+        **whole CRAM** (every contig in the header, full length) with no region
+        limitation.
     reference : str
         Path to the reference FASTA (required to decode a CRAM).
     index_path : str | None, optional
@@ -206,7 +211,7 @@ def collect_family_metrics_from_rs_tags(
         Keys: ``per_category`` (DataFrame indexed by category with columns
         ``n_reads``, ``avg_family_size``, ``median_family_size``,
         ``covered_bases``, ``coverage``), ``total_interval_bp``,
-        ``n_reads_scanned``, ``n_unclassified`` (reads with a malformed ``rs``),
+        ``n_reads_scanned``, ``n_unclassified`` (reads with malformed strand tags),
         and ``family_sizes`` (dict category -> np.ndarray of sizes).
     """
     family_sizes: dict[str, list[int]] = {c: [] for c in CATEGORIES}
@@ -220,6 +225,9 @@ def collect_family_metrics_from_rs_tags(
         open_kwargs["index_filename"] = index_path
 
     with pysam.AlignmentFile(cram_path, "rc", **open_kwargs) as samfile:
+        # intervals=None -> scan the whole CRAM: every contig, full length.
+        if intervals is None:
+            intervals = [(name, 0, None) for name in samfile.references]
         # Resolve open-ended intervals ("to end of contig") from the header, then merge.
         resolved = [
             (chrom, start, samfile.get_reference_length(chrom) if end is None else end)
@@ -243,7 +251,7 @@ def collect_family_metrics_from_rs_tags(
 
             classified = _classify_read(read)
             if classified is None:
-                # Malformed/scalar rs - excluded from family stats.
+                # Malformed strand tags - excluded from family stats.
                 n_unclassified += 1
                 continue
             category, size = classified
@@ -283,7 +291,7 @@ def collect_family_metrics_from_mi_tags(
 ) -> dict:
     """Fallback: classify families by grouping reads on the ``MI`` tag.
 
-    Use only for consensus/duplicate-marked CRAMs that lack the ``rs`` tag. A
+    Use only for consensus/duplicate-marked CRAMs that lack the ``fs``/``rs`` strand tags. A
     family is *duplex* if its reads span both strands, *single_strand* if all
     reads share one strand, and *singleton* if it has a single read. This mirrors
     the historical MI-tag analysis; :func:`collect_family_metrics_from_rs_tags`

--- a/src/consensus/ugbio_consensus/on_target.py
+++ b/src/consensus/ugbio_consensus/on_target.py
@@ -1,0 +1,153 @@
+"""
+On-target rate and target coverage for a ReadFuserAlignSort run.
+
+Given a per-sample coverage bedGraph (the local ``bedgraph_mapq0`` output) and an
+optional *targets* BED (e.g. an exome capture BED), compute:
+
+* ``on_target_rate`` - fraction of coverage-weighted aligned bases that fall
+  inside the targets, i.e. ``sum((end-start)*depth)`` over the bedGraph
+  intersected with the targets, divided by the same sum over the whole bedGraph.
+* ``target_mean_cvg`` - mean depth over the target territory
+  (on-target weighted bases / target size).
+* ``genome_mean_cvg`` - mean depth over the callable genome.
+
+If no targets BED is supplied the on-target metrics are skipped and only
+genome-wide coverage is reported.
+
+The heavy lifting is a single streamed pass over the (large, gzipped) bedGraph,
+piped through ``bedtools intersect`` - the same approach as the reference
+notebook, generalised to an arbitrary BED and made target-agnostic.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class OnTargetResult:
+    """Coverage summary for one sample.
+
+    Attributes
+    ----------
+    total_bases_seq : int
+        Coverage-weighted aligned bases genome-wide (``sum((end-start)*depth)``).
+    on_target_bases_seq : int | None
+        Coverage-weighted aligned bases inside the targets (``None`` if no BED).
+    genome_size : int
+        Callable genome size (bp) used for ``genome_mean_cvg``.
+    target_size : int | None
+        Target territory (bp) used for ``target_mean_cvg`` (``None`` if no BED).
+    """
+
+    total_bases_seq: int
+    on_target_bases_seq: int | None
+    genome_size: int
+    target_size: int | None
+
+    @property
+    def genome_mean_cvg(self) -> float:
+        return self.total_bases_seq / self.genome_size if self.genome_size else float("nan")
+
+    @property
+    def target_mean_cvg(self) -> float | None:
+        if self.on_target_bases_seq is None or not self.target_size:
+            return None
+        return self.on_target_bases_seq / self.target_size
+
+    @property
+    def on_target_rate(self) -> float | None:
+        if self.on_target_bases_seq is None or not self.total_bases_seq:
+            return None
+        return self.on_target_bases_seq / self.total_bases_seq
+
+
+def bed_covered_size(bed_path: str) -> int:
+    """Return the number of bp covered by a BED, merging overlaps.
+
+    Parameters
+    ----------
+    bed_path : str
+        Path to a BED file.
+
+    Returns
+    -------
+    int
+        Sum of merged interval lengths (non-overlapping).
+    """
+    cmd = f"sort -k1,1 -k2,2n {bed_path} | bedtools merge -i - | awk '{{s+=$3-$2}} END{{print s+0}}'"
+    out = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, check=True)  # noqa: S607
+    return int(out.stdout.strip() or 0)
+
+
+def sorted_bed(bed_path: str, output_path: str) -> str:
+    """Write a coordinate-sorted copy of ``bed_path`` (needed for ``intersect -sorted``).
+
+    Parameters
+    ----------
+    bed_path : str
+        Input BED.
+    output_path : str
+        Where to write the sorted BED.
+
+    Returns
+    -------
+    str
+        ``output_path``.
+    """
+    subprocess.run(f"sort -k1,1 -k2,2n {bed_path} > {output_path}", shell=True, check=True)  # noqa: S602
+    return output_path
+
+
+def compute_coverage_from_bedgraph(
+    bedgraph: str,
+    genome_size: int,
+    *,
+    targets_bed_sorted: str | None = None,
+    target_size: int | None = None,
+) -> OnTargetResult:
+    """Stream a local coverage bedGraph once and sum genome-wide (and optional on-target) depth.
+
+    When ``targets_bed_sorted`` is given, the stream is ``tee``'d: one branch sums
+    all coverage-weighted bases, the other intersects with the targets and sums
+    the on-target subset.
+
+    Parameters
+    ----------
+    bedgraph : str
+        Local path of the coverage bedGraph (``bedgraph_mapq0``), plain or gzipped.
+    genome_size : int
+        Callable genome size (bp) for ``genome_mean_cvg`` (e.g. from the sorter
+        JSON ``base_coverage["Genome"]`` histogram length-weighted sum).
+    targets_bed_sorted : str | None, optional
+        Coordinate-sorted targets BED. If ``None``, only genome-wide totals are
+        computed.
+    target_size : int | None, optional
+        Merged target size in bp (required with ``targets_bed_sorted``).
+
+    Returns
+    -------
+    OnTargetResult
+        Coverage summary for the sample.
+    """
+    source = f"zcat '{bedgraph}'" if bedgraph.endswith(".gz") else f"cat '{bedgraph}'"
+
+    if targets_bed_sorted is not None:
+        if target_size is None:
+            raise ValueError("target_size is required when targets_bed_sorted is given")
+        # tee: one branch totals all bases, the other totals the on-target subset.
+        cmd = (
+            f"{source} "
+            f"| tee >(awk '{{t+=($3-$2)*$4}} END{{print t+0}}' > /tmp/_consensus_tot_$$) "
+            f"| bedtools intersect -a - -b {targets_bed_sorted} -sorted 2>/dev/null "
+            f"| awk '{{o+=($3-$2)*$4}} END{{print o+0}}'; "
+            f"cat /tmp/_consensus_tot_$$; rm -f /tmp/_consensus_tot_$$"
+        )
+        out = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, check=True).stdout.split()  # noqa: S607
+        on_target_bases, total_bases = int(out[0]), int(out[1])
+        return OnTargetResult(total_bases, on_target_bases, genome_size, target_size)
+
+    cmd = f"{source} | awk '{{t+=($3-$2)*$4}} END{{print t+0}}'"
+    out = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, check=True).stdout.strip()  # noqa: S607
+    return OnTargetResult(int(out or 0), None, genome_size, None)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> New isolated reporting package and CLI with local-file inputs; no changes to existing production pipelines beyond optional Docker workflow and LFS paths.
> 
> **Overview**
> Adds a new **`ugbio_consensus`** workspace package and **`consensus_report`** CLI that builds self-contained HTML reports (plus `_per_sample.csv` and `_manifest.csv`) from local post-consensus artifacts—no cloud I/O.
> 
> The report pulls **sorter QC** from CSV, **genome-wide / optional on-target coverage** from bedGraph + targets BED (`bedtools` streaming), **duplex family metrics** by classifying consensus reads from **`fs:i` / `rs:i`** tags over a configurable chromosome or `--duplex-chrom all`, and optional **consensus stdout** counters via log parsing. HTML assembly uses Plotly tables and charts with medians across samples.
> 
> **CI / packaging:** `consensus` is added to the manual ugbio member Docker workflow; a multi-stage **`src/consensus/Dockerfile`** ships the wheel with `ugbio_core` and `ugbio_cloud_utils`. **Git LFS** rules cover large consensus test JSON and gzipped bedGraph fixtures. Unit and system tests cover parsers, duplex logic, report assembly, and an end-to-end run on a regional BAM fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfcaf2d6416d7e6eef8a7300b4c9ae9c50bcf4bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->