### PR TITLE
BIOIN-2960 Finish "mixed = mixed start" migration in SRSNV report

### DIFF
--- a/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
+++ b/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
@@ -466,3 +466,51 @@ def test_calc_run_info_table_numerical_validation(test_resources_calc_run_info, 
         # Basic checks on structure
         assert isinstance(quality_summary, pd.Series), "run_quality_summary_table should be a Series"
         assert len(quality_summary) > 0, "run_quality_summary_table should not be empty"
+
+
+def test_plot_logit_histograms_writes_legacy_and_mixed_start_keys(
+    test_resources_calc_run_info, real_models_calc_run_info
+):
+    """plot_logit_histograms should write both the legacy (both-ends) and the new mixed-start h5 keys.
+
+    The report displays the mixed-start version (mixed = start ppmSeq tag is MIXED), while the legacy
+    both-ends histogram is retained under the original ``logit_histogram`` key for backward compatibility.
+    """
+    featuremap_df, metadata, _ = test_resources_calc_run_info
+
+    with tempfile.TemporaryDirectory() as temp_output_dir:
+        temp_metadata_file = os.path.join(temp_output_dir, "test_metadata.json")
+        with open(temp_metadata_file, "w") as f:
+            json.dump(metadata, f)
+
+        categorical_features = [f for f in metadata["features"] if f["type"] == "c"]
+        numerical_features = [f for f in metadata["features"] if f["type"] != "c"]
+
+        params = {
+            "workdir": temp_output_dir,
+            "data_name": "test_run",
+            "categorical_features_names": [f["name"] for f in categorical_features],
+            "categorical_features_dict": {f["name"]: list(f["values"].keys()) for f in categorical_features},
+            "numerical_features": [f["name"] for f in numerical_features],
+            "fp_regions_bed_file": 1,
+            "num_CV_folds": len(real_models_calc_run_info),
+        }
+
+        report = SRSNVReport(
+            models=real_models_calc_run_info,
+            data_df=featuremap_df.copy(),
+            params=params,
+            out_path=temp_output_dir,
+            srsnv_metadata=temp_metadata_file,
+            base_name="test_",
+            raise_exceptions=True,
+        )
+
+        report.plot_logit_histograms(output_filename=os.path.join(temp_output_dir, "logit_histogram"))
+
+        h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
+        with pd.HDFStore(h5_file, "r") as store:
+            assert "/logit_histogram" in store.keys(), "legacy logit_histogram key should be retained"
+            assert (
+                "/logit_histogram_mixed_start" in store.keys()
+            ), "new logit_histogram_mixed_start key should be written for display"

--- a/src/srsnv/ugbio_srsnv/reports/srsnv_report.ipynb
+++ b/src/srsnv/ugbio_srsnv/reports/srsnv_report.ipynb
@@ -365,16 +365,7 @@
    "id": "ac116334",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "ipy_display(HTML('<font size=\"5\">Run Info </font>'))\n",
-    "run_info_table = pd.read_hdf(srsnv_qc_h5_file, key=\"run_info_table\")\n",
-    "try:\n",
-    "    if isinstance(run_info_table.loc[(\"Docker image\", \"\")], str):\n",
-    "        run_info_table.loc[(\"Docker image\", \"\")] = \"/<br>\".join(run_info_table.loc[(\"Docker image\", \"\")].split(\"/\"))\n",
-    "except KeyError:\n",
-    "    pass\n",
-    "ipy_display(HTML(run_info_table.to_frame().to_html(escape=False)))"
-   ]
+   "source": "ipy_display(HTML('<font size=\"5\">Run Info </font>'))\nrun_info_table = pd.read_hdf(srsnv_qc_h5_file, key=\"run_info_table_mixed_start\")\ntry:\n    if isinstance(run_info_table.loc[(\"Docker image\", \"\")], str):\n        run_info_table.loc[(\"Docker image\", \"\")] = \"/<br>\".join(run_info_table.loc[(\"Docker image\", \"\")].split(\"/\"))\nexcept KeyError:\n    pass\nipy_display(HTML(run_info_table.to_frame().to_html(escape=False)))"
   },
   {
    "cell_type": "markdown",

--- a/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
@@ -2651,7 +2651,7 @@ class SRSNVReport:
         col = stats_for_plot.columns[0]
         polys, lines = [], []
         for is_mixed, color in zip(
-            [~stats_for_plot[IS_MIXED], stats_for_plot[IS_MIXED]], [c_false, c_true], strict=False
+            [~stats_for_plot[IS_MIXED_START], stats_for_plot[IS_MIXED_START]], [c_false, c_true], strict=False
         ):
             qual_df = stats_for_plot.loc[is_mixed & stats_for_plot[LABEL] & (stats_for_plot["count"] > min_count), :]
             fb_kws["color"] = color
@@ -2682,7 +2682,7 @@ class SRSNVReport:
             q2 [float]: upper quantile for interquartile range
             bin_edges [list]: bin edges for discretization. If it is None, use discrete (integer) values
         """
-        required_cols = [col, LABEL, IS_MIXED, QUAL]
+        required_cols = [col, LABEL, IS_MIXED_START, QUAL]
 
         # If binning is needed, create binned column in a view/subset
         if bin_edges is not None:
@@ -2693,7 +2693,7 @@ class SRSNVReport:
             # Use a view of the original dataframe (no copy needed)
             subset = self.data_df[required_cols]
 
-        stats_for_plot = subset.groupby([col, LABEL, IS_MIXED], observed=True).agg(
+        stats_for_plot = subset.groupby([col, LABEL, IS_MIXED_START], observed=True).agg(
             median_qual=(QUAL, "median"),
             quantile1_qual=(QUAL, lambda x: x.quantile(q1)),
             quantile3_qual=(QUAL, lambda x: x.quantile(q2)),
@@ -2906,12 +2906,17 @@ class SRSNVReport:
         fig.tight_layout()
         self._save_plt(output_filename=output_filename, fig=fig)
 
-    def _plot_logit_histogram(self, plot_df, ax, alpha=0.4):
-        """Plot a single histogram of logit values, by: FP, TP mixed, TP non-mixed."""
+    def _plot_logit_histogram(self, plot_df, ax, alpha=0.4, mixed_col=IS_MIXED_START):
+        """Plot a single histogram of logit values, by: FP, TP mixed, TP non-mixed.
+
+        ``mixed_col`` selects which column defines a "mixed" read. It defaults to IS_MIXED_START
+        (start ppmSeq tag is MIXED) to match the report's simplified mixed definition; pass
+        IS_MIXED for the legacy both-ends definition.
+        """
         plot_df[""] = plot_df[LABEL].astype(str)
         plot_df.loc[~plot_df[LABEL], ""] = "FP"
-        plot_df.loc[plot_df[LABEL] & plot_df[IS_MIXED], ""] = "TP mixed"
-        plot_df.loc[plot_df[LABEL] & ~plot_df[IS_MIXED], ""] = "TP non-mixed"
+        plot_df.loc[plot_df[LABEL] & plot_df[mixed_col], ""] = "TP mixed"
+        plot_df.loc[plot_df[LABEL] & ~plot_df[mixed_col], ""] = "TP non-mixed"
         sns.histplot(
             data=plot_df,
             x=ML_LOGIT_TEST,
@@ -2933,19 +2938,29 @@ class SRSNVReport:
         # label_fontsize = 12
         # ticklabelsfontsize = 12
         logger.info("Plotting logit histogram")
-        fig, ax = plt.subplots(figsize=(12, 7))
 
-        plot_df = self.data_df[[ML_LOGIT_TEST, LABEL, IS_MIXED, FOLD_ID]].copy()
-        self._plot_logit_histogram(plot_df, ax)
+        plot_df_all = self.data_df[[ML_LOGIT_TEST, LABEL, IS_MIXED, IS_MIXED_START, FOLD_ID]].copy()
+
+        # Legacy histogram data (both-ends IS_MIXED) for backward-compatible h5 storage
+        fig_legacy, ax_legacy = plt.subplots(figsize=(12, 7))
+        self._plot_logit_histogram(plot_df_all.copy(), ax_legacy, mixed_col=IS_MIXED)
+        hist_data_df_legacy = self._get_histogram_data(ax_legacy, col_name="")
+        hist_data_df_legacy.to_hdf(self.output_h5_filename, key="logit_histogram", mode="a")
+        plt.close(fig_legacy)
+
+        # New histogram (IS_MIXED_START) for display and new h5 key
+        fig, ax = plt.subplots(figsize=(12, 7))
+        plot_df = plot_df_all.copy()
+        self._plot_logit_histogram(plot_df, ax, mixed_col=IS_MIXED_START)
         hist_data_df = self._get_histogram_data(ax, col_name="")
-        hist_data_df.to_hdf(self.output_h5_filename, key="logit_histogram", mode="a")
+        hist_data_df.to_hdf(self.output_h5_filename, key="logit_histogram_mixed_start", mode="a")
 
         if plot_by_fold:
             plt.close(fig)
             fig, ax = plt.subplots(figsize=(12, 7))
-            plot_dfs = [plot_df[plot_df[FOLD_ID] == k] for k in range(len(self.models))]
+            plot_dfs = [plot_df_all[plot_df_all[FOLD_ID] == k] for k in range(len(self.models))]
             for plot_df in plot_dfs:
-                self._plot_logit_histogram(plot_df, ax, alpha=0.15)
+                self._plot_logit_histogram(plot_df.copy(), ax, alpha=0.15, mixed_col=IS_MIXED_START)
 
         sns.move_legend(
             ax,


### PR DESCRIPTION
## Context

Commit b4ff9318 (BIOIN-2883, #294) redefined displayed **"mixed"** reads in the SRSNV report to mean *start ppmSeq tag = MIXED* (`IS_MIXED_START`), keeping the old both-ends `IS_MIXED` only for backward-compatible h5 keys. The migration was incomplete: several displayed elements still used both-ends `IS_MIXED` while labeled simply "Mixed"/"Non-mixed", making them inconsistent with the histogram/summary/ROC-AUC views the commit already migrated. Because deep-srsnv (ugbio-private-utils) reuses `ugbio_srsnv` verbatim, the same mislabeling appeared in both the XGBoost and DNN reports.

## Changes

- **Run Info table**: notebook now reads `run_info_table_mixed_start` (the mixed-start key already written by `calc_run_info_table`); legacy `run_info_table` key retained for downstream consumers.
- **Logit histogram**: display split (`_plot_logit_histogram` / `plot_logit_histograms`) now uses `IS_MIXED_START`. Legacy both-ends histogram still written to h5 key `logit_histogram`; new display histogram written to `logit_histogram_mixed_start` (mirrors the `quality_histogram` / `quality_histogram_mixed_start` pattern).
- **Per-feature SNVQ curves**: `_get_stats_for_feature_plot` / `_plot_feature_qual_stats` now group/select by `IS_MIXED_START` (PNG only, no h5 key).
- Added a unit test asserting both `logit_histogram` and `logit_histogram_mixed_start` keys are written.

Left unchanged (analysis, not display): LoD-simulation `mixed_read_filter` / `default_LoD_filters`, the unused `get_data_subsets` / `get_fpr_recalls_subsets`, and all intentional `*_legacy` h5 writers.

## Testing

- `uv run pytest src/srsnv/tests/unit/test_srsnv_plotting_utils.py` — passes (new test included).
- Pinned pre-commit (ruff v0.8.4) passes on changed files.

Docker image built from this branch: `ugbio_srsnv:test_3953c06` (build-ugbio-member-docker.yml run 30190317275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Report plotting and HDF5 key selection only; legacy keys are preserved and changes align displayed metrics with an existing partial migration.
> 
> **Overview**
> Completes the **mixed = start ppmSeq MIXED** migration so remaining SRSNV report views match histograms, ROC-AUC, and quality summary tables that already used `IS_MIXED_START`.
> 
> The **Run Info** notebook cell now loads `run_info_table_mixed_start` instead of the legacy `run_info_table` key. **Logit histograms** split TP mixed vs non-mixed using `IS_MIXED_START` for the saved PNG and fold overlays; `_plot_logit_histogram` accepts a `mixed_col` argument (default `IS_MIXED_START`, `IS_MIXED` for legacy). H5 output keeps **`logit_histogram`** (both-ends) and adds **`logit_histogram_mixed_start`** for display, mirroring the quality histogram pattern. **Per-feature SNVQ curves** (`_get_stats_for_feature_plot` / `_plot_feature_qual_stats`) group by `IS_MIXED_START` instead of `IS_MIXED`.
> 
> A unit test asserts both logit histogram HDF5 keys are written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3953c067bca0e26d4573d3fcfddad3b3aaa248bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->