### PR TITLE
BIOIN-2966 SRSNV report: auto mode selection + N-group read splits

### DIFF
--- a/src/featuremap/ugbio_featuremap/featuremap_utils.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_utils.py
@@ -33,6 +33,8 @@ class FeatureMapFields(Enum):
     X_HMER_ALT = "X_HMER_ALT"
     ST = "st"
     ET = "et"
+    FS = "fs"  # forward-strand read count (consensus data)
+    RS = "rs"  # reverse-strand read count (consensus data)
     EDIST = "EDIST"
     HAMDIST = "HAMDIST"
     HAMDIST_FILT = "HAMDIST_FILT"

--- a/src/featuremap/ugbio_featuremap/featuremap_utils.py
+++ b/src/featuremap/ugbio_featuremap/featuremap_utils.py
@@ -33,8 +33,8 @@ class FeatureMapFields(Enum):
     X_HMER_ALT = "X_HMER_ALT"
     ST = "st"
     ET = "et"
-    FS = "fs"  # forward-strand read count (consensus data)
-    RS = "rs"  # reverse-strand read count (consensus data)
+    NF = "nf"  # forward-strand read count (consensus data)
+    NR = "nr"  # reverse-strand read count (consensus data)
     EDIST = "EDIST"
     HAMDIST = "HAMDIST"
     HAMDIST_FILT = "HAMDIST_FILT"

--- a/src/srsnv/tests/unit/test_split_scheme.py
+++ b/src/srsnv/tests/unit/test_split_scheme.py
@@ -1,0 +1,210 @@
+"""Unit tests for the SRSNV split-scheme "recipe" module (ugbio_srsnv.split_scheme).
+
+Covers: scheme detection from columns, per-scheme add_columns, the ordered group_fns, variant
+h5-key composition, and the extensibility contract (a new scheme registered in SPLIT_SCHEMES is
+picked up by resolve_scheme without touching any report/figure code).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from ugbio_srsnv import split_scheme as ss
+from ugbio_srsnv.split_scheme import (
+    CONSENSUS_SCHEME,
+    MIXED_SCHEME,
+    NONE_SCHEME,
+    SplitScheme,
+    SplitVariant,
+    h5_key,
+    resolve_scheme,
+    resolve_scheme_and_add_columns,
+)
+from ugbio_srsnv.srsnv_utils import (
+    FS,
+    IS_CONSENSUS,
+    IS_MIXED,
+    READ_GROUP,
+    RS,
+    ReportMode,
+)
+
+# ──────────────────────────── detection ────────────────────────────
+
+
+class TestResolveScheme:
+    def test_mixed_from_st_et(self):
+        data_df = pd.DataFrame({"st": ["MIXED", "PLUS"], "et": ["MIXED", "MINUS"]})
+        assert resolve_scheme(data_df) is MIXED_SCHEME
+
+    def test_mixed_from_v5_tags(self):
+        data_df = pd.DataFrame({"as": [1, 2], "ae": [1, 0], "ts": [0, 1], "te": [1, 1]})
+        assert resolve_scheme(data_df) is MIXED_SCHEME
+
+    def test_consensus_from_fs_rs(self):
+        data_df = pd.DataFrame({FS: [0, 1, 2], RS: [1, 1, 0]})
+        assert resolve_scheme(data_df) is CONSENSUS_SCHEME
+
+    def test_none_when_no_split_columns(self):
+        data_df = pd.DataFrame({"MQUAL": [10.0, 20.0], "label": [True, False]})
+        assert resolve_scheme(data_df) is NONE_SCHEME
+
+    def test_ppmseq_tags_take_priority_over_fs_rs(self):
+        data_df = pd.DataFrame({"st": ["MIXED", "PLUS"], "et": ["MIXED", "MINUS"], FS: [1, 2], RS: [1, 0]})
+        assert resolve_scheme(data_df) is MIXED_SCHEME
+
+    def test_resolve_by_mode_value(self):
+        assert resolve_scheme(mode="mixed") is MIXED_SCHEME
+        assert resolve_scheme(mode="consensus") is CONSENSUS_SCHEME
+        assert resolve_scheme(mode="none") is NONE_SCHEME
+
+    def test_resolve_by_mode_enum(self):
+        assert resolve_scheme(mode=ReportMode.CONSENSUS) is CONSENSUS_SCHEME
+
+
+# ──────────────────────────── h5 keys / variants ────────────────────────────
+
+
+class TestVariantsAndKeys:
+    def test_mixed_has_two_variants_legacy_first(self):
+        assert len(MIXED_SCHEME.variants) == 2
+        # variants[0] is the legacy/base-key variant (empty suffix)
+        assert MIXED_SCHEME.legacy_variant.suffix == ""
+        assert MIXED_SCHEME.display_variant.suffix == "mixed_start"
+
+    def test_consensus_single_display_variant(self):
+        assert len(CONSENSUS_SCHEME.variants) == 1
+        assert CONSENSUS_SCHEME.display_variant.suffix == "strand_support"
+        assert CONSENSUS_SCHEME.display_suffix == "strand_support"
+
+    def test_h5_key_empty_suffix_is_bare_base(self):
+        assert h5_key("run_info_table", MIXED_SCHEME.legacy_variant) == "run_info_table"
+
+    def test_h5_key_nonempty_suffix(self):
+        assert h5_key("run_info_table", MIXED_SCHEME.display_variant) == "run_info_table_mixed_start"
+        assert h5_key("run_info_table", CONSENSUS_SCHEME.display_variant) == "run_info_table_strand_support"
+
+    def test_exactly_one_display_variant_per_scheme(self):
+        for scheme in (MIXED_SCHEME, CONSENSUS_SCHEME, NONE_SCHEME):
+            assert sum(v.is_display for v in scheme.variants) == 1
+
+
+# ──────────────────────────── group functions ────────────────────────────
+
+
+class TestGroupFunctions:
+    def test_consensus_groups_definition(self):
+        # single: fs+rs<=1 ; one strand: >=2 total & exactly one of fs/rs == 0 ; duplex: fs>=1 & rs>=1
+        data_df = pd.DataFrame({FS: [0, 0, 3, 1, 2], RS: [0, 1, 0, 1, 3]})
+        groups = np.asarray(CONSENSUS_SCHEME.display_variant.group_fn(data_df))
+        assert list(groups) == [
+            "single read",  # 0+0
+            "single read",  # 0+1
+            "consensus, one strand",  # 3+0
+            "consensus, duplex",  # 1+1
+            "consensus, duplex",  # 2+3
+        ]
+
+    def test_consensus_groups_are_ordered_categorical(self):
+        data_df = pd.DataFrame({FS: [0, 1], RS: [0, 1]})
+        cat = CONSENSUS_SCHEME.display_variant.group_fn(data_df)
+        assert isinstance(cat, pd.Categorical)
+        assert cat.ordered
+        assert list(cat.categories) == ["single read", "consensus, one strand", "consensus, duplex"]
+
+    def test_mixed_display_groups_from_is_mixed_start(self):
+        data_df = pd.DataFrame({"is_mixed_start": [True, False, True], "is_mixed": [False, False, True]})
+        disp = np.asarray(MIXED_SCHEME.display_variant.group_fn(data_df))
+        assert list(disp) == ["Mixed", "Non-mixed", "Mixed"]
+
+    def test_mixed_legacy_groups_from_is_mixed(self):
+        data_df = pd.DataFrame({"is_mixed_start": [True, False, True], "is_mixed": [False, False, True]})
+        legacy = np.asarray(MIXED_SCHEME.legacy_variant.group_fn(data_df))
+        assert list(legacy) == ["Non-mixed", "Non-mixed", "Mixed"]
+
+    def test_group_masks_are_boolean_arrays(self):
+        data_df = pd.DataFrame({FS: [0, 1, 2], RS: [0, 1, 0]})
+        masks = CONSENSUS_SCHEME.display_variant.group_masks(data_df)
+        assert set(masks) == {"single read", "consensus, one strand", "consensus, duplex"}
+        for m in masks.values():
+            assert m.dtype == bool
+            assert len(m) == 3
+        # exhaustive + mutually exclusive
+        stacked = np.vstack(list(masks.values()))
+        assert stacked.sum(axis=0).tolist() == [1, 1, 1]
+
+
+# ──────────────────────────── add_columns / resolve+add ────────────────────────────
+
+
+class TestAddColumns:
+    def test_consensus_adds_is_consensus_and_read_group(self):
+        data_df = pd.DataFrame({FS: [0, 1, 2, 3], RS: [1, 1, 0, 2]})
+        out, scheme = resolve_scheme_and_add_columns(data_df)
+        assert scheme is CONSENSUS_SCHEME
+        assert IS_CONSENSUS in out.columns
+        expected = ((data_df[FS] >= 1) & (data_df[RS] >= 1)).tolist()
+        assert out[IS_CONSENSUS].tolist() == expected
+        # read_group is the display variant's grouping
+        assert READ_GROUP in out.columns
+        np.testing.assert_array_equal((out[READ_GROUP] == "consensus, duplex").to_numpy(), np.array(expected))
+
+    def test_none_sets_is_consensus_false_and_single_group(self):
+        data_df = pd.DataFrame({"MQUAL": [1.0, 2.0, 3.0]})
+        out, scheme = resolve_scheme_and_add_columns(data_df)
+        assert scheme is NONE_SCHEME
+        assert out[IS_CONSENSUS].tolist() == [False, False, False]
+        assert list(out[READ_GROUP].unique()) == ["all reads"]
+
+    def test_mixed_adds_is_mixed_columns(self):
+        data_df = pd.DataFrame({"st": ["MIXED", "MIXED", "PLUS", "MINUS"], "et": ["MIXED", "PLUS", "PLUS", "MINUS"]})
+        out, scheme = resolve_scheme_and_add_columns(data_df, adapter_version="v1")
+        assert scheme is MIXED_SCHEME
+        assert IS_MIXED in out.columns
+        assert READ_GROUP in out.columns
+
+
+# ──────────────────────────── extensibility contract ────────────────────────────
+
+
+class TestExtensibility:
+    def test_new_scheme_registered_is_detected_without_touching_report(self):
+        """A new scheme = one SplitScheme + detector appended to SPLIT_SCHEMES; resolve_scheme
+        picks it up. This is the core generality claim of the refactor."""
+        marker = "duplex_v2_marker"
+
+        def _dv2_groups(df):
+            g = pd.Series("weak", index=df.index, dtype=object)
+            g[df[marker] > 0] = "strong"
+            return pd.Categorical(g, categories=["weak", "strong"], ordered=True)
+
+        dummy = SplitScheme(
+            mode=ReportMode.NONE,  # reuse an enum value; detection is by `detect`, not mode
+            detect=lambda cols: marker in cols,
+            add_columns=lambda data_df, kw: data_df,  # noqa: ARG005
+            variants=(
+                SplitVariant(
+                    suffix="duplex_v2",
+                    group_fn=_dv2_groups,
+                    groups=("weak", "strong"),
+                    is_display=True,
+                ),
+            ),
+            tag_axis="duplex v2",
+        )
+
+        original = ss.SPLIT_SCHEMES
+        try:
+            # insert before NONE (the fallback) so it can win detection
+            ss.SPLIT_SCHEMES = (dummy, *original)
+            data_df = pd.DataFrame({marker: [0, 1, 2]})
+            assert resolve_scheme(data_df) is dummy
+            # and a scheme without the marker still resolves to a built-in
+            assert resolve_scheme(pd.DataFrame({FS: [1], RS: [1]})) is CONSENSUS_SCHEME
+        finally:
+            ss.SPLIT_SCHEMES = original
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/src/srsnv/tests/unit/test_split_scheme.py
+++ b/src/srsnv/tests/unit/test_split_scheme.py
@@ -22,11 +22,11 @@ from ugbio_srsnv.split_scheme import (
     resolve_scheme_and_add_columns,
 )
 from ugbio_srsnv.srsnv_utils import (
-    FS,
     IS_CONSENSUS,
     IS_MIXED,
+    NF,
+    NR,
     READ_GROUP,
-    RS,
     ReportMode,
 )
 
@@ -42,16 +42,16 @@ class TestResolveScheme:
         data_df = pd.DataFrame({"as": [1, 2], "ae": [1, 0], "ts": [0, 1], "te": [1, 1]})
         assert resolve_scheme(data_df) is MIXED_SCHEME
 
-    def test_consensus_from_fs_rs(self):
-        data_df = pd.DataFrame({FS: [0, 1, 2], RS: [1, 1, 0]})
+    def test_consensus_from_nf_nr(self):
+        data_df = pd.DataFrame({NF: [0, 1, 2], NR: [1, 1, 0]})
         assert resolve_scheme(data_df) is CONSENSUS_SCHEME
 
     def test_none_when_no_split_columns(self):
         data_df = pd.DataFrame({"MQUAL": [10.0, 20.0], "label": [True, False]})
         assert resolve_scheme(data_df) is NONE_SCHEME
 
-    def test_ppmseq_tags_take_priority_over_fs_rs(self):
-        data_df = pd.DataFrame({"st": ["MIXED", "PLUS"], "et": ["MIXED", "MINUS"], FS: [1, 2], RS: [1, 0]})
+    def test_ppmseq_tags_take_priority_over_nf_nr(self):
+        data_df = pd.DataFrame({"st": ["MIXED", "PLUS"], "et": ["MIXED", "MINUS"], NF: [1, 2], NR: [1, 0]})
         assert resolve_scheme(data_df) is MIXED_SCHEME
 
     def test_resolve_by_mode_value(self):
@@ -95,8 +95,8 @@ class TestVariantsAndKeys:
 
 class TestGroupFunctions:
     def test_consensus_groups_definition(self):
-        # single: fs+rs<=1 ; one strand: >=2 total & exactly one of fs/rs == 0 ; duplex: fs>=1 & rs>=1
-        data_df = pd.DataFrame({FS: [0, 0, 3, 1, 2], RS: [0, 1, 0, 1, 3]})
+        # single: nf+nr<=1 ; one strand: >=2 total & exactly one of nf/nr == 0 ; duplex: nf>=1 & nr>=1
+        data_df = pd.DataFrame({NF: [0, 0, 3, 1, 2], NR: [0, 1, 0, 1, 3]})
         groups = np.asarray(CONSENSUS_SCHEME.display_variant.group_fn(data_df))
         assert list(groups) == [
             "single read",  # 0+0
@@ -107,7 +107,7 @@ class TestGroupFunctions:
         ]
 
     def test_consensus_groups_are_ordered_categorical(self):
-        data_df = pd.DataFrame({FS: [0, 1], RS: [0, 1]})
+        data_df = pd.DataFrame({NF: [0, 1], NR: [0, 1]})
         cat = CONSENSUS_SCHEME.display_variant.group_fn(data_df)
         assert isinstance(cat, pd.Categorical)
         assert cat.ordered
@@ -124,7 +124,7 @@ class TestGroupFunctions:
         assert list(legacy) == ["Non-mixed", "Non-mixed", "Mixed"]
 
     def test_group_masks_are_boolean_arrays(self):
-        data_df = pd.DataFrame({FS: [0, 1, 2], RS: [0, 1, 0]})
+        data_df = pd.DataFrame({NF: [0, 1, 2], NR: [0, 1, 0]})
         masks = CONSENSUS_SCHEME.display_variant.group_masks(data_df)
         assert set(masks) == {"single read", "consensus, one strand", "consensus, duplex"}
         for m in masks.values():
@@ -140,11 +140,11 @@ class TestGroupFunctions:
 
 class TestAddColumns:
     def test_consensus_adds_is_consensus_and_read_group(self):
-        data_df = pd.DataFrame({FS: [0, 1, 2, 3], RS: [1, 1, 0, 2]})
+        data_df = pd.DataFrame({NF: [0, 1, 2, 3], NR: [1, 1, 0, 2]})
         out, scheme = resolve_scheme_and_add_columns(data_df)
         assert scheme is CONSENSUS_SCHEME
         assert IS_CONSENSUS in out.columns
-        expected = ((data_df[FS] >= 1) & (data_df[RS] >= 1)).tolist()
+        expected = ((data_df[NF] >= 1) & (data_df[NR] >= 1)).tolist()
         assert out[IS_CONSENSUS].tolist() == expected
         # read_group is the display variant's grouping
         assert READ_GROUP in out.columns
@@ -201,7 +201,7 @@ class TestExtensibility:
             data_df = pd.DataFrame({marker: [0, 1, 2]})
             assert resolve_scheme(data_df) is dummy
             # and a scheme without the marker still resolves to a built-in
-            assert resolve_scheme(pd.DataFrame({FS: [1], RS: [1]})) is CONSENSUS_SCHEME
+            assert resolve_scheme(pd.DataFrame({NF: [1], NR: [1]})) is CONSENSUS_SCHEME
         finally:
             ss.SPLIT_SCHEMES = original
 

--- a/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
+++ b/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
@@ -514,3 +514,197 @@ def test_plot_logit_histograms_writes_legacy_and_mixed_start_keys(
             assert (
                 "/logit_histogram_mixed_start" in store.keys()
             ), "new logit_histogram_mixed_start key should be written for display"
+
+
+# ──────────────────────── consensus mode (fs/rs) tests ──────────────────────
+
+
+@pytest.fixture
+def consensus_resources(test_resources_calc_run_info):
+    """Build a consensus-mode featuremap from the real ppmSeq resources.
+
+    Drops the ppmSeq st/et tags and adds fs/rs read counts so the report auto-detects
+    CONSENSUS mode. Returns (featuremap_df, metadata).
+    """
+    featuremap_df, metadata, _ = test_resources_calc_run_info
+    consensus_df = featuremap_df.copy()
+    consensus_df = consensus_df.drop(columns=[c for c in ("st", "et") if c in consensus_df.columns])
+    rng = np.random.default_rng(7)
+    consensus_df["fs"] = rng.integers(0, 6, len(consensus_df))
+    consensus_df["rs"] = rng.integers(0, 6, len(consensus_df))
+    # Ensure both consensus and non-consensus reads are present
+    consensus_df.loc[consensus_df.index[:50], ["fs", "rs"]] = 2
+    consensus_df.loc[consensus_df.index[50:100], "fs"] = 0
+    # Drop st/et from the metadata categorical features so params don't reference them
+    metadata = json.loads(json.dumps(metadata))
+    metadata["features"] = [f for f in metadata["features"] if f["name"] not in ("st", "et")]
+    return consensus_df, metadata
+
+
+def _make_consensus_report(df, metadata, temp_output_dir, models):
+    """Helper: build an SRSNVReport in consensus mode from a consensus dataframe."""
+    temp_metadata_file = os.path.join(temp_output_dir, "test_metadata.json")
+    with open(temp_metadata_file, "w") as f:
+        json.dump(metadata, f)
+    categorical_features = [f for f in metadata["features"] if f["type"] == "c"]
+    numerical_features = [f for f in metadata["features"] if f["type"] != "c"]
+    params = {
+        "workdir": temp_output_dir,
+        "data_name": "test_run",
+        "categorical_features_names": [f["name"] for f in categorical_features],
+        "categorical_features_dict": {f["name"]: list(f["values"].keys()) for f in categorical_features},
+        "numerical_features": [f["name"] for f in numerical_features],
+        "fp_regions_bed_file": 1,
+        "num_CV_folds": len(models),
+        "report_mode": "consensus",
+    }
+    return SRSNVReport(
+        models=models,
+        data_df=df.copy(),
+        params=params,
+        out_path=temp_output_dir,
+        srsnv_metadata=temp_metadata_file,
+        base_name="test_",
+        raise_exceptions=True,
+    )
+
+
+def test_consensus_mode_auto_detected(consensus_resources, real_models_calc_run_info):
+    """SRSNVReport auto-detects consensus mode, adds is_consensus and the 3-group read_group."""
+    df, metadata = consensus_resources
+    with tempfile.TemporaryDirectory() as temp_output_dir:
+        report = _make_consensus_report(df, metadata, temp_output_dir, real_models_calc_run_info)
+        assert report.report_mode.value == "consensus"
+        assert report.split.groups == ["single read", "consensus, one strand", "consensus, duplex"]
+        assert "is_consensus" in report.data_df.columns
+        assert "read_group" in report.data_df.columns
+        # duplex group == the is_consensus boolean
+        expected = ((df["fs"] >= 1) & (df["rs"] >= 1)).to_numpy()
+        np.testing.assert_array_equal(report.data_df["is_consensus"].to_numpy(), expected)
+        np.testing.assert_array_equal((report.data_df["read_group"] == "consensus, duplex").to_numpy(), expected)
+
+
+def test_consensus_mode_roc_auc_table_keys_and_labels(consensus_resources, real_models_calc_run_info):
+    """ROC AUC table keeps stable h5 keys and uses the 3 consensus read-group labels."""
+    df, metadata = consensus_resources
+    with tempfile.TemporaryDirectory() as temp_output_dir:
+        report = _make_consensus_report(df, metadata, temp_output_dir, real_models_calc_run_info)
+        report.calc_roc_auc_table()
+        h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
+        with pd.HDFStore(h5_file, "r") as store:
+            assert "/roc_auc_table" in store.keys()
+            assert "/roc_auc_table_mixed_start" in store.keys()
+        table = pd.read_hdf(h5_file, key="roc_auc_table_mixed_start")
+        # Index after .T stores the group labels
+        labels = list(table.columns) + list(table.index)
+        assert "single read only" in labels
+        assert "consensus, one strand only" in labels
+        assert "consensus, duplex only" in labels
+
+
+CONSENSUS_GROUP_LABELS = ["single read", "consensus, one strand", "consensus, duplex"]
+
+
+def test_consensus_mode_run_quality_table_labels(consensus_resources, real_models_calc_run_info):
+    """Run quality display table carries the 3 consensus read-group labels; keys stable."""
+    df, metadata = consensus_resources
+    with tempfile.TemporaryDirectory() as temp_output_dir:
+        report = _make_consensus_report(df, metadata, temp_output_dir, real_models_calc_run_info)
+        report.plot_fq_recall(only_calculate=True)
+        report.calc_run_quality_table()
+        h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
+        with pd.HDFStore(h5_file, "r") as store:
+            assert "/run_quality_table" in store.keys()
+            assert "/run_quality_table_mixed_start" in store.keys()
+            assert "/run_quality_table_display" in store.keys()
+        display = pd.read_hdf(h5_file, key="run_quality_table_display")
+        third_level = set(display.columns.get_level_values(2))
+        for label in CONSENSUS_GROUP_LABELS:
+            assert label in third_level
+
+
+def test_consensus_mode_run_info_table_label(consensus_resources, real_models_calc_run_info):
+    """Run info table labels one row group per consensus read group."""
+    df, metadata = consensus_resources
+    with tempfile.TemporaryDirectory() as temp_output_dir:
+        report = _make_consensus_report(df, metadata, temp_output_dir, real_models_calc_run_info)
+        report.plot_fq_recall(only_calculate=True)
+        report.calc_run_info_table()
+        h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
+        run_info = pd.read_hdf(h5_file, key="run_info_table_mixed_start")
+        level0 = set(run_info.index.get_level_values(0))
+        for label in CONSENSUS_GROUP_LABELS:
+            assert f"{label} training reads" in level0
+
+
+def test_consensus_mode_quality_per_tags_table(consensus_resources, real_models_calc_run_info):
+    """quality_per_ppmseq_tags produces a per-read-group (3-row) table under stable keys."""
+    df, metadata = consensus_resources
+    with tempfile.TemporaryDirectory() as temp_output_dir:
+        report = _make_consensus_report(df, metadata, temp_output_dir, real_models_calc_run_info)
+        out_png = os.path.join(temp_output_dir, "qual_vs_tags")
+        report.quality_per_ppmseq_tags(output_filename=out_png)
+        h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
+        with pd.HDFStore(h5_file, "r") as store:
+            assert "/ppmseq_category_quality_table_mixed_start" in store.keys()
+            # legacy keys still written so downstream h5->json conversion doesn't KeyError
+            assert "/ppmseq_category_quality_table" in store.keys()
+            assert "/ppmseq_category_quantity_table" in store.keys()
+        summary = pd.read_hdf(h5_file, key="ppmseq_category_quality_table_mixed_start")
+        assert list(summary.index) == CONSENSUS_GROUP_LABELS
+        assert os.path.exists(out_png + ".png")
+
+
+def test_consensus_mode_histograms_run(consensus_resources, real_models_calc_run_info):
+    """Quality + logit histograms run in consensus mode and keep stable h5 keys."""
+    df, metadata = consensus_resources
+    with tempfile.TemporaryDirectory() as temp_output_dir:
+        report = _make_consensus_report(df, metadata, temp_output_dir, real_models_calc_run_info)
+        report.plot_quality_histogram(output_filename=os.path.join(temp_output_dir, "qual_hist"))
+        report.plot_logit_histograms(output_filename=os.path.join(temp_output_dir, "logit_hist"))
+        h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
+        with pd.HDFStore(h5_file, "r") as store:
+            keys = store.keys()
+        for k in (
+            "/quality_histogram",
+            "/quality_histogram_mixed_start",
+            "/logit_histogram",
+            "/logit_histogram_mixed_start",
+        ):
+            assert k in keys, f"missing {k}"
+
+
+def test_none_mode_graceful(test_resources_calc_run_info, real_models_calc_run_info):
+    """With neither ppmSeq tags nor fs/rs, the report runs as a single group (NONE mode)."""
+    featuremap_df, metadata, _ = test_resources_calc_run_info
+    none_df = featuremap_df.copy().drop(columns=[c for c in ("st", "et") if c in featuremap_df.columns])
+    metadata = json.loads(json.dumps(metadata))
+    metadata["features"] = [f for f in metadata["features"] if f["name"] not in ("st", "et")]
+    with tempfile.TemporaryDirectory() as temp_output_dir:
+        temp_metadata_file = os.path.join(temp_output_dir, "test_metadata.json")
+        with open(temp_metadata_file, "w") as f:
+            json.dump(metadata, f)
+        categorical_features = [f for f in metadata["features"] if f["type"] == "c"]
+        numerical_features = [f for f in metadata["features"] if f["type"] != "c"]
+        params = {
+            "workdir": temp_output_dir,
+            "data_name": "test_run",
+            "categorical_features_names": [f["name"] for f in categorical_features],
+            "categorical_features_dict": {f["name"]: list(f["values"].keys()) for f in categorical_features},
+            "numerical_features": [f["name"] for f in numerical_features],
+            "fp_regions_bed_file": 1,
+            "num_CV_folds": len(real_models_calc_run_info),
+        }
+        report = SRSNVReport(
+            models=real_models_calc_run_info,
+            data_df=none_df.copy(),
+            params=params,
+            out_path=temp_output_dir,
+            srsnv_metadata=temp_metadata_file,
+            base_name="test_",
+            raise_exceptions=True,
+        )
+        assert report.report_mode.value == "none"
+        assert not report.data_df["is_consensus"].any()
+        report.plot_fq_recall(only_calculate=True)
+        report.calc_roc_auc_table()  # should not raise

--- a/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
+++ b/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
@@ -517,25 +517,25 @@ def test_plot_logit_histograms_writes_legacy_and_mixed_start_keys(
             ), "new logit_histogram_mixed_start key should be written for display"
 
 
-# ──────────────────────── consensus mode (fs/rs) tests ──────────────────────
+# ──────────────────────── consensus mode (nf/nr) tests ──────────────────────
 
 
 @pytest.fixture
 def consensus_resources(test_resources_calc_run_info):
     """Build a consensus-mode featuremap from the real ppmSeq resources.
 
-    Drops the ppmSeq st/et tags and adds fs/rs read counts so the report auto-detects
+    Drops the ppmSeq st/et tags and adds nf/nr read counts so the report auto-detects
     CONSENSUS mode. Returns (featuremap_df, metadata).
     """
     featuremap_df, metadata, _ = test_resources_calc_run_info
     consensus_df = featuremap_df.copy()
     consensus_df = consensus_df.drop(columns=[c for c in ("st", "et") if c in consensus_df.columns])
     rng = np.random.default_rng(7)
-    consensus_df["fs"] = rng.integers(0, 6, len(consensus_df))
-    consensus_df["rs"] = rng.integers(0, 6, len(consensus_df))
+    consensus_df["nf"] = rng.integers(0, 6, len(consensus_df))
+    consensus_df["nr"] = rng.integers(0, 6, len(consensus_df))
     # Ensure both consensus and non-consensus reads are present
-    consensus_df.loc[consensus_df.index[:50], ["fs", "rs"]] = 2
-    consensus_df.loc[consensus_df.index[50:100], "fs"] = 0
+    consensus_df.loc[consensus_df.index[:50], ["nf", "nr"]] = 2
+    consensus_df.loc[consensus_df.index[50:100], "nf"] = 0
     # Drop st/et from the metadata categorical features so params don't reference them
     metadata = json.loads(json.dumps(metadata))
     metadata["features"] = [f for f in metadata["features"] if f["name"] not in ("st", "et")]
@@ -584,7 +584,7 @@ def test_consensus_mode_auto_detected(consensus_resources, real_models_calc_run_
         assert "is_consensus" in report.data_df.columns
         assert "read_group" in report.data_df.columns
         # duplex group == the is_consensus boolean
-        expected = ((df["fs"] >= 1) & (df["rs"] >= 1)).to_numpy()
+        expected = ((df["nf"] >= 1) & (df["nr"] >= 1)).to_numpy()
         np.testing.assert_array_equal(report.data_df["is_consensus"].to_numpy(), expected)
         np.testing.assert_array_equal((report.data_df["read_group"] == "consensus, duplex").to_numpy(), expected)
 
@@ -681,7 +681,7 @@ def test_consensus_mode_histograms_run(consensus_resources, real_models_calc_run
 
 
 def test_none_mode_graceful(test_resources_calc_run_info, real_models_calc_run_info):
-    """With neither ppmSeq tags nor fs/rs, the report runs as a single group (NONE mode)."""
+    """With neither ppmSeq tags nor nf/nr, the report runs as a single group (NONE mode)."""
     featuremap_df, metadata, _ = test_resources_calc_run_info
     none_df = featuremap_df.copy().drop(columns=[c for c in ("st", "et") if c in featuremap_df.columns])
     metadata = json.loads(json.dumps(metadata))

--- a/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
+++ b/src/srsnv/tests/unit/test_srsnv_plotting_utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -575,7 +576,11 @@ def test_consensus_mode_auto_detected(consensus_resources, real_models_calc_run_
     with tempfile.TemporaryDirectory() as temp_output_dir:
         report = _make_consensus_report(df, metadata, temp_output_dir, real_models_calc_run_info)
         assert report.report_mode.value == "consensus"
-        assert report.split.groups == ["single read", "consensus, one strand", "consensus, duplex"]
+        assert list(report.scheme.display_variant.groups) == [
+            "single read",
+            "consensus, one strand",
+            "consensus, duplex",
+        ]
         assert "is_consensus" in report.data_df.columns
         assert "read_group" in report.data_df.columns
         # duplex group == the is_consensus boolean
@@ -592,9 +597,10 @@ def test_consensus_mode_roc_auc_table_keys_and_labels(consensus_resources, real_
         report.calc_roc_auc_table()
         h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
         with pd.HDFStore(h5_file, "r") as store:
+            # consensus writes the scheme-suffixed key + the bare base alias (for h5->json)
             assert "/roc_auc_table" in store.keys()
-            assert "/roc_auc_table_mixed_start" in store.keys()
-        table = pd.read_hdf(h5_file, key="roc_auc_table_mixed_start")
+            assert "/roc_auc_table_strand_support" in store.keys()
+        table = pd.read_hdf(h5_file, key="roc_auc_table_strand_support")
         # Index after .T stores the group labels
         labels = list(table.columns) + list(table.index)
         assert "single read only" in labels
@@ -615,7 +621,7 @@ def test_consensus_mode_run_quality_table_labels(consensus_resources, real_model
         h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
         with pd.HDFStore(h5_file, "r") as store:
             assert "/run_quality_table" in store.keys()
-            assert "/run_quality_table_mixed_start" in store.keys()
+            assert "/run_quality_table_strand_support" in store.keys()
             assert "/run_quality_table_display" in store.keys()
         display = pd.read_hdf(h5_file, key="run_quality_table_display")
         third_level = set(display.columns.get_level_values(2))
@@ -631,7 +637,7 @@ def test_consensus_mode_run_info_table_label(consensus_resources, real_models_ca
         report.plot_fq_recall(only_calculate=True)
         report.calc_run_info_table()
         h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
-        run_info = pd.read_hdf(h5_file, key="run_info_table_mixed_start")
+        run_info = pd.read_hdf(h5_file, key="run_info_table_strand_support")
         level0 = set(run_info.index.get_level_values(0))
         for label in CONSENSUS_GROUP_LABELS:
             assert f"{label} training reads" in level0
@@ -646,11 +652,11 @@ def test_consensus_mode_quality_per_tags_table(consensus_resources, real_models_
         report.quality_per_ppmseq_tags(output_filename=out_png)
         h5_file = os.path.join(temp_output_dir, "test_single_read_snv.applicationQC.h5")
         with pd.HDFStore(h5_file, "r") as store:
-            assert "/ppmseq_category_quality_table_mixed_start" in store.keys()
-            # legacy keys still written so downstream h5->json conversion doesn't KeyError
+            assert "/ppmseq_category_quality_table_strand_support" in store.keys()
+            # bare base keys still written so downstream h5->json conversion doesn't KeyError
             assert "/ppmseq_category_quality_table" in store.keys()
             assert "/ppmseq_category_quantity_table" in store.keys()
-        summary = pd.read_hdf(h5_file, key="ppmseq_category_quality_table_mixed_start")
+        summary = pd.read_hdf(h5_file, key="ppmseq_category_quality_table_strand_support")
         assert list(summary.index) == CONSENSUS_GROUP_LABELS
         assert os.path.exists(out_png + ".png")
 
@@ -667,9 +673,9 @@ def test_consensus_mode_histograms_run(consensus_resources, real_models_calc_run
             keys = store.keys()
         for k in (
             "/quality_histogram",
-            "/quality_histogram_mixed_start",
+            "/quality_histogram_strand_support",
             "/logit_histogram",
-            "/logit_histogram_mixed_start",
+            "/logit_histogram_strand_support",
         ):
             assert k in keys, f"missing {k}"
 
@@ -708,3 +714,66 @@ def test_none_mode_graceful(test_resources_calc_run_info, real_models_calc_run_i
         assert not report.data_df["is_consensus"].any()
         report.plot_fq_recall(only_calculate=True)
         report.calc_roc_auc_table()  # should not raise
+
+
+# The exact historical mixed (ppmSeq) h5 key surface produced by the full prepare_report path.
+# The recipe refactor MUST keep the ppmSeq report byte-identical, and the key set is the first
+# line of defense: any dropped / renamed / added key for mixed data breaks backward compatibility
+# (the notebook reads *_mixed_start; h5->json conversion reads the bare base keys).
+MIXED_EXPECTED_H5_KEYS = {
+    "/FQ_recall_LoD",
+    "/FQ_recall_LoD_mixed_start",
+    "/keys_to_convert",
+    "/logit_histogram",
+    "/logit_histogram_mixed_start",
+    "/mean_abs_SHAP_scores",
+    "/ppmseq_category_quality_table",
+    "/ppmseq_category_quality_table_mixed_start",
+    "/ppmseq_category_quantity_table",
+    "/quality_histogram",
+    "/quality_histogram_mixed_start",
+    "/roc_auc_table",
+    "/roc_auc_table_mixed_start",
+    "/run_info_table",
+    "/run_info_table_mixed_start",
+    "/run_quality_summary_table",
+    "/run_quality_summary_table_mixed_start",
+    "/run_quality_table",
+    "/run_quality_table_display",
+    "/run_quality_table_mixed_start",
+    "/training_info_table",
+    "/training_progress",
+    "/trinuc_stats",
+}
+
+
+def test_mixed_report_h5_key_surface_is_stable(resources_dir):
+    """Full ppmSeq report via prepare_report writes exactly the historical mixed h5 key set.
+
+    Locks the byte-identical contract at the key level (mixed keeps the base + *_mixed_start dual
+    keys; consensus/none use their own suffixes, tested separately)."""
+    featuremap_df = str(resources_dir / "402572-CL10377.featuremap_df.parquet")
+    srsnv_metadata = str(resources_dir / "402572-CL10377.srsnv_metadata.json")
+    with tempfile.TemporaryDirectory() as td:
+        # prepare_report resolves model paths relative to CWD basename fallback; copy models in.
+        for mf in resources_dir.glob("402572-CL10377.model_fold_*.json"):
+            shutil.copy(mf, td)
+        cwd = os.getcwd()
+        os.chdir(td)
+        try:
+            prepare_report(
+                featuremap_df=featuremap_df,
+                srsnv_metadata=srsnv_metadata,
+                report_path=td,
+                basename="bl",
+                random_seed=0,
+            )
+        finally:
+            os.chdir(cwd)
+        h5 = next(Path(td).glob("*single_read_snv.applicationQC.h5"))
+        with pd.HDFStore(str(h5), "r") as store:
+            keys = set(store.keys())
+        assert keys == MIXED_EXPECTED_H5_KEYS, (
+            f"mixed h5 key surface drifted:\n  missing={MIXED_EXPECTED_H5_KEYS - keys}\n"
+            f"  unexpected={keys - MIXED_EXPECTED_H5_KEYS}"
+        )

--- a/src/srsnv/tests/unit/test_srsnv_report.py
+++ b/src/srsnv/tests/unit/test_srsnv_report.py
@@ -22,6 +22,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import xgboost as xgb
+from ugbio_srsnv.split_scheme import MIXED_SCHEME
 from ugbio_srsnv.srsnv_report import (
     _build_params,
     _fallback_dummy_models,
@@ -34,7 +35,7 @@ from ugbio_srsnv.srsnv_report import (
     compute_is_cycle_skip_column,
     prepare_report,
 )
-from ugbio_srsnv.srsnv_utils import ReportMode
+from ugbio_srsnv.srsnv_utils import ReportMode  # noqa: F401  (kept for other tests)
 
 # ──────────────────────── _ModelWithTrainingResults ──────────────────────
 
@@ -496,10 +497,10 @@ class TestPrepareReport:
         with (
             patch("ugbio_srsnv.srsnv_report.SRSNVReport") as mock_report_cls,
             patch("ugbio_srsnv.srsnv_report.create_srsnv_report_html") as mock_html,
-            patch("ugbio_srsnv.srsnv_report.resolve_and_add_split_columns") as mock_mixed,
+            patch("ugbio_srsnv.srsnv_report.resolve_scheme_and_add_columns") as mock_mixed,
         ):
-            # Mock add_is_mixed to return the same df
-            mock_mixed.side_effect = lambda df, *args, **kwargs: (df, ReportMode.MIXED)
+            # Mock split-column resolution to return the same df + the mixed scheme
+            mock_mixed.side_effect = lambda df, *args, **kwargs: (df, MIXED_SCHEME)
             # Mock the report class
             mock_report_instance = MagicMock()
             mock_report_cls.return_value = mock_report_instance
@@ -569,9 +570,9 @@ class TestPrepareReport:
         with (
             patch("ugbio_srsnv.srsnv_report.SRSNVReport") as mock_report_cls,
             patch("ugbio_srsnv.srsnv_report.create_srsnv_report_html"),
-            patch("ugbio_srsnv.srsnv_report.resolve_and_add_split_columns") as mock_mixed,
+            patch("ugbio_srsnv.srsnv_report.resolve_scheme_and_add_columns") as mock_mixed,
         ):
-            mock_mixed.side_effect = lambda df, *args, **kwargs: (df, ReportMode.MIXED)
+            mock_mixed.side_effect = lambda df, *args, **kwargs: (df, MIXED_SCHEME)
             mock_report_instance = MagicMock()
             mock_report_cls.return_value = mock_report_instance
 
@@ -622,9 +623,9 @@ class TestPrepareReport:
         with (
             patch("ugbio_srsnv.srsnv_report.SRSNVReport") as mock_report_cls,
             patch("ugbio_srsnv.srsnv_report.create_srsnv_report_html"),
-            patch("ugbio_srsnv.srsnv_report.resolve_and_add_split_columns") as mock_mixed,
+            patch("ugbio_srsnv.srsnv_report.resolve_scheme_and_add_columns") as mock_mixed,
         ):
-            mock_mixed.side_effect = lambda df, *args, **kwargs: (df, ReportMode.MIXED)
+            mock_mixed.side_effect = lambda df, *args, **kwargs: (df, MIXED_SCHEME)
             mock_report_cls.return_value = MagicMock()
 
             # Test basename without trailing dot gets dot added

--- a/src/srsnv/tests/unit/test_srsnv_report.py
+++ b/src/srsnv/tests/unit/test_srsnv_report.py
@@ -34,6 +34,7 @@ from ugbio_srsnv.srsnv_report import (
     compute_is_cycle_skip_column,
     prepare_report,
 )
+from ugbio_srsnv.srsnv_utils import ReportMode
 
 # ──────────────────────── _ModelWithTrainingResults ──────────────────────
 
@@ -495,10 +496,10 @@ class TestPrepareReport:
         with (
             patch("ugbio_srsnv.srsnv_report.SRSNVReport") as mock_report_cls,
             patch("ugbio_srsnv.srsnv_report.create_srsnv_report_html") as mock_html,
-            patch("ugbio_srsnv.srsnv_report.add_is_mixed_to_featuremap_df") as mock_mixed,
+            patch("ugbio_srsnv.srsnv_report.resolve_and_add_split_columns") as mock_mixed,
         ):
             # Mock add_is_mixed to return the same df
-            mock_mixed.side_effect = lambda df, *args, **kwargs: df
+            mock_mixed.side_effect = lambda df, *args, **kwargs: (df, ReportMode.MIXED)
             # Mock the report class
             mock_report_instance = MagicMock()
             mock_report_cls.return_value = mock_report_instance
@@ -568,9 +569,9 @@ class TestPrepareReport:
         with (
             patch("ugbio_srsnv.srsnv_report.SRSNVReport") as mock_report_cls,
             patch("ugbio_srsnv.srsnv_report.create_srsnv_report_html"),
-            patch("ugbio_srsnv.srsnv_report.add_is_mixed_to_featuremap_df") as mock_mixed,
+            patch("ugbio_srsnv.srsnv_report.resolve_and_add_split_columns") as mock_mixed,
         ):
-            mock_mixed.side_effect = lambda df, *args, **kwargs: df
+            mock_mixed.side_effect = lambda df, *args, **kwargs: (df, ReportMode.MIXED)
             mock_report_instance = MagicMock()
             mock_report_cls.return_value = mock_report_instance
 
@@ -621,9 +622,9 @@ class TestPrepareReport:
         with (
             patch("ugbio_srsnv.srsnv_report.SRSNVReport") as mock_report_cls,
             patch("ugbio_srsnv.srsnv_report.create_srsnv_report_html"),
-            patch("ugbio_srsnv.srsnv_report.add_is_mixed_to_featuremap_df") as mock_mixed,
+            patch("ugbio_srsnv.srsnv_report.resolve_and_add_split_columns") as mock_mixed,
         ):
-            mock_mixed.side_effect = lambda df, *args, **kwargs: df
+            mock_mixed.side_effect = lambda df, *args, **kwargs: (df, ReportMode.MIXED)
             mock_report_cls.return_value = MagicMock()
 
             # Test basename without trailing dot gets dot added

--- a/src/srsnv/tests/unit/test_srsnv_utils_unit.py
+++ b/src/srsnv/tests/unit/test_srsnv_utils_unit.py
@@ -870,6 +870,24 @@ class TestConstructTrinucContextWithAlt:
         result = construct_trinuc_context_with_alt(frame)
         assert list(result) == ["ACGT", "TGCA"]
 
+    def test_keeps_alt_when_alt_differs_from_ref(self):
+        """Regression: when ALT already differs from REF, keep ALT even if X_ALT is a valid base.
+
+        Some report parquets carry the substitution in ALT (REF != ALT) and set X_ALT to the REF
+        base. Overriding with X_ALT there would wrongly produce a REF==alt context (maps to NaN).
+        """
+        frame = pd.DataFrame(
+            {
+                "X_PREV1": ["A", "T"],
+                "REF": ["C", "G"],
+                "X_NEXT1": ["G", "C"],
+                "ALT": ["T", "A"],  # real substitution already in ALT
+                "X_ALT": ["C", "G"],  # X_ALT == REF (must be ignored)
+            }
+        )
+        result = construct_trinuc_context_with_alt(frame)
+        assert list(result) == ["ACGT", "TGCA"]
+
 
 # ──────────────────────── get_trinuc_context_with_alt_fwd_vectorized ────
 

--- a/src/srsnv/tests/unit/test_srsnv_utils_unit.py
+++ b/src/srsnv/tests/unit/test_srsnv_utils_unit.py
@@ -28,11 +28,28 @@ import pandas as pd
 import polars as pl
 import pytest
 from ugbio_srsnv.srsnv_utils import (
+    CONSENSUS_GROUP_DUPLEX,
+    CONSENSUS_GROUP_ONE_STRAND,
+    CONSENSUS_GROUP_SINGLE,
+    CONSENSUS_GROUPS,
+    FS,
+    IS_CONSENSUS,
+    IS_MIXED,
+    IS_MIXED_START,
+    MIXED_GROUP_NON,
+    MIXED_GROUP_POS,
+    NONE_GROUP_ALL,
+    READ_GROUP,
+    RS,
+    ReportMode,
     _aggregate_probabilities_from_folds,
     _compute_snvq_prefactor,
     _find_filter_rows,
     _probability_rescaling,
+    add_is_consensus_to_featuremap_df,
+    add_read_group_column,
     construct_trinuc_context_with_alt,
+    detect_report_mode,
     get_base_error_rate_from_filters,
     get_base_recall_from_filters,
     get_filter_ratio,
@@ -48,6 +65,7 @@ from ugbio_srsnv.srsnv_utils import (
     prob_to_phred,
     recalibrate_snvq,
     recalibrate_snvq_kde,
+    resolve_and_add_split_columns,
     safe_roc_auc,
     seq2key,
     set_featuremap_df_dtypes,
@@ -824,6 +842,34 @@ class TestConstructTrinucContextWithAlt:
         result = construct_trinuc_context_with_alt(frame)
         assert list(result) == ["ACGT", "TGCA"]
 
+    def test_prefers_x_alt_when_valid(self):
+        """When X_ALT holds a valid base (DNN convention: ALT == REF for TP), it is used as alt."""
+        frame = pd.DataFrame(
+            {
+                "X_PREV1": ["A", "T"],
+                "REF": ["C", "G"],
+                "X_NEXT1": ["G", "C"],
+                "ALT": ["C", "G"],  # ALT == REF (TP reads, no variant in ALT)
+                "X_ALT": ["T", "A"],  # real substituted base
+            }
+        )
+        result = construct_trinuc_context_with_alt(frame)
+        assert list(result) == ["ACGT", "TGCA"]
+
+    def test_falls_back_to_alt_when_x_alt_invalid(self):
+        """When X_ALT is not a valid base (e.g. NaN for FP reads), ALT is used."""
+        frame = pd.DataFrame(
+            {
+                "X_PREV1": ["A", "T"],
+                "REF": ["C", "G"],
+                "X_NEXT1": ["G", "C"],
+                "ALT": ["T", "A"],  # real substitution in ALT (FP reads)
+                "X_ALT": ["nan", ""],  # invalid -> fall back to ALT
+            }
+        )
+        result = construct_trinuc_context_with_alt(frame)
+        assert list(result) == ["ACGT", "TGCA"]
+
 
 # ──────────────────────── get_trinuc_context_with_alt_fwd_vectorized ────
 
@@ -1531,3 +1577,130 @@ class TestSafeRocAucAdditional:
         y_pred = [0.1, 0.4, 0.6, 0.9, 0.3, 0.7]
         result = safe_roc_auc(y_true, y_pred)
         assert 0.5 < result <= 1.0
+
+
+# ──────────────────────── report mode detection / split columns ──────────────────────
+
+
+class TestDetectReportMode:
+    """Test automatic report-mode detection from featuremap columns."""
+
+    def test_mixed_from_st_et(self):
+        """st/et present -> MIXED mode."""
+        data_df = pd.DataFrame({"st": ["MIXED", "PLUS"], "et": ["MIXED", "MINUS"]})
+        assert detect_report_mode(data_df) is ReportMode.MIXED
+
+    def test_mixed_from_v5_tags(self):
+        """as/ae/ts/te present (no st/et) -> MIXED mode."""
+        data_df = pd.DataFrame({"as": [1, 2], "ae": [1, 0], "ts": [0, 1], "te": [1, 1]})
+        assert detect_report_mode(data_df) is ReportMode.MIXED
+
+    def test_consensus_from_fs_rs(self):
+        """fs/rs present (no ppmSeq tags) -> CONSENSUS mode."""
+        data_df = pd.DataFrame({FS: [0, 1, 2], RS: [1, 1, 0]})
+        assert detect_report_mode(data_df) is ReportMode.CONSENSUS
+
+    def test_none_when_no_split_columns(self):
+        """Neither ppmSeq tags nor fs/rs -> NONE mode."""
+        data_df = pd.DataFrame({"MQUAL": [10.0, 20.0], "label": [True, False]})
+        assert detect_report_mode(data_df) is ReportMode.NONE
+
+    def test_ppmseq_tags_take_priority_over_fs_rs(self):
+        """If both st/et and fs/rs are present, ppmSeq tags win (MIXED)."""
+        data_df = pd.DataFrame(
+            {
+                "st": ["MIXED", "PLUS"],
+                "et": ["MIXED", "MINUS"],
+                FS: [1, 2],
+                RS: [1, 0],
+            }
+        )
+        assert detect_report_mode(data_df) is ReportMode.MIXED
+
+
+class TestAddIsConsensus:
+    """Test the fs>=1 & rs>=1 consensus derivation."""
+
+    def test_is_consensus_definition(self):
+        """A read is consensus iff it has >=1 forward and >=1 reverse read."""
+        data_df = pd.DataFrame({FS: [0, 1, 2, 0, 5], RS: [1, 1, 0, 0, 3]})
+        out = add_is_consensus_to_featuremap_df(data_df)
+        assert out[IS_CONSENSUS].tolist() == [False, True, False, False, True]
+        assert out[IS_CONSENSUS].dtype == bool
+
+
+class TestResolveAndAddSplitColumns:
+    """Test the mode-resolving split-column entry point used by the report."""
+
+    def test_consensus_adds_is_consensus(self):
+        data_df = pd.DataFrame({FS: [0, 1, 2, 3], RS: [1, 1, 0, 2]})
+        out, mode = resolve_and_add_split_columns(data_df)
+        assert mode is ReportMode.CONSENSUS
+        expected = ((data_df[FS] >= 1) & (data_df[RS] >= 1)).tolist()
+        assert out[IS_CONSENSUS].tolist() == expected
+
+    def test_none_sets_is_consensus_all_false(self):
+        data_df = pd.DataFrame({"MQUAL": [1.0, 2.0, 3.0]})
+        out, mode = resolve_and_add_split_columns(data_df)
+        assert mode is ReportMode.NONE
+        assert out[IS_CONSENSUS].tolist() == [False, False, False]
+
+    def test_mixed_adds_is_mixed_columns(self):
+        """MIXED mode delegates to add_is_mixed_to_featuremap_df, adding is_mixed columns."""
+        data_df = pd.DataFrame(
+            {
+                "st": ["MIXED", "MIXED", "PLUS", "MINUS"],
+                "et": ["MIXED", "PLUS", "PLUS", "MINUS"],
+            }
+        )
+        out, mode = resolve_and_add_split_columns(data_df, adapter_version="v1")
+        assert mode is ReportMode.MIXED
+        assert IS_MIXED in out.columns
+
+
+# ──────────────────────── read_group (N-group split) ──────────────────────
+
+
+class TestAddReadGroupColumn:
+    """Test the ordered read_group column for the N-group split."""
+
+    def test_consensus_three_groups_exhaustive_exclusive(self):
+        # fs+rs: (0,0)->single, (0,1)/(1,0)->single, one-strand (>=2, one side 0), duplex
+        data_df = pd.DataFrame(
+            {
+                FS: [0, 0, 1, 2, 0, 5, 3],
+                RS: [0, 1, 0, 0, 3, 3, 1],
+            }
+        )
+        out = add_read_group_column(data_df, ReportMode.CONSENSUS)
+        rg = out[READ_GROUP]
+        assert list(rg.cat.categories) == CONSENSUS_GROUPS
+        assert rg.cat.ordered
+        expected = [
+            CONSENSUS_GROUP_SINGLE,  # 0,0
+            CONSENSUS_GROUP_SINGLE,  # 0,1
+            CONSENSUS_GROUP_SINGLE,  # 1,0
+            CONSENSUS_GROUP_ONE_STRAND,  # 2,0
+            CONSENSUS_GROUP_ONE_STRAND,  # 0,3
+            CONSENSUS_GROUP_DUPLEX,  # 5,3
+            CONSENSUS_GROUP_DUPLEX,  # 3,1
+        ]
+        assert list(rg.astype(str)) == expected
+        # exhaustive: no NaN
+        assert not rg.isna().any()
+
+    def test_consensus_single_folds_in_zero_zero(self):
+        data_df = pd.DataFrame({FS: [0], RS: [0]})
+        out = add_read_group_column(data_df, ReportMode.CONSENSUS)
+        assert out[READ_GROUP].astype(str).iloc[0] == CONSENSUS_GROUP_SINGLE
+
+    def test_mixed_two_groups(self):
+        data_df = pd.DataFrame({IS_MIXED_START: [True, False, True]})
+        out = add_read_group_column(data_df, ReportMode.MIXED)
+        assert list(out[READ_GROUP].cat.categories) == [MIXED_GROUP_NON, MIXED_GROUP_POS]
+        assert list(out[READ_GROUP].astype(str)) == [MIXED_GROUP_POS, MIXED_GROUP_NON, MIXED_GROUP_POS]
+
+    def test_none_single_group(self):
+        data_df = pd.DataFrame({"MQUAL": [1.0, 2.0]})
+        out = add_read_group_column(data_df, ReportMode.NONE)
+        assert list(out[READ_GROUP].astype(str)) == [NONE_GROUP_ALL, NONE_GROUP_ALL]

--- a/src/srsnv/tests/unit/test_srsnv_utils_unit.py
+++ b/src/srsnv/tests/unit/test_srsnv_utils_unit.py
@@ -842,47 +842,15 @@ class TestConstructTrinucContextWithAlt:
         result = construct_trinuc_context_with_alt(frame)
         assert list(result) == ["ACGT", "TGCA"]
 
-    def test_prefers_x_alt_when_valid(self):
-        """When X_ALT holds a valid base (DNN convention: ALT == REF for TP), it is used as alt."""
+    def test_ignores_x_alt_column(self):
+        """The report featuremap's ALT already holds the substitution; an X_ALT column is ignored."""
         frame = pd.DataFrame(
             {
                 "X_PREV1": ["A", "T"],
                 "REF": ["C", "G"],
                 "X_NEXT1": ["G", "C"],
-                "ALT": ["C", "G"],  # ALT == REF (TP reads, no variant in ALT)
-                "X_ALT": ["T", "A"],  # real substituted base
-            }
-        )
-        result = construct_trinuc_context_with_alt(frame)
-        assert list(result) == ["ACGT", "TGCA"]
-
-    def test_falls_back_to_alt_when_x_alt_invalid(self):
-        """When X_ALT is not a valid base (e.g. NaN for FP reads), ALT is used."""
-        frame = pd.DataFrame(
-            {
-                "X_PREV1": ["A", "T"],
-                "REF": ["C", "G"],
-                "X_NEXT1": ["G", "C"],
-                "ALT": ["T", "A"],  # real substitution in ALT (FP reads)
-                "X_ALT": ["nan", ""],  # invalid -> fall back to ALT
-            }
-        )
-        result = construct_trinuc_context_with_alt(frame)
-        assert list(result) == ["ACGT", "TGCA"]
-
-    def test_keeps_alt_when_alt_differs_from_ref(self):
-        """Regression: when ALT already differs from REF, keep ALT even if X_ALT is a valid base.
-
-        Some report parquets carry the substitution in ALT (REF != ALT) and set X_ALT to the REF
-        base. Overriding with X_ALT there would wrongly produce a REF==alt context (maps to NaN).
-        """
-        frame = pd.DataFrame(
-            {
-                "X_PREV1": ["A", "T"],
-                "REF": ["C", "G"],
-                "X_NEXT1": ["G", "C"],
-                "ALT": ["T", "A"],  # real substitution already in ALT
-                "X_ALT": ["C", "G"],  # X_ALT == REF (must be ignored)
+                "ALT": ["T", "A"],  # substitution in ALT (report convention)
+                "X_ALT": ["C", "G"],  # X_ALT == REF; must not affect the result
             }
         )
         result = construct_trinuc_context_with_alt(frame)

--- a/src/srsnv/tests/unit/test_srsnv_utils_unit.py
+++ b/src/srsnv/tests/unit/test_srsnv_utils_unit.py
@@ -32,15 +32,15 @@ from ugbio_srsnv.srsnv_utils import (
     CONSENSUS_GROUP_ONE_STRAND,
     CONSENSUS_GROUP_SINGLE,
     CONSENSUS_GROUPS,
-    FS,
     IS_CONSENSUS,
     IS_MIXED,
     IS_MIXED_START,
     MIXED_GROUP_NON,
     MIXED_GROUP_POS,
+    NF,
     NONE_GROUP_ALL,
+    NR,
     READ_GROUP,
-    RS,
     ReportMode,
     _aggregate_probabilities_from_folds,
     _compute_snvq_prefactor,
@@ -1581,35 +1581,35 @@ class TestDetectReportMode:
         data_df = pd.DataFrame({"as": [1, 2], "ae": [1, 0], "ts": [0, 1], "te": [1, 1]})
         assert detect_report_mode(data_df) is ReportMode.MIXED
 
-    def test_consensus_from_fs_rs(self):
-        """fs/rs present (no ppmSeq tags) -> CONSENSUS mode."""
-        data_df = pd.DataFrame({FS: [0, 1, 2], RS: [1, 1, 0]})
+    def test_consensus_from_nf_nr(self):
+        """nf/nr present (no ppmSeq tags) -> CONSENSUS mode."""
+        data_df = pd.DataFrame({NF: [0, 1, 2], NR: [1, 1, 0]})
         assert detect_report_mode(data_df) is ReportMode.CONSENSUS
 
     def test_none_when_no_split_columns(self):
-        """Neither ppmSeq tags nor fs/rs -> NONE mode."""
+        """Neither ppmSeq tags nor nf/nr -> NONE mode."""
         data_df = pd.DataFrame({"MQUAL": [10.0, 20.0], "label": [True, False]})
         assert detect_report_mode(data_df) is ReportMode.NONE
 
-    def test_ppmseq_tags_take_priority_over_fs_rs(self):
-        """If both st/et and fs/rs are present, ppmSeq tags win (MIXED)."""
+    def test_ppmseq_tags_take_priority_over_nf_nr(self):
+        """If both st/et and nf/nr are present, ppmSeq tags win (MIXED)."""
         data_df = pd.DataFrame(
             {
                 "st": ["MIXED", "PLUS"],
                 "et": ["MIXED", "MINUS"],
-                FS: [1, 2],
-                RS: [1, 0],
+                NF: [1, 2],
+                NR: [1, 0],
             }
         )
         assert detect_report_mode(data_df) is ReportMode.MIXED
 
 
 class TestAddIsConsensus:
-    """Test the fs>=1 & rs>=1 consensus derivation."""
+    """Test the nf>=1 & nr>=1 consensus derivation."""
 
     def test_is_consensus_definition(self):
         """A read is consensus iff it has >=1 forward and >=1 reverse read."""
-        data_df = pd.DataFrame({FS: [0, 1, 2, 0, 5], RS: [1, 1, 0, 0, 3]})
+        data_df = pd.DataFrame({NF: [0, 1, 2, 0, 5], NR: [1, 1, 0, 0, 3]})
         out = add_is_consensus_to_featuremap_df(data_df)
         assert out[IS_CONSENSUS].tolist() == [False, True, False, False, True]
         assert out[IS_CONSENSUS].dtype == bool
@@ -1619,10 +1619,10 @@ class TestResolveAndAddSplitColumns:
     """Test the mode-resolving split-column entry point used by the report."""
 
     def test_consensus_adds_is_consensus(self):
-        data_df = pd.DataFrame({FS: [0, 1, 2, 3], RS: [1, 1, 0, 2]})
+        data_df = pd.DataFrame({NF: [0, 1, 2, 3], NR: [1, 1, 0, 2]})
         out, mode = resolve_and_add_split_columns(data_df)
         assert mode is ReportMode.CONSENSUS
-        expected = ((data_df[FS] >= 1) & (data_df[RS] >= 1)).tolist()
+        expected = ((data_df[NF] >= 1) & (data_df[NR] >= 1)).tolist()
         assert out[IS_CONSENSUS].tolist() == expected
 
     def test_none_sets_is_consensus_all_false(self):
@@ -1651,11 +1651,11 @@ class TestAddReadGroupColumn:
     """Test the ordered read_group column for the N-group split."""
 
     def test_consensus_three_groups_exhaustive_exclusive(self):
-        # fs+rs: (0,0)->single, (0,1)/(1,0)->single, one-strand (>=2, one side 0), duplex
+        # nf+nr: (0,0)->single, (0,1)/(1,0)->single, one-strand (>=2, one side 0), duplex
         data_df = pd.DataFrame(
             {
-                FS: [0, 0, 1, 2, 0, 5, 3],
-                RS: [0, 1, 0, 0, 3, 3, 1],
+                NF: [0, 0, 1, 2, 0, 5, 3],
+                NR: [0, 1, 0, 0, 3, 3, 1],
             }
         )
         out = add_read_group_column(data_df, ReportMode.CONSENSUS)
@@ -1676,7 +1676,7 @@ class TestAddReadGroupColumn:
         assert not rg.isna().any()
 
     def test_consensus_single_folds_in_zero_zero(self):
-        data_df = pd.DataFrame({FS: [0], RS: [0]})
+        data_df = pd.DataFrame({NF: [0], NR: [0]})
         out = add_read_group_column(data_df, ReportMode.CONSENSUS)
         assert out[READ_GROUP].astype(str).iloc[0] == CONSENSUS_GROUP_SINGLE
 

--- a/src/srsnv/tests/unit/test_trinuc_histogram_plotting.py
+++ b/src/srsnv/tests/unit/test_trinuc_histogram_plotting.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from ugbio_srsnv.trinuc_histogram_plotting import (
+    _resolve_qual_group_specs,
     calc_and_plot_trinuc_hist,
     calc_trinuc_stats,
     plot_trinuc_hist,
@@ -333,3 +334,72 @@ class TestTrinucHistogramPlotting:
 
         # Clean up
         fig.clear()
+
+
+class TestTrinucNGroupSplit:
+    """Test the N-group (consensus) split of the trinuc quality panel."""
+
+    @pytest.fixture
+    def consensus_sample(self):
+        rng = np.random.default_rng(1)
+        contexts = ["AAAC", "AAAG", "AAAT", "AACG", "ACAC", "ACAG", "AGAT", "ATAC"] * 100
+        n = len(contexts)
+        return pd.DataFrame(
+            {
+                "tcwa_fwd": contexts,
+                "label": rng.choice([False, True], n, p=[0.5, 0.5]),
+                "is_forward": rng.choice([True, False], n),
+                "SNVQ": rng.normal(40, 10, n).clip(5, 70),
+                "is_cycle_skip": rng.choice([True, False], n),
+                "read_group": pd.Categorical(
+                    rng.choice(["single read", "consensus, one strand", "consensus, duplex"], n),
+                    categories=["single read", "consensus, one strand", "consensus, duplex"],
+                    ordered=True,
+                ),
+            }
+        )
+
+    def test_calc_trinuc_stats_read_group_columns(self, consensus_sample):
+        """calc_trinuc_stats splits quality by read_group when is_mixed_col=read_group."""
+        stats_df = calc_trinuc_stats(
+            consensus_sample,
+            labels=[True],
+            is_mixed_col="read_group",
+            include_quality=True,
+            collapsed=True,
+            motif_orientation="ref_dir",
+        )
+        for grp in ("single read", "consensus, one strand", "consensus, duplex"):
+            assert f"mixed={grp} median_qual" in stats_df.columns
+
+    def test_resolve_qual_group_specs_ngroup_order(self, consensus_sample):
+        """_resolve_qual_group_specs returns the given ordered specs (3 groups)."""
+        stats_df = calc_trinuc_stats(
+            consensus_sample,
+            labels=[True],
+            is_mixed_col="read_group",
+            include_quality=True,
+            collapsed=True,
+            motif_orientation="ref_dir",
+        )
+        groups = ["single read", "consensus, one strand", "consensus, duplex"]
+        specs = [(f"mixed={g}", g, "r") for g in groups]
+        resolved = _resolve_qual_group_specs(stats_df, specs)
+        assert [label for _, label, _ in resolved] == groups
+
+    def test_mixed_auto_detection_unchanged(self, consensus_sample):
+        """Without group_specs, ppmSeq auto-detection yields the historical Mixed/Non-mixed labels."""
+        mixed_df = consensus_sample.copy()
+        rng = np.random.default_rng(3)
+        mixed_df["is_mixed"] = rng.choice([True, False], len(mixed_df))
+        stats_df = calc_trinuc_stats(
+            mixed_df,
+            labels=[True],
+            is_mixed_col="is_mixed",
+            include_quality=True,
+            collapsed=True,
+            motif_orientation="ref_dir",
+        )
+        resolved = _resolve_qual_group_specs(stats_df)
+        labels = [label for _, label, _ in resolved]
+        assert labels == ["Mixed reads", "Non-mixed reads"]

--- a/src/srsnv/ugbio_srsnv/reports/srsnv_report.ipynb
+++ b/src/srsnv/ugbio_srsnv/reports/srsnv_report.ipynb
@@ -66,22 +66,7 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "# papermill parameters\n",
-    "srsnv_metadata_file = None\n",
-    "srsnv_qc_h5_file = None\n",
-    "FQ_vs_recall_plot = None  # noqa: N816\n",
-    "qual_vs_ppmseq_tags_table = None\n",
-    "training_progress_plot = None\n",
-    "SHAP_importance_plot = None\n",
-    "SHAP_beeswarm_plot = None\n",
-    "trinuc_stats_plot = None\n",
-    "output_qual_per_feature = None\n",
-    "qual_histogram = None\n",
-    "logit_histogram = None\n",
-    "calibration_fn_with_hist = None\n",
-    "split_mode = \"mixed\"  # \"mixed\" (ppmSeq) or \"consensus\"; set by prepare_report"
-   ]
+   "source": "# papermill parameters\nsrsnv_metadata_file = None\nsrsnv_qc_h5_file = None\nFQ_vs_recall_plot = None  # noqa: N816\nqual_vs_ppmseq_tags_table = None\ntraining_progress_plot = None\nSHAP_importance_plot = None\nSHAP_beeswarm_plot = None\ntrinuc_stats_plot = None\noutput_qual_per_feature = None\nqual_histogram = None\nlogit_histogram = None\ncalibration_fn_with_hist = None\nsplit_mode = \"mixed\"  # \"mixed\" (ppmSeq) or \"consensus\"; set by prepare_report\ndisplay_suffix = \"mixed_start\"  # h5-key suffix of the active scheme's display variant; set by prepare_report"
   },
   {
    "cell_type": "code",
@@ -121,15 +106,7 @@
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Mode-aware display labels for the read split (ppmSeq \"mixed\" vs \"consensus\")\n",
-    "_SPLIT_LABELS = {\n",
-    "    \"mixed\": {\"pos\": \"mixed\", \"tag\": \"ppmSeq tag\", \"pos_title\": \"Mixed\"},\n",
-    "    \"consensus\": {\"pos\": \"consensus\", \"tag\": \"strand support\", \"pos_title\": \"Consensus\"},\n",
-    "    \"none\": {\"pos\": \"mixed\", \"tag\": \"ppmSeq tag\", \"pos_title\": \"Mixed\"},\n",
-    "}\n",
-    "_labels = _SPLIT_LABELS.get(split_mode, _SPLIT_LABELS[\"mixed\"])"
-   ]
+   "source": "# Mode-aware display labels for the read split (ppmSeq \"mixed\" vs \"consensus\")\n_SPLIT_LABELS = {\n    \"mixed\": {\"pos\": \"mixed\", \"tag\": \"ppmSeq tag\", \"pos_title\": \"Mixed\"},\n    \"consensus\": {\"pos\": \"consensus\", \"tag\": \"strand support\", \"pos_title\": \"Consensus\"},\n    \"none\": {\"pos\": \"mixed\", \"tag\": \"ppmSeq tag\", \"pos_title\": \"Mixed\"},\n}\n_labels = _SPLIT_LABELS.get(split_mode, _SPLIT_LABELS[\"mixed\"])\n\n\ndef _k(base):\n    \"\"\"Compose the h5 key for the active scheme's display variant: base + \"_\" + display_suffix.\n\n    Mirrors ugbio_srsnv.split_scheme.h5_key. For ppmSeq (display_suffix=\"mixed_start\") this yields\n    the historical keys (e.g. \"run_info_table_mixed_start\"); other schemes use their own suffix.\n    \"\"\"\n    return f\"{base}_{display_suffix}\" if display_suffix else base"
   },
   {
    "cell_type": "code",
@@ -382,16 +359,7 @@
    "id": "ac116334",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "ipy_display(HTML('<font size=\"5\">Run Info </font>'))\n",
-    "run_info_table = pd.read_hdf(srsnv_qc_h5_file, key=\"run_info_table_mixed_start\")\n",
-    "try:\n",
-    "    if isinstance(run_info_table.loc[(\"Docker image\", \"\")], str):\n",
-    "        run_info_table.loc[(\"Docker image\", \"\")] = \"/<br>\".join(run_info_table.loc[(\"Docker image\", \"\")].split(\"/\"))\n",
-    "except KeyError:\n",
-    "    pass\n",
-    "ipy_display(HTML(run_info_table.to_frame().to_html(escape=False)))"
-   ]
+   "source": "ipy_display(HTML('<font size=\"5\">Run Info </font>'))\nrun_info_table = pd.read_hdf(srsnv_qc_h5_file, key=_k(\"run_info_table\"))\ntry:\n    if isinstance(run_info_table.loc[(\"Docker image\", \"\")], str):\n        run_info_table.loc[(\"Docker image\", \"\")] = \"/<br>\".join(run_info_table.loc[(\"Docker image\", \"\")].split(\"/\"))\nexcept KeyError:\n    pass\nipy_display(HTML(run_info_table.to_frame().to_html(escape=False)))"
   },
   {
    "cell_type": "markdown",
@@ -419,20 +387,7 @@
    "id": "4672c348",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "run_quality_summary_table = pd.read_hdf(srsnv_qc_h5_file, key=\"run_quality_summary_table_mixed_start\")\n",
-    "run_quality_summary_table = run_quality_summary_table.unstack(sort=False).T  # noqa: PD010\n",
-    "cols_to_rename = []\n",
-    "for col in run_quality_summary_table.columns:\n",
-    "    if \"Recall\" in col:  # Transform recall columns to %\n",
-    "        cols_to_rename.append(col)\n",
-    "        run_quality_summary_table[col] = run_quality_summary_table[col] * 100\n",
-    "    run_quality_summary_table[col] = run_quality_summary_table[col].apply(signif, args=(4,)).astype(str)\n",
-    "run_quality_summary_table = run_quality_summary_table.rename(\n",
-    "    columns={col: col + \" (%)\" for col in cols_to_rename}\n",
-    ")  # Add % to recall column names\n",
-    "run_quality_summary_table"
-   ]
+   "source": "run_quality_summary_table = pd.read_hdf(srsnv_qc_h5_file, key=_k(\"run_quality_summary_table\"))\nrun_quality_summary_table = run_quality_summary_table.unstack(sort=False).T  # noqa: PD010\ncols_to_rename = []\nfor col in run_quality_summary_table.columns:\n    if \"Recall\" in col:  # Transform recall columns to %\n        cols_to_rename.append(col)\n        run_quality_summary_table[col] = run_quality_summary_table[col] * 100\n    run_quality_summary_table[col] = run_quality_summary_table[col].apply(signif, args=(4,)).astype(str)\nrun_quality_summary_table = run_quality_summary_table.rename(\n    columns={col: col + \" (%)\" for col in cols_to_rename}\n)  # Add % to recall column names\nrun_quality_summary_table"
   },
   {
    "cell_type": "code",
@@ -623,10 +578,7 @@
    "id": "87d23efa",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "roc_auc_table = pd.read_hdf(srsnv_qc_h5_file, key=\"roc_auc_table_mixed_start\").T\n",
-    "roc_auc_table"
-   ]
+   "source": "roc_auc_table = pd.read_hdf(srsnv_qc_h5_file, key=_k(\"roc_auc_table\")).T\nroc_auc_table"
   },
   {
    "cell_type": "markdown",

--- a/src/srsnv/ugbio_srsnv/reports/srsnv_report.ipynb
+++ b/src/srsnv/ugbio_srsnv/reports/srsnv_report.ipynb
@@ -435,7 +435,7 @@
    "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
    "outputs": [],
-   "source": "ipy_display(\n    HTML(\n        \"<h2>SNVQ histogram (TP SNVs)</h2>\"\n        + (\n            f\"In this plot, <b>{_labels['pos']}</b> refers to reads where the start ppmSeq tag is MIXED. \"\n            if split_mode != \"consensus\"\n            else (\n                \"Reads are split by strand support into three groups: \"\n                \"<b>single read</b> (fs + rs &le; 1), \"\n                \"<b>consensus, one strand</b> (&ge; 2 reads, all on one strand), and \"\n                \"<b>consensus, duplex</b> (&ge; 1 forward and &ge; 1 reverse read). \"\n            )\n        )\n    )\n)"
+   "source": "ipy_display(\n    HTML(\n        \"<h2>SNVQ histogram (TP SNVs)</h2>\"\n        + (\n            f\"In this plot, <b>{_labels['pos']}</b> refers to reads where the start ppmSeq tag is MIXED. \"\n            if split_mode != \"consensus\"\n            else (\n                \"Reads are split by strand support into three groups: \"\n                \"<b>single read</b> (nf + nr &le; 1), \"\n                \"<b>consensus, one strand</b> (&ge; 2 reads, all on one strand), and \"\n                \"<b>consensus, duplex</b> (&ge; 1 forward and &ge; 1 reverse read). \"\n            )\n        )\n    )\n)"
   },
   {
    "cell_type": "code",
@@ -883,7 +883,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# ppmSeq tags / strand support glossary section (depends on split_mode)\nif split_mode == \"consensus\":\n    _glossary_split = (\n        \"<h3>Strand support</h3>  \\n\\n\"\n        \"Reads are split into three groups by the number of forward (fs) and reverse (rs) reads:\\n\\n\"\n        \"- **single read** — fs + rs &le; 1.\\n\"\n        \"- **consensus, one strand** — fs + rs &ge; 2, with all reads on a single strand \"\n        \"(exactly one of fs/rs is 0).\\n\"\n        \"- **consensus, duplex** — at least one forward read (fs &ge; 1) and one reverse read \"\n        \"(rs &ge; 1). \\n\\n\"\n    )\nelse:\n    _glossary_split = (\n        \"<h3>ppmSeq tags</h3>  \\n\\n\"\n        \"- **mixed** refers to reads where the start ppmSeq tag is MIXED. \"\n        \"See [SNVQ vs ppmSeq tag](#SNVQ-vs-ppmSeq-tag) for more detailed information \"\n        \"about ppmSeq tags. \\n\\n\"\n    )\nipy_display(HTML(_glossary_split))"
+   "source": "# ppmSeq tags / strand support glossary section (depends on split_mode)\nif split_mode == \"consensus\":\n    _glossary_split = (\n        \"<h3>Strand support</h3>  \\n\\n\"\n        \"Reads are split into three groups by the number of forward (nf) and reverse (nr) reads:\\n\\n\"\n        \"- **single read** — nf + nr &le; 1.\\n\"\n        \"- **consensus, one strand** — nf + nr &ge; 2, with all reads on a single strand \"\n        \"(exactly one of nf/nr is 0).\\n\"\n        \"- **consensus, duplex** — at least one forward read (nf &ge; 1) and one reverse read \"\n        \"(nr &ge; 1). \\n\\n\"\n    )\nelse:\n    _glossary_split = (\n        \"<h3>ppmSeq tags</h3>  \\n\\n\"\n        \"- **mixed** refers to reads where the start ppmSeq tag is MIXED. \"\n        \"See [SNVQ vs ppmSeq tag](#SNVQ-vs-ppmSeq-tag) for more detailed information \"\n        \"about ppmSeq tags. \\n\\n\"\n    )\nipy_display(HTML(_glossary_split))"
   },
   {
    "cell_type": "markdown",

--- a/src/srsnv/ugbio_srsnv/reports/srsnv_report.ipynb
+++ b/src/srsnv/ugbio_srsnv/reports/srsnv_report.ipynb
@@ -79,7 +79,8 @@
     "output_qual_per_feature = None\n",
     "qual_histogram = None\n",
     "logit_histogram = None\n",
-    "calibration_fn_with_hist = None"
+    "calibration_fn_with_hist = None\n",
+    "split_mode = \"mixed\"  # \"mixed\" (ppmSeq) or \"consensus\"; set by prepare_report"
    ]
   },
   {
@@ -112,6 +113,22 @@
     "\n",
     "if len(missing) > 0:\n",
     "    raise ValueError(f\"Following inputs missing:\\n{(os.linesep).join(missing)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mode-aware display labels for the read split (ppmSeq \"mixed\" vs \"consensus\")\n",
+    "_SPLIT_LABELS = {\n",
+    "    \"mixed\": {\"pos\": \"mixed\", \"tag\": \"ppmSeq tag\", \"pos_title\": \"Mixed\"},\n",
+    "    \"consensus\": {\"pos\": \"consensus\", \"tag\": \"strand support\", \"pos_title\": \"Consensus\"},\n",
+    "    \"none\": {\"pos\": \"mixed\", \"tag\": \"ppmSeq tag\", \"pos_title\": \"Mixed\"},\n",
+    "}\n",
+    "_labels = _SPLIT_LABELS.get(split_mode, _SPLIT_LABELS[\"mixed\"])"
    ]
   },
   {
@@ -365,7 +382,16 @@
    "id": "ac116334",
    "metadata": {},
    "outputs": [],
-   "source": "ipy_display(HTML('<font size=\"5\">Run Info </font>'))\nrun_info_table = pd.read_hdf(srsnv_qc_h5_file, key=\"run_info_table_mixed_start\")\ntry:\n    if isinstance(run_info_table.loc[(\"Docker image\", \"\")], str):\n        run_info_table.loc[(\"Docker image\", \"\")] = \"/<br>\".join(run_info_table.loc[(\"Docker image\", \"\")].split(\"/\"))\nexcept KeyError:\n    pass\nipy_display(HTML(run_info_table.to_frame().to_html(escape=False)))"
+   "source": [
+    "ipy_display(HTML('<font size=\"5\">Run Info </font>'))\n",
+    "run_info_table = pd.read_hdf(srsnv_qc_h5_file, key=\"run_info_table_mixed_start\")\n",
+    "try:\n",
+    "    if isinstance(run_info_table.loc[(\"Docker image\", \"\")], str):\n",
+    "        run_info_table.loc[(\"Docker image\", \"\")] = \"/<br>\".join(run_info_table.loc[(\"Docker image\", \"\")].split(\"/\"))\n",
+    "except KeyError:\n",
+    "    pass\n",
+    "ipy_display(HTML(run_info_table.to_frame().to_html(escape=False)))"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -393,7 +419,20 @@
    "id": "4672c348",
    "metadata": {},
    "outputs": [],
-   "source": "run_quality_summary_table = pd.read_hdf(srsnv_qc_h5_file, key=\"run_quality_summary_table_mixed_start\")\nrun_quality_summary_table = run_quality_summary_table.unstack(sort=False).T  # noqa: PD010\ncols_to_rename = []\nfor col in run_quality_summary_table.columns:\n    if \"Recall\" in col:  # Transform recall columns to %\n        cols_to_rename.append(col)\n        run_quality_summary_table[col] = run_quality_summary_table[col] * 100\n    run_quality_summary_table[col] = run_quality_summary_table[col].apply(signif, args=(4,)).astype(str)\nrun_quality_summary_table = run_quality_summary_table.rename(\n    columns={col: col + \" (%)\" for col in cols_to_rename}\n)  # Add % to recall column names\nrun_quality_summary_table"
+   "source": [
+    "run_quality_summary_table = pd.read_hdf(srsnv_qc_h5_file, key=\"run_quality_summary_table_mixed_start\")\n",
+    "run_quality_summary_table = run_quality_summary_table.unstack(sort=False).T  # noqa: PD010\n",
+    "cols_to_rename = []\n",
+    "for col in run_quality_summary_table.columns:\n",
+    "    if \"Recall\" in col:  # Transform recall columns to %\n",
+    "        cols_to_rename.append(col)\n",
+    "        run_quality_summary_table[col] = run_quality_summary_table[col] * 100\n",
+    "    run_quality_summary_table[col] = run_quality_summary_table[col].apply(signif, args=(4,)).astype(str)\n",
+    "run_quality_summary_table = run_quality_summary_table.rename(\n",
+    "    columns={col: col + \" (%)\" for col in cols_to_rename}\n",
+    ")  # Add % to recall column names\n",
+    "run_quality_summary_table"
+   ]
   },
   {
    "cell_type": "code",
@@ -436,10 +475,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "deb2f8e5",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
    "metadata": {},
-   "source": "## SNVQ histogram (TP SNVs)\n\nIn this plot, **mixed** refers to reads where the start ppmSeq tag is MIXED. "
+   "outputs": [],
+   "source": "ipy_display(\n    HTML(\n        \"<h2>SNVQ histogram (TP SNVs)</h2>\"\n        + (\n            f\"In this plot, <b>{_labels['pos']}</b> refers to reads where the start ppmSeq tag is MIXED. \"\n            if split_mode != \"consensus\"\n            else (\n                \"Reads are split by strand support into three groups: \"\n                \"<b>single read</b> (fs + rs &le; 1), \"\n                \"<b>consensus, one strand</b> (&ge; 2 reads, all on one strand), and \"\n                \"<b>consensus, duplex</b> (&ge; 1 forward and &ge; 1 reverse read). \"\n            )\n        )\n    )\n)"
   },
   {
    "cell_type": "code",
@@ -468,16 +509,22 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "457f1a9b",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
    "metadata": {},
-   "source": "### SNVQ vs ppmSeq tag"
+   "outputs": [],
+   "source": [
+    "ipy_display(HTML(f\"<h3>SNVQ vs {_labels['tag']}</h3>\"))"
+   ]
   },
   {
-   "cell_type": "markdown",
-   "id": "75af1951",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
-   "source": "The table below presents median SNVQ values and proportion of reads per start ppmSeq tag category on the TP (homozygous substitutions) training dataset. "
+   "outputs": [],
+   "source": "ipy_display(\n    HTML(\n        \"The table below presents median SNVQ values and proportion of reads \"\n        + (\n            \"per start ppmSeq tag category \"\n            if split_mode != \"consensus\"\n            else f\"per {_labels['tag']} group (single read / consensus, one strand / consensus, duplex) \"\n        )\n        + \"on the TP (homozygous substitutions) training dataset.\"\n    )\n)"
   },
   {
    "cell_type": "code",
@@ -576,7 +623,10 @@
    "id": "87d23efa",
    "metadata": {},
    "outputs": [],
-   "source": "roc_auc_table = pd.read_hdf(srsnv_qc_h5_file, key=\"roc_auc_table_mixed_start\").T\nroc_auc_table"
+   "source": [
+    "roc_auc_table = pd.read_hdf(srsnv_qc_h5_file, key=\"roc_auc_table_mixed_start\").T\n",
+    "roc_auc_table"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -862,9 +912,58 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4946fbee",
    "metadata": {},
-   "source": "# Glossary of terms\n\n- **MQUAL** is the output of the SRSNV model, in phred scale: $$\\mathrm{MQUAL} = -10 \\log_{10}(1-\\hat{p}),$$ where $\\hat{p}$ is the model prediction (estimate of the probability that the SNV is not noise).\n\n- **Filter Quality (FQ)** quantifies the reliability of a filtering strategy for SNVs. Given a filter that selects a subset of SNVs, the FQ is defined as:  $$\\text{FQ} = -10 \\log_{10} \\left(b_{\\text{FP}} \\frac{\\text{FPR}}{\\text{TPR}} \\right)$$ where **FPR** and **TPR** are the filter's false and true positive rates, and $$b_{\\text{FP}} = \\frac{\\#\\text{FP}}{\\#\\text{sequenced}}$$ is the **base error rate** (the fraction of all sequenced bases that are falsely read as SNVs). \nHere, FPR and TPR are measured with respect to the training set, $\\#\\text{FP}$ is the filtered number of SNVs sequenced, and $\\#\\text{sequenced}$ is the effective number of bases sequenced, measured as (mean coverage)x(size of analyzed genomic regions). \nThe FQ score is closely related to the precision of the filter:\n$1 - \\text{Precision} \\approx b_{\\text{FP}}\\frac{\\text{FPR}}{\\text{TPR}}$, where the approximation holds when $b_{\\text{FP}}\\frac{\\text{FPR}}{\\text{TPR}} \\ll 1$.\n\n- **SNVQ**. The SRSNV model is used to filter SNVs by retaining only those with MQUAL values above a certain threshold. This filtering startegy defines a calibration function that maps the threshold MQUAL value to the FQ of the resulting filter (see [MQUAL -> SNVQ mapping function](#MQUAL--%3E-SNVQ-mapping-function)). SNVQ is then defined to be this calibration function applied to the MQUAL of the SNV. In other words, it is the FQ of the filter whose threshold is the SNV's MQUAL.\n\n\n<h3>ppmSeq tags</h3>  \n\n- **mixed** refers to reads where the start ppmSeq tag is MIXED. See [SNVQ vs ppmSeq tag](#SNVQ-vs-ppmSeq-tag) for more detailed information about ppmSeq tags. \n\n<h3>Training set lables</h3>  \n\n- **TP** refers to homozygous SNVs. They are labeled as *True*.\n- **FP** refers to SNVs that are supported by a single read (in a locus with a high coverage). They are labeled as *False*.\n\n<h3>Filtering Statistics</h3>  \nFor details on the training set construction and the filters applied see [howto-single-read-snv](https://github.com/Ultimagen/healthomics-workflows/blob/main/workflows/single_read_snv/howto-single-read-snv.md)\n\nColumn legend:\n1. name - the name of the filter\n2. type\n    1. raw - number of entries before filters are applied\n    2. region - filters applied to genomic regions\n    3. mapping - mapping quality filter/s\n    4. quality - SNVs filtered due to low quality, e.g. low base calling quality or reads with very high edit distances\n    5. label - filters applied for labeling the training set, for example reads supporting the reference allele for the TP set or variants with low VAF for the FP set.\n3. op\n    1. eq - equals\n    2. ne - not equals\n    3. ge - greater than or equal to\n    4. gt - greater than\n    5. le - less than or equal to\n    6. lt - less than \n4. value - the value the filters refers to\n5. pass / % pass - number / percent of data points passing this filter\n6. funnel / % funnel - number / percent of data points passing this filter after passing all previous filters, in the order of appearance in the table"
+   "source": [
+    "# Glossary of terms\n",
+    "\n",
+    "- **MQUAL** is the output of the SRSNV model, in phred scale: $$\\mathrm{MQUAL} = -10 \\log_{10}(1-\\hat{p}),$$ where $\\hat{p}$ is the model prediction (estimate of the probability that the SNV is not noise).\n",
+    "\n",
+    "- **Filter Quality (FQ)** quantifies the reliability of a filtering strategy for SNVs. Given a filter that selects a subset of SNVs, the FQ is defined as:  $$\\text{FQ} = -10 \\log_{10} \\left(b_{\\text{FP}} \\frac{\\text{FPR}}{\\text{TPR}} \\right)$$ where **FPR** and **TPR** are the filter's false and true positive rates, and $$b_{\\text{FP}} = \\frac{\\#\\text{FP}}{\\#\\text{sequenced}}$$ is the **base error rate** (the fraction of all sequenced bases that are falsely read as SNVs). \n",
+    "Here, FPR and TPR are measured with respect to the training set, $\\#\\text{FP}$ is the filtered number of SNVs sequenced, and $\\#\\text{sequenced}$ is the effective number of bases sequenced, measured as (mean coverage)x(size of analyzed genomic regions). \n",
+    "The FQ score is closely related to the precision of the filter:\n",
+    "$1 - \\text{Precision} \\approx b_{\\text{FP}}\\frac{\\text{FPR}}{\\text{TPR}}$, where the approximation holds when $b_{\\text{FP}}\\frac{\\text{FPR}}{\\text{TPR}} \\ll 1$.\n",
+    "\n",
+    "- **SNVQ**. The SRSNV model is used to filter SNVs by retaining only those with MQUAL values above a certain threshold. This filtering startegy defines a calibration function that maps the threshold MQUAL value to the FQ of the resulting filter (see [MQUAL -> SNVQ mapping function](#MQUAL--%3E-SNVQ-mapping-function)). SNVQ is then defined to be this calibration function applied to the MQUAL of the SNV. In other words, it is the FQ of the filter whose threshold is the SNV's MQUAL.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# ppmSeq tags / strand support glossary section (depends on split_mode)\nif split_mode == \"consensus\":\n    _glossary_split = (\n        \"<h3>Strand support</h3>  \\n\\n\"\n        \"Reads are split into three groups by the number of forward (fs) and reverse (rs) reads:\\n\\n\"\n        \"- **single read** — fs + rs &le; 1.\\n\"\n        \"- **consensus, one strand** — fs + rs &ge; 2, with all reads on a single strand \"\n        \"(exactly one of fs/rs is 0).\\n\"\n        \"- **consensus, duplex** — at least one forward read (fs &ge; 1) and one reverse read \"\n        \"(rs &ge; 1). \\n\\n\"\n    )\nelse:\n    _glossary_split = (\n        \"<h3>ppmSeq tags</h3>  \\n\\n\"\n        \"- **mixed** refers to reads where the start ppmSeq tag is MIXED. \"\n        \"See [SNVQ vs ppmSeq tag](#SNVQ-vs-ppmSeq-tag) for more detailed information \"\n        \"about ppmSeq tags. \\n\\n\"\n    )\nipy_display(HTML(_glossary_split))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<h3>Training set lables</h3>  \n",
+    "\n",
+    "- **TP** refers to homozygous SNVs. They are labeled as *True*.\n",
+    "- **FP** refers to SNVs that are supported by a single read (in a locus with a high coverage). They are labeled as *False*.\n",
+    "\n",
+    "<h3>Filtering Statistics</h3>  \n",
+    "For details on the training set construction and the filters applied see [howto-single-read-snv](https://github.com/Ultimagen/healthomics-workflows/blob/main/workflows/single_read_snv/howto-single-read-snv.md)\n",
+    "\n",
+    "Column legend:\n",
+    "1. name - the name of the filter\n",
+    "2. type\n",
+    "    1. raw - number of entries before filters are applied\n",
+    "    2. region - filters applied to genomic regions\n",
+    "    3. mapping - mapping quality filter/s\n",
+    "    4. quality - SNVs filtered due to low quality, e.g. low base calling quality or reads with very high edit distances\n",
+    "    5. label - filters applied for labeling the training set, for example reads supporting the reference allele for the TP set or variants with low VAF for the FP set.\n",
+    "3. op\n",
+    "    1. eq - equals\n",
+    "    2. ne - not equals\n",
+    "    3. ge - greater than or equal to\n",
+    "    4. gt - greater than\n",
+    "    5. le - less than or equal to\n",
+    "    6. lt - less than \n",
+    "4. value - the value the filters refers to\n",
+    "5. pass / % pass - number / percent of data points passing this filter\n",
+    "6. funnel / % funnel - number / percent of data points passing this filter after passing all previous filters, in the order of appearance in the table"
+   ]
   },
   {
    "cell_type": "code",

--- a/src/srsnv/ugbio_srsnv/split_scheme.py
+++ b/src/srsnv/ugbio_srsnv/split_scheme.py
@@ -33,16 +33,16 @@ from ugbio_srsnv.srsnv_utils import (
     CONSENSUS_GROUP_SINGLE,
     CONSENSUS_GROUPS,
     ET,
-    FS,
     IS_CONSENSUS,
     IS_MIXED,
     IS_MIXED_START,
     MIXED_GROUP_NON,
     MIXED_GROUP_POS,
     MIXED_GROUPS,
+    NF,
     NONE_GROUP_ALL,
+    NR,
     READ_GROUP,
-    RS,
     ST,
     TE,
     TS,
@@ -51,7 +51,7 @@ from ugbio_srsnv.srsnv_utils import (
     add_is_mixed_to_featuremap_df,
 )
 
-MIN_CONSENSUS_READS = 2  # fs + rs >= 2 to be more than a single read
+MIN_CONSENSUS_READS = 2  # nf + nr >= 2 to be more than a single read
 
 
 @dataclass(frozen=True)
@@ -193,12 +193,12 @@ def _mixed_legacy_groups(data_df: pd.DataFrame) -> pd.Categorical:
 
 def _consensus_groups(data_df: pd.DataFrame) -> pd.Categorical:
     """Strand-support split: single read / consensus one strand / consensus duplex."""
-    fs = data_df[FS]
-    rs = data_df[RS]
-    total = fs + rs
+    nf = data_df[NF]
+    nr = data_df[NR]
+    total = nf + nr
     g = pd.Series(CONSENSUS_GROUP_SINGLE, index=data_df.index, dtype=object)
-    g[(total >= MIN_CONSENSUS_READS) & ((fs == 0) ^ (rs == 0))] = CONSENSUS_GROUP_ONE_STRAND
-    g[(fs >= 1) & (rs >= 1)] = CONSENSUS_GROUP_DUPLEX
+    g[(total >= MIN_CONSENSUS_READS) & ((nf == 0) ^ (nr == 0))] = CONSENSUS_GROUP_ONE_STRAND
+    g[(nf >= 1) & (nr >= 1)] = CONSENSUS_GROUP_DUPLEX
     return _ordered(g, CONSENSUS_GROUPS)
 
 
@@ -289,7 +289,7 @@ MIXED_SCHEME = SplitScheme(
 
 CONSENSUS_SCHEME = SplitScheme(
     mode=ReportMode.CONSENSUS,
-    detect=lambda cols: FS in cols and RS in cols,
+    detect=lambda cols: NF in cols and NR in cols,
     add_columns=_consensus_add_columns,
     tag_axis="strand support",
     variants=(
@@ -319,7 +319,7 @@ NONE_SCHEME = SplitScheme(
     ),
 )
 
-# Ordered registry. Detection order preserves the historical priority: ppmSeq tags beat fs/rs.
+# Ordered registry. Detection order preserves the historical priority: ppmSeq tags beat nf/nr.
 # NONE is the explicit fallback and is not consulted via `detect`.
 SPLIT_SCHEMES: tuple[SplitScheme, ...] = (MIXED_SCHEME, CONSENSUS_SCHEME, NONE_SCHEME)
 _BY_MODE: dict[ReportMode, SplitScheme] = {s.mode: s for s in SPLIT_SCHEMES}

--- a/src/srsnv/ugbio_srsnv/split_scheme.py
+++ b/src/srsnv/ugbio_srsnv/split_scheme.py
@@ -1,0 +1,364 @@
+"""Data-driven read-split "recipes" for the SRSNV report.
+
+The report splits reads into groups (e.g. ppmSeq mixed/non-mixed, or consensus
+single/one-strand/duplex) for every figure and table. Instead of scattering ``if mode ==``
+branches across the report methods, all split behavior is described by a :class:`SplitScheme`
+"recipe": a detector predicate, a function that adds the columns the scheme needs, and an
+ordered list of :class:`SplitVariant` renderings. Each figure/table method consumes the active
+scheme's variants uniformly and never names a scheme.
+
+Adding a new split scheme = define one :class:`SplitScheme` object (+ its detector) and append it
+to :data:`SPLIT_SCHEMES`. No report method changes.
+
+h5 keys: every split table is written as ``base`` for the legacy variant (``suffix == ""``) and
+``base + "_" + suffix`` for other variants (see :func:`h5_key`). Mixed keeps its historical
+suffixes (``""`` legacy / ``mixed_start`` display); other schemes get their own scheme-id suffix.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from ugbio_core.logger import logger
+
+from ugbio_srsnv.srsnv_utils import (
+    AE,
+    AS,
+    CONSENSUS_GROUP_DUPLEX,
+    CONSENSUS_GROUP_ONE_STRAND,
+    CONSENSUS_GROUP_SINGLE,
+    CONSENSUS_GROUPS,
+    ET,
+    FS,
+    IS_CONSENSUS,
+    IS_MIXED,
+    IS_MIXED_START,
+    MIXED_GROUP_NON,
+    MIXED_GROUP_POS,
+    MIXED_GROUPS,
+    NONE_GROUP_ALL,
+    READ_GROUP,
+    RS,
+    ST,
+    TE,
+    TS,
+    ReportMode,
+    add_is_consensus_to_featuremap_df,
+    add_is_mixed_to_featuremap_df,
+)
+
+MIN_CONSENSUS_READS = 2  # fs + rs >= 2 to be more than a single read
+
+
+@dataclass(frozen=True)
+class SplitVariant:
+    """One rendering of the read split into ordered groups, with its own h5-key suffix.
+
+    A scheme has one or more variants. The report loops variants: each writes its table under
+    ``h5_key(base, variant)`` and the ``is_display`` variant additionally drives the PNG and the
+    key the notebook reads.
+
+    Attributes
+    ----------
+    suffix : str
+        h5-key suffix. ``""`` yields the bare ``base`` key (the historical "legacy" key).
+    group_fn : Callable[[pd.DataFrame], pd.Series]
+        Maps rows to ordered group labels (returns an ordered Categorical / label Series aligned
+        to ``df.index``). The single source of truth for how this variant groups reads.
+    groups : tuple[str, ...]
+        Ordered group labels this variant emits (2 for a binary split, N for N groups).
+    colors : dict | None
+        ``{label: matplotlib color}``; ``None`` -> seaborn palette sized to ``groups``.
+    is_display : bool
+        Exactly one variant per scheme is the display variant (drives PNG + notebook key).
+    pos, neg, pos_lc, neg_lc : str | None
+        Binary-framing labels, used only by renderers that still need a positive/negative framing
+        (ROC "X only" rows, run-quality columns) for byte-identical mixed output. ``None`` for
+        purely N-group schemes -> those renderers use the N-group path (``pos is None`` discriminator).
+    tag_axis : str
+        Axis/index label for the per-tag summary table.
+    hist_col_name : str
+        ``col_name`` passed to the histogram-data extractor; part of the h5 column MultiIndex, so it
+        must stay literal for byte-identical mixed output. Empty -> use the group column name.
+    fq_conditions_fn : Callable | None
+        Optional builder of the ordered ``{label: mask|None}`` FQ-recall conditions for this variant
+        (mixed legacy needs the special both-ends/start conditions). ``None`` -> derived from groups.
+    summary_group_fn : Callable | None
+        Optional grouping for the per-tag summary table when it differs from ``group_fn`` (mixed
+        display groups by start-tag category, not by the 2-group label). ``None`` -> ``group_fn``.
+    trinuc_split_col : str | None
+        Column name fed to the trinuc plotter as its split column. ``None`` -> a materialized
+        ``read_group`` column. (Mixed uses the raw ``is_mixed`` bool to keep trinuc_stats identical.)
+    trinuc_group_specs : Any
+        ``group_specs`` passed to the trinuc plotter (``None`` -> the plotter auto-detects, which is
+        the historical mixed behavior).
+    """
+
+    suffix: str
+    group_fn: Callable[[pd.DataFrame], pd.Series]
+    groups: tuple[str, ...]
+    colors: dict[str, Any] | None = None
+    is_display: bool = False
+    pos: str | None = None
+    neg: str | None = None
+    pos_lc: str | None = None
+    neg_lc: str | None = None
+    tag_axis: str = ""
+    hist_col_name: str = ""
+    fq_conditions_fn: Callable[[pd.DataFrame], dict] | None = None
+    summary_group_fn: Callable[[pd.DataFrame], pd.Series] | None = None
+    trinuc_split_col: str | None = None
+    trinuc_group_specs: Any = None
+
+    def group_masks(self, data_df: pd.DataFrame) -> dict[str, np.ndarray]:
+        """Ordered ``{label: boolean mask (np.ndarray)}`` for this variant's groups over ``data_df``."""
+        col = np.asarray(self.group_fn(data_df))
+        return {label: (col == label) for label in self.groups}
+
+
+@dataclass(frozen=True)
+class SplitScheme:
+    """A full read-split recipe for one detected data type.
+
+    Attributes
+    ----------
+    mode : ReportMode
+        Detection key / legacy mode id (its ``.value`` is stored in metadata JSON). Report methods
+        never switch on this.
+    detect : Callable[[pd.Index], bool]
+        Column-presence predicate deciding whether this scheme applies to a dataframe.
+    add_columns : Callable[[pd.DataFrame, dict], pd.DataFrame]
+        Adds the boolean / categorical columns the variants' ``group_fn``s read.
+    variants : tuple[SplitVariant, ...]
+        Ordered; ``variants[0]`` is the legacy/base-key variant, one variant has ``is_display``.
+    tag_axis : str
+        Per-tag summary axis label ("ppmSeq tag" / "strand support").
+    legacy_hist_fn, crosstab_fn : Callable | None
+        Optional scheme-owned renderers for the two genuinely ppmSeq-specific outputs (the
+        3-category quality histogram and the start x end 2D tables). ``None`` -> generic path.
+    """
+
+    mode: ReportMode
+    detect: Callable[[pd.Index], bool]
+    add_columns: Callable[[pd.DataFrame, dict], pd.DataFrame]
+    variants: tuple[SplitVariant, ...]
+    tag_axis: str = ""
+    # Capability flags for the two genuinely ppmSeq-specific renderers (True only for mixed).
+    # The report dispatches on these instead of checking the mode.
+    ppmseq_crosstab: bool = False  # per-tag table uses the start x end 2D cross-tab
+    ppmseq_legacy_hist: bool = False  # quality histogram uses the 3-category (non/one-end/both-ends) split
+
+    @property
+    def display_variant(self) -> SplitVariant:
+        return next(v for v in self.variants if v.is_display)
+
+    @property
+    def legacy_variant(self) -> SplitVariant:
+        return self.variants[0]
+
+    @property
+    def display_suffix(self) -> str:
+        return self.display_variant.suffix
+
+
+def h5_key(base: str, variant: SplitVariant) -> str:
+    """Compose the h5 key for a base name and variant: bare base for empty suffix, else suffixed."""
+    return f"{base}_{variant.suffix}" if variant.suffix else base
+
+
+# ──────────────────────────── group functions ──────────────────────────────
+
+
+def _ordered(labels: pd.Series | np.ndarray, categories: list[str]) -> pd.Categorical:
+    return pd.Categorical(labels, categories=categories, ordered=True)
+
+
+def _mixed_display_groups(data_df: pd.DataFrame) -> pd.Categorical:
+    """Start-tag split -> [Non-mixed, Mixed] (the display split)."""
+    g = pd.Series(MIXED_GROUP_NON, index=data_df.index, dtype=object)
+    g[data_df[IS_MIXED_START]] = MIXED_GROUP_POS
+    return _ordered(g, MIXED_GROUPS)
+
+
+def _mixed_legacy_groups(data_df: pd.DataFrame) -> pd.Categorical:
+    """Both-ends split -> [Non-mixed, Mixed] (the legacy split)."""
+    g = pd.Series(MIXED_GROUP_NON, index=data_df.index, dtype=object)
+    g[data_df[IS_MIXED]] = MIXED_GROUP_POS
+    return _ordered(g, MIXED_GROUPS)
+
+
+def _consensus_groups(data_df: pd.DataFrame) -> pd.Categorical:
+    """Strand-support split: single read / consensus one strand / consensus duplex."""
+    fs = data_df[FS]
+    rs = data_df[RS]
+    total = fs + rs
+    g = pd.Series(CONSENSUS_GROUP_SINGLE, index=data_df.index, dtype=object)
+    g[(total >= MIN_CONSENSUS_READS) & ((fs == 0) ^ (rs == 0))] = CONSENSUS_GROUP_ONE_STRAND
+    g[(fs >= 1) & (rs >= 1)] = CONSENSUS_GROUP_DUPLEX
+    return _ordered(g, CONSENSUS_GROUPS)
+
+
+def _none_groups(data_df: pd.DataFrame) -> pd.Categorical:
+    return _ordered([NONE_GROUP_ALL] * len(data_df), [NONE_GROUP_ALL])
+
+
+# ──────────────────────────── add-columns hooks ────────────────────────────
+
+
+def _mixed_add_columns(data_df: pd.DataFrame, kw: dict) -> pd.DataFrame:
+    return add_is_mixed_to_featuremap_df(data_df, kw.get("adapter_version"), kw.get("categorical_features_names"))
+
+
+def _consensus_add_columns(data_df: pd.DataFrame, kw: dict) -> pd.DataFrame:  # noqa: ARG001
+    return add_is_consensus_to_featuremap_df(data_df)
+
+
+def _none_add_columns(data_df: pd.DataFrame, kw: dict) -> pd.DataFrame:  # noqa: ARG001
+    data_df[IS_CONSENSUS] = False
+    return data_df
+
+
+# ──────────────────── mixed FQ-recall condition builders ────────────────────
+# These reproduce the historical ppmSeq FQ-recall conditions exactly (the only place the raw
+# is_mixed / is_mixed_start columns are read for FQ-recall).
+
+
+def _mixed_legacy_fq_conditions(data_df: pd.DataFrame) -> dict:
+    conditions = {"all reads": None}
+    if IS_MIXED in data_df.columns and data_df[IS_MIXED].any():
+        conditions["mixed both ends"] = data_df[IS_MIXED]
+    if IS_MIXED_START in data_df.columns and data_df[IS_MIXED_START].any():
+        conditions["mixed start"] = data_df[IS_MIXED_START]
+    return conditions
+
+
+def _mixed_display_fq_conditions(data_df: pd.DataFrame) -> dict:
+    conditions = {"all reads": None}
+    if IS_MIXED_START in data_df.columns and data_df[IS_MIXED_START].any():
+        conditions["mixed"] = data_df[IS_MIXED_START]
+    return conditions
+
+
+# ──────────────────────────── the recipes ──────────────────────────────────
+
+MIXED_SCHEME = SplitScheme(
+    mode=ReportMode.MIXED,
+    detect=lambda cols: (ST in cols and ET in cols) or all(c in cols for c in (AS, AE, TS, TE)),
+    add_columns=_mixed_add_columns,
+    tag_axis="ppmSeq tag",
+    ppmseq_crosstab=True,
+    ppmseq_legacy_hist=True,
+    variants=(
+        SplitVariant(
+            suffix="",
+            group_fn=_mixed_legacy_groups,
+            groups=tuple(MIXED_GROUPS),
+            colors={MIXED_GROUP_NON: "tab:red", MIXED_GROUP_POS: "tab:green"},
+            pos=MIXED_GROUP_POS,
+            neg=MIXED_GROUP_NON,
+            pos_lc="mixed",
+            neg_lc="non-mixed",
+            tag_axis="ppmSeq tag",
+            hist_col_name=IS_MIXED,
+            trinuc_split_col=IS_MIXED,
+            trinuc_group_specs=None,
+            fq_conditions_fn=_mixed_legacy_fq_conditions,
+        ),
+        SplitVariant(
+            suffix="mixed_start",
+            group_fn=_mixed_display_groups,
+            groups=tuple(MIXED_GROUPS),
+            colors={MIXED_GROUP_NON: "tab:red", MIXED_GROUP_POS: "tab:green"},
+            is_display=True,
+            pos=MIXED_GROUP_POS,
+            neg=MIXED_GROUP_NON,
+            pos_lc="mixed",
+            neg_lc="non-mixed",
+            tag_axis="ppmSeq tag",
+            hist_col_name=IS_MIXED_START,
+            trinuc_split_col=IS_MIXED,
+            trinuc_group_specs=None,
+            fq_conditions_fn=_mixed_display_fq_conditions,
+        ),
+    ),
+)
+
+CONSENSUS_SCHEME = SplitScheme(
+    mode=ReportMode.CONSENSUS,
+    detect=lambda cols: FS in cols and RS in cols,
+    add_columns=_consensus_add_columns,
+    tag_axis="strand support",
+    variants=(
+        SplitVariant(
+            suffix="strand_support",
+            group_fn=_consensus_groups,
+            groups=tuple(CONSENSUS_GROUPS),
+            is_display=True,
+            tag_axis="strand support",
+        ),
+    ),
+)
+
+NONE_SCHEME = SplitScheme(
+    mode=ReportMode.NONE,
+    detect=lambda cols: True,  # fallback; never reached via detection order
+    add_columns=_none_add_columns,
+    tag_axis="ppmSeq tag",
+    variants=(
+        SplitVariant(
+            suffix="",
+            group_fn=_none_groups,
+            groups=(NONE_GROUP_ALL,),
+            is_display=True,
+            tag_axis="ppmSeq tag",
+        ),
+    ),
+)
+
+# Ordered registry. Detection order preserves the historical priority: ppmSeq tags beat fs/rs.
+# NONE is the explicit fallback and is not consulted via `detect`.
+SPLIT_SCHEMES: tuple[SplitScheme, ...] = (MIXED_SCHEME, CONSENSUS_SCHEME, NONE_SCHEME)
+_BY_MODE: dict[ReportMode, SplitScheme] = {s.mode: s for s in SPLIT_SCHEMES}
+
+
+def resolve_scheme(data_df: pd.DataFrame | None = None, *, mode: ReportMode | str | None = None) -> SplitScheme:
+    """Return the active split scheme.
+
+    If ``mode`` is given (a :class:`ReportMode` or its string value), return that scheme directly
+    (used when the mode was already resolved and stored in params). Otherwise detect from the
+    dataframe columns, in registry order, falling back to :data:`NONE_SCHEME`.
+    """
+    if mode is not None:
+        mode = ReportMode(mode) if not isinstance(mode, ReportMode) else mode
+        return _BY_MODE[mode]
+    cols = data_df.columns
+    for scheme in SPLIT_SCHEMES:
+        if scheme is NONE_SCHEME:
+            continue
+        if scheme.detect(cols):
+            return scheme
+    return NONE_SCHEME
+
+
+def resolve_scheme_and_add_columns(
+    data_df: pd.DataFrame,
+    adapter_version: str | None = None,
+    categorical_features_names: list[str] | None = None,
+) -> tuple[pd.DataFrame, SplitScheme]:
+    """Detect the active scheme, add the columns it needs, and add the ordered ``read_group``.
+
+    ``read_group`` is written from the scheme's *display* variant, giving a uniform N-group column
+    for plots that read it directly. Returns ``(df, scheme)``.
+    """
+    scheme = resolve_scheme(data_df)
+    logger.info("Detected SRSNV split scheme: %s", scheme.mode.value)
+    data_df = scheme.add_columns(
+        data_df,
+        {"adapter_version": adapter_version, "categorical_features_names": categorical_features_names},
+    )
+    data_df[READ_GROUP] = scheme.display_variant.group_fn(data_df)
+    return data_df, scheme

--- a/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
@@ -4,7 +4,6 @@ import functools
 import json
 import os
 from collections.abc import Callable
-from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -36,25 +35,27 @@ from ugbio_ppmseq.ppmSeq_utils import PpmseqAdapterVersions, PpmseqCategories
 
 from ugbio_srsnv.shap_plotting import SHAPPlotter
 from ugbio_srsnv.smoothing_utils import AdaptiveKDEPrecisionEstimator
+from ugbio_srsnv.split_scheme import (
+    h5_key as split_h5_key,
+)
+from ugbio_srsnv.split_scheme import (
+    resolve_scheme,
+    resolve_scheme_and_add_columns,
+)
 from ugbio_srsnv.srsnv_utils import (
-    CONSENSUS_GROUPS,
     ET,
     ET_FILLNA,
-    IS_CONSENSUS,
+    FS,
     MAX_PHRED,
-    MIXED_GROUPS,
-    NONE_GROUP_ALL,
     READ_GROUP,
+    RS,
     ST,
     ST_FILLNA,
-    ReportMode,
     construct_trinuc_context_with_alt,
-    detect_report_mode,
     get_base_recall_from_filters,
     phred_to_prob,
     prob_to_logit,
     prob_to_phred,
-    resolve_and_add_split_columns,
     safe_roc_auc,
     split_validation_training_preds,
 )
@@ -71,104 +72,6 @@ IS_MIXED_START = "is_mixed_start"
 IS_MIXED_END = "is_mixed_end"
 FOLD_ID = "fold_id"
 
-
-@dataclass(frozen=True)
-class ReadSplit:
-    """Describes how the report splits reads into a positive/negative group.
-
-    The report supports several :class:`~ugbio_srsnv.srsnv_utils.ReportMode` values, each of
-    which splits the reads on a different boolean column and labels the two groups differently.
-    All split-dependent report methods consult a ``ReadSplit`` instead of hard-coding the
-    ppmSeq "mixed" columns/labels, so the same code produces correctly-labelled output for
-    every mode.
-
-    Attributes
-    ----------
-    mode : ReportMode
-        The detected report mode.
-    display_col : str
-        Boolean column driving the display (simplified) tables/plots and their `_mixed_start`
-        h5 keys. For MIXED this is ``is_mixed_start``; for CONSENSUS/NONE it is ``is_consensus``.
-    legacy_col : str
-        Boolean column driving the legacy (backward-compatible) h5 keys. For MIXED this is
-        ``is_mixed`` (both ends); for CONSENSUS/NONE it equals ``display_col`` (no start/end
-        distinction exists).
-    pos, neg : str
-        Capitalised labels for the positive / negative group of the *binary* split used by
-        MIXED (and NONE) mode (e.g. "Mixed"/"Non-mixed").
-    pos_lc, neg_lc : str
-        Lower-case variants of ``pos``/``neg`` used inside plot legends / column keys.
-    tag_axis : str
-        Axis/index label for the per-tag summary table ("ppmSeq tag" / "strand support").
-    groups : list[str]
-        Ordered display labels of the read groups this mode splits into. MIXED has 2
-        (``[neg, pos]``), CONSENSUS has 3 (single / one strand / duplex), NONE has 1.
-        Values match the categories written into the ``read_group`` column.
-    group_col : str
-        Name of the ordered-categorical column carrying the group label (``read_group``).
-
-    Notes
-    -----
-    MIXED mode carries a *dual* split — a legacy both-ends column (``is_mixed``) written to legacy
-    h5 keys and a display start column (``is_mixed_start``) written to ``*_mixed_start`` keys — which
-    a single ``read_group`` column cannot represent. Therefore MIXED (and NONE, for byte-identical
-    output) keep the original binary rendering via ``display_col``/``legacy_col``; only CONSENSUS
-    uses the N-group path driven by ``groups``/``group_col``.
-    """
-
-    mode: ReportMode
-    display_col: str
-    legacy_col: str
-    pos: str
-    neg: str
-    pos_lc: str
-    neg_lc: str
-    tag_axis: str
-    groups: list
-    group_col: str
-
-
-# Note: the split *columns* below keep the historical is_mixed* names for MIXED mode so that
-# all h5 keys and the deep-srsnv report path remain byte-for-byte backward compatible. Only the
-# display *labels* change per mode.
-MODE_SPLIT = {
-    ReportMode.MIXED: ReadSplit(
-        mode=ReportMode.MIXED,
-        display_col=IS_MIXED_START,
-        legacy_col=IS_MIXED,
-        pos="Mixed",
-        neg="Non-mixed",
-        pos_lc="mixed",
-        neg_lc="non-mixed",
-        tag_axis="ppmSeq tag",
-        groups=list(MIXED_GROUPS),
-        group_col=READ_GROUP,
-    ),
-    ReportMode.CONSENSUS: ReadSplit(
-        mode=ReportMode.CONSENSUS,
-        display_col=IS_CONSENSUS,
-        legacy_col=IS_CONSENSUS,
-        pos="Consensus",
-        neg="Non-consensus",
-        pos_lc="consensus",
-        neg_lc="non-consensus",
-        tag_axis="strand support",
-        groups=list(CONSENSUS_GROUPS),
-        group_col=READ_GROUP,
-    ),
-    ReportMode.NONE: ReadSplit(
-        mode=ReportMode.NONE,
-        display_col=IS_CONSENSUS,
-        legacy_col=IS_CONSENSUS,
-        pos="Mixed",
-        neg="Non-mixed",
-        pos_lc="mixed",
-        neg_lc="non-mixed",
-        tag_axis="ppmSeq tag",
-        groups=[NONE_GROUP_ALL],
-        group_col=READ_GROUP,
-    ),
-}
 EDIST = FeatureMapFields.EDIST.value
 SCORE = FeatureMapFields.BCSQ.value
 INDEX = FeatureMapFields.INDEX.value
@@ -394,7 +297,8 @@ def create_srsnv_report_html(
     out_basename,
     srsnv_metadata_file,
     simple_pipeline=None,
-    split_mode: str = ReportMode.MIXED.value,
+    split_mode: str = "mixed",
+    display_suffix: str = "mixed_start",
 ):
     if len(out_basename) > 0 and not out_basename.endswith("."):
         out_basename += "."
@@ -432,6 +336,7 @@ def create_srsnv_report_html(
         "logit_histogram": logit_histogram,
         "calibration_fn_with_hist": calibration_fn_with_hist,
         "split_mode": split_mode,
+        "display_suffix": display_suffix,
     }
 
     generate_report(
@@ -1661,23 +1566,25 @@ class SRSNVReport:
             logger.info(f"Adding {IS_FORWARD} column to data_df as negation of {REV}")
             self.data_df.loc[:, IS_FORWARD] = self.data_df[REV].astype(int) != 1
 
-        # Resolve the report split mode (mixed vs consensus vs none) and its labels.
-        # The mode may be provided by the caller (params["report_mode"], set by the CLI) or
-        # auto-detected from the columns present in the dataframe.
+        # Resolve the read-split "recipe" (scheme). The scheme may be provided by the caller
+        # (params["report_mode"], set by the CLI) or auto-detected from the dataframe columns.
         report_mode_param = self.params.get("report_mode")
-        self.report_mode = ReportMode(report_mode_param) if report_mode_param else detect_report_mode(self.data_df)
-        self.split = MODE_SPLIT[self.report_mode]
+        if report_mode_param:
+            self.scheme = resolve_scheme(mode=report_mode_param)
+        else:
+            self.scheme = resolve_scheme(self.data_df)
+        self.report_mode = self.scheme.mode  # kept for metadata / backward compat
 
         # Add the split column(s) if they don't exist yet (e.g. when SRSNVReport is constructed
         # directly, without going through prepare_report which already adds them).
-        if self.split.display_col not in self.data_df.columns:
-            logger.info(f"Adding split column(s) for report mode {self.report_mode.value} to data_df")
+        if READ_GROUP not in self.data_df.columns:
+            logger.info(f"Adding split column(s) for split scheme {self.scheme.mode.value} to data_df")
             adapter_version = self.params.get("adapter_version", None)
             categorical_features = [f["name"] for f in self.srsnv_metadata["features"] if f.get("type") == "c"]
-            self.data_df, self.report_mode = resolve_and_add_split_columns(
+            self.data_df, self.scheme = resolve_scheme_and_add_columns(
                 self.data_df, adapter_version=adapter_version, categorical_features_names=categorical_features
             )
-            self.split = MODE_SPLIT[self.report_mode]
+            self.report_mode = self.scheme.mode
 
         # add logits to data_df
         self.data_df[ML_LOGIT_TEST] = prob_to_logit(
@@ -1691,27 +1598,74 @@ class SRSNVReport:
         self.data_df["ML_prob_train"] = preds_train
         self.data_df["ML_logit_train"] = prob_to_logit(preds_train, max_value=self.max_qual)
 
-    def _group_labels(self):
-        """Ordered list of read-group display labels for the current mode."""
-        return list(self.split.groups)
+    # ──────────────────────── split-scheme helpers ────────────────────────
+    # These give every figure/table method a uniform, scheme-agnostic interface: iterate
+    # `self.scheme.variants`, get group masks / colors / h5 keys from the variant. No method
+    # switches on the scheme.
 
-    def _group_masks(self, data_df=None):
-        """Yield ``(label, boolean_mask)`` per read group, in order, for the given dataframe.
+    @property
+    def _display_variant(self):
+        return self.scheme.display_variant
 
-        Masks come from the ordered ``read_group`` categorical. Used by the N-group (consensus)
-        report paths so every method splits reads the same way. Defaults to ``self.data_df``.
-        """
+    @property
+    def tag_axis(self):
+        return self.scheme.tag_axis
+
+    def _display_groups(self):
+        """Ordered list of the display variant's group labels."""
+        return list(self._display_variant.groups)
+
+    def _group_masks(self, variant=None, data_df=None):
+        """Yield ``(label, boolean_mask)`` per group, in order, for a variant (default: display)."""
+        if variant is None:
+            variant = self._display_variant
         if data_df is None:
             data_df = self.data_df
-        col = data_df[self.split.group_col]
-        for label in self.split.groups:
-            yield label, (col == label).to_numpy()
+        yield from variant.group_masks(data_df).items()
 
-    def _group_palette(self):
-        """A stable {label: color} mapping sized to the number of groups."""
-        labels = self.split.groups
-        colors = sns.color_palette(n_colors=len(labels))
-        return dict(zip(labels, colors, strict=False))
+    def _variant_palette(self, variant=None):
+        """Stable ``{label: color}`` for a variant: its declared colors, else a seaborn palette."""
+        if variant is None:
+            variant = self._display_variant
+        if variant.colors:
+            return dict(variant.colors)
+        colors = sns.color_palette(n_colors=len(variant.groups))
+        return dict(zip(variant.groups, colors, strict=False))
+
+    def _is_legacy_variant(self, variant):
+        """True for the legacy (base-key) variant of a multi-variant scheme (mixed's both-ends)."""
+        return len(self.scheme.variants) > 1 and variant is self.scheme.legacy_variant
+
+    def _has_dual_split(self):
+        """True when the scheme keeps a distinct legacy + display table (ppmSeq mixed only).
+
+        Single-grouping schemes (consensus/none) render one per-group table; the dual-split path
+        additionally emits the historical 3-way (start / both-ends) run-info & quality rows.
+        """
+        return len(self.scheme.variants) > 1
+
+    def _variant_roc_groups(self, variant):
+        """Ordered ``[(name, mask), ...]`` and the ROC-table index for a variant.
+
+        Binary variants (``pos`` set) keep the historical ``[pos, neg]`` order and
+        ``["Total", "{pos} only", "{neg} only"]`` index; N-group variants list one row per group.
+        """
+        masks = variant.group_masks(self.data_df)
+        if variant.pos is not None:
+            groups = [(variant.pos, masks[variant.pos]), (variant.neg, masks[variant.neg])]
+            index = ["Total", f"{variant.pos} only", f"{variant.neg} only"]
+        else:
+            groups = list(masks.items())
+            index = ["Total", *[f"{label} only" for label in variant.groups]]
+        return groups, index
+
+    def _write_variant_table(self, base, variant, obj):
+        """Write ``obj`` to the variant's h5 key, and also to the bare ``base`` key when the scheme
+        has no explicit legacy (``suffix==''``) variant (so keys_to_convert / json conversion works).
+        """
+        obj.to_hdf(self.output_h5_filename, key=split_h5_key(base, variant), mode="a")
+        if variant.is_display and all(v.suffix != "" for v in self.scheme.variants):
+            obj.to_hdf(self.output_h5_filename, key=base, mode="a")
 
     def _save_plt(self, output_filename: str = None, fig=None, *, tight_layout=True, **kwargs):
         if output_filename is not None:
@@ -1912,12 +1866,8 @@ class SRSNVReport:
         self.base_recall = base_recall
         self.base_fq = base_fq
 
-        # Legacy conditions using IS_MIXED (both ends) and IS_MIXED_START separately
-        conditions_legacy = {"all reads": None}
-        if IS_MIXED in self.data_df.columns and self.data_df[IS_MIXED].any():
-            conditions_legacy["mixed both ends"] = self.data_df[IS_MIXED]
-        if IS_MIXED_START in self.data_df.columns and self.data_df[IS_MIXED_START].any():
-            conditions_legacy["mixed start"] = self.data_df[IS_MIXED_START]
+        # Legacy variant conditions (mixed: the historical both-ends + start conditions).
+        conditions_legacy = self._fq_conditions(self.scheme.legacy_variant)
         pr_df_legacy = pr_df.copy()
         for label, condition in conditions_legacy.items():
             recall, fq = self._calc_threshold_based_fq_recall(pr_df_legacy["MQUAL"].to_numpy(), condition=condition)
@@ -1925,15 +1875,8 @@ class SRSNVReport:
             pr_df_legacy[f"FQ_{label}"] = fq
         pr_df_legacy.to_hdf(self.output_h5_filename, key="FQ_recall_LoD", mode="a")
 
-        # New conditions: one curve per read group (consensus) or the binary positive group.
-        conditions = {"all reads": None}
-        if self.split.mode is ReportMode.CONSENSUS:
-            for label, mask in self._group_masks():
-                if mask.any():
-                    conditions[label] = pd.Series(mask, index=self.data_df.index)
-        elif self.split.display_col in self.data_df.columns:
-            if self.data_df[self.split.display_col].any():
-                conditions[self.split.pos_lc] = self.data_df[self.split.display_col]
+        # Display variant conditions (one curve per read group, or the binary positive group).
+        conditions = self._fq_conditions(self._display_variant)
 
         if only_calculate:
             for label, condition in conditions.items():
@@ -1954,7 +1897,21 @@ class SRSNVReport:
             ax.grid(visible=True)
             self._save_plt(output_filename, fig)
         self.pr_df = pr_df
-        self.pr_df.to_hdf(self.output_h5_filename, key="FQ_recall_LoD_mixed_start", mode="a")
+        self.pr_df.to_hdf(self.output_h5_filename, key=split_h5_key("FQ_recall_LoD", self._display_variant), mode="a")
+
+    def _fq_conditions(self, variant):
+        """Ordered ``{label: mask|None}`` FQ-recall conditions for a variant.
+
+        Uses the variant's ``fq_conditions_fn`` when set (mixed's historical both-ends/start
+        conditions); otherwise ``{"all reads": None}`` plus one condition per non-empty group.
+        """
+        if variant.fq_conditions_fn is not None:
+            return variant.fq_conditions_fn(self.data_df)
+        conditions = {"all reads": None}
+        for label, mask in variant.group_masks(self.data_df).items():
+            if mask.any():
+                conditions[label] = pd.Series(mask, index=self.data_df.index)
+        return conditions
 
     def get_dataset_sizes(self):
         """Calculate dataset sizes for different folds and overall."""
@@ -2060,23 +2017,24 @@ class SRSNVReport:
                 self._safe_roc_auc(sub[LABEL], sub[ML_PROB_1_TEST], name=f"run info {label}"), max_value=self.max_qual
             )
 
+        groups = list(self._display_variant.groups)
         performance_info = {("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS)}
-        for label in self.split.groups:
+        for label in groups:
             performance_info[("Median SNVQ", label)] = signif(grp_median[label], SIG_DIGITS)
         for snvq in snvq_thresholds:
             performance_info[(f"Recall at SNVQ={snvq}", "All reads")] = signif(
                 self._get_recall_at_snvq(snvq=snvq) / recall_at_0, SIG_DIGITS
             )
-            for label in self.split.groups:
+            for label in groups:
                 denom = grp_recall0[label]
                 performance_info[(f"Recall at SNVQ={snvq}", label)] = signif(
                     grp_recall[label][snvq] / denom if denom else np.nan, SIG_DIGITS
                 )
         performance_info[("Pre-filter Recall", "All reads")] = signif(recall_at_0, SIG_DIGITS)
-        for label in self.split.groups:
+        for label in groups:
             performance_info[("Pre-filter Recall", label)] = signif(grp_recall0[label], SIG_DIGITS)
         performance_info[("ROC AUC (Phred)", "All reads")] = signif(roc_auc_phred, SIG_DIGITS)
-        for label in self.split.groups:
+        for label in groups:
             performance_info[("ROC AUC (Phred)", label)] = signif(grp_roc[label], SIG_DIGITS)
 
         training_info = {("Number of CV folds", ""): self.params["num_CV_folds"]}
@@ -2084,11 +2042,10 @@ class SRSNVReport:
         run_info_table = pd.Series({**general_info, **version_info}, name="")
         run_quality_summary_table = pd.Series({**performance_info}, name="")
         training_info_table = pd.Series({**training_info, **dataset_sizes}, name="")
-        # No legacy/both-ends distinction in consensus: write identical table to both keys.
-        run_info_table.to_hdf(self.output_h5_filename, key="run_info_table", mode="a")
-        run_info_table.to_hdf(self.output_h5_filename, key="run_info_table_mixed_start", mode="a")
-        run_quality_summary_table.to_hdf(self.output_h5_filename, key="run_quality_summary_table", mode="a")
-        run_quality_summary_table.to_hdf(self.output_h5_filename, key="run_quality_summary_table_mixed_start", mode="a")
+        # Single display grouping: write to the display variant's suffixed key + bare base key.
+        variant = self._display_variant
+        self._write_variant_table("run_info_table", variant, run_info_table)
+        self._write_variant_table("run_quality_summary_table", variant, run_quality_summary_table)
         training_info_table.to_hdf(self.output_h5_filename, key="training_info_table", mode="a")
 
     @exception_handler
@@ -2096,15 +2053,14 @@ class SRSNVReport:
         """Calculate run_info_table, a table with general run information."""
         # Generate Run Info table
         logger.info("Generating Run Info table")
-        if self.split.mode is ReportMode.CONSENSUS:
+        # Schemes with a single display grouping use the per-group path; ppmSeq (mixed) keeps its
+        # dual legacy(both-ends)/display(start) tables with the historical 3-way performance rows.
+        if not self._has_dual_split():
             self._calc_run_info_table_by_group()
             return
-        # "positive-group" label for this mode (Mixed / Consensus). The report keeps two tables:
-        # a display table (mode's display_col) and a legacy backward-compatible one (legacy_col);
-        # in non-mixed modes both columns are identical.
-        pos = self.split.pos
-        display_col = self.split.display_col
-        legacy_col = self.split.legacy_col
+        pos = self._display_variant.pos
+        display_col = IS_MIXED_START
+        legacy_col = IS_MIXED
         n_tp = self.data_df[LABEL].sum()
         n_fp = (~self.data_df[LABEL]).sum()
         # Legacy positive-group percent using the legacy split column (IS_MIXED both ends for ppmSeq)
@@ -2426,31 +2382,13 @@ class SRSNVReport:
                 ]
             return result
 
-        if self.split.mode is ReportMode.CONSENSUS:
-            # N-group split: one row per read group, in the group order.
-            groups = list(self._group_masks())
-            auc_index = ["Total", *[f"{label} only" for label in self.split.groups]]
-            # Consensus has no legacy/both-ends distinction; write the same table to both keys.
-            auc_dict = _calc_roc_auc_dict(groups)
-            pd.DataFrame(auc_dict, index=auc_index).T.to_hdf(self.output_h5_filename, key="roc_auc_table", mode="a")
-            pd.DataFrame(auc_dict, index=auc_index).T.to_hdf(
-                self.output_h5_filename, key="roc_auc_table_mixed_start", mode="a"
-            )
-        else:
-            # MIXED / NONE binary split: keep the historical pos/neg row order and labels.
-            auc_index = ["Total", f"{self.split.pos} only", f"{self.split.neg} only"]
-            legacy_mask = self.data_df[self.split.legacy_col].to_numpy()
-            legacy_groups = [(self.split.pos, legacy_mask), (self.split.neg, ~legacy_mask)]
-            auc_table_dict_legacy = _calc_roc_auc_dict(legacy_groups, label_suffix=" legacy")
-            pd.DataFrame(auc_table_dict_legacy, index=auc_index).T.to_hdf(
-                self.output_h5_filename, key="roc_auc_table", mode="a"
-            )
-            display_mask = self.data_df[self.split.display_col].to_numpy()
-            display_groups = [(self.split.pos, display_mask), (self.split.neg, ~display_mask)]
-            auc_table_dict = _calc_roc_auc_dict(display_groups)
-            pd.DataFrame(auc_table_dict, index=auc_index).T.to_hdf(
-                self.output_h5_filename, key="roc_auc_table_mixed_start", mode="a"
-            )
+        # One table per variant. Binary variants (pos/neg set) keep the historical
+        # "{pos} only"/"{neg} only" row order; N-group variants list one row per group.
+        for variant in self.scheme.variants:
+            groups, auc_index = self._variant_roc_groups(variant)
+            label_suffix = " legacy" if self._is_legacy_variant(variant) else ""
+            auc_dict = _calc_roc_auc_dict(groups, label_suffix=label_suffix)
+            self._write_variant_table("roc_auc_table", variant, pd.DataFrame(auc_dict, index=auc_index).T)
 
     @exception_handler
     def calc_run_quality_table(
@@ -2492,9 +2430,11 @@ class SRSNVReport:
             "_FP": (~self.data_df[LABEL]).to_numpy(),
         }
 
-        if self.split.mode is ReportMode.CONSENSUS:
-            # N-group split: one TP column per read group. The internal join keys use the group
-            # label directly (kept literal for col_order); display uses the same labels.
+        if not self._has_dual_split():
+            # Single-grouping scheme (consensus / none): one TP column per read group. The internal
+            # join keys use the group label directly (kept literal for col_order); display uses the
+            # same labels.
+            display_variant = self._display_variant
             tp = self.data_df[LABEL].to_numpy()
             conds = dict(base_conds)
             for label, mask in self._group_masks():
@@ -2504,20 +2444,21 @@ class SRSNVReport:
             for qcol in (QUAL, "ML_qual"):
                 display_columns.append((qcol, "FP", ""))
                 display_columns.append((qcol, "TP", "overall"))
-                for label in self.split.groups:
+                for label in display_variant.groups:
                     display_columns.append((qcol, "TP", label))
             col_order = [
                 "_".join(cols) if cols[2] not in ["", "overall"] else "_".join(cols[:2]) for cols in display_columns
             ]
             run_quality_table_display = run_quality_table.loc[:, col_order].copy()
             run_quality_table_display.columns = pd.MultiIndex.from_tuples(display_columns)
-            # Consensus has no legacy/both-ends distinction: same table to both keys.
-            run_quality_table.T.to_hdf(self.output_h5_filename, key="run_quality_table", mode="a")
-            run_quality_table.T.to_hdf(self.output_h5_filename, key="run_quality_table_mixed_start", mode="a")
+            # No legacy/both-ends distinction: write the same table to the display key + bare base.
+            self._write_variant_table("run_quality_table", display_variant, run_quality_table.T)
             run_quality_table_display.to_hdf(self.output_h5_filename, key="run_quality_table_display", mode="a")
             return
 
-        # MIXED / NONE binary split — unchanged historical output.
+        # Dual-split scheme (ppmSeq mixed) — unchanged historical output.
+        legacy_variant = self.scheme.legacy_variant
+        display_variant = self._display_variant
         if display_columns is None:
             display_columns = [
                 (QUAL, "FP", ""),
@@ -2530,21 +2471,24 @@ class SRSNVReport:
                 ("ML_qual", "TP", "non-mixed"),
             ]
         # Note: the "_TP_mixed"/"_TP_non-mixed" keys below are internal join keys (matched by
-        # col_order); they stay literal regardless of mode. Only the displayed MultiIndex labels
-        # are swapped to the mode's split labels further down.
-        # Legacy table using the legacy split column (IS_MIXED both ends for ppmSeq)
+        # col_order); they stay literal regardless of scheme. Only the displayed MultiIndex labels
+        # are swapped to the variant's split labels further down.
+        label = self.data_df[LABEL].to_numpy()
+        legacy_masks = legacy_variant.group_masks(self.data_df)
+        display_masks = display_variant.group_masks(self.data_df)
+        # Legacy table using the legacy variant's positive group (IS_MIXED both ends for ppmSeq)
         conds_dict_legacy = {
             **base_conds,
-            "_TP_mixed": np.logical_and(self.data_df[self.split.legacy_col], self.data_df[LABEL]),
-            "_TP_non-mixed": np.logical_and(~self.data_df[self.split.legacy_col], self.data_df[LABEL]),
+            "_TP_mixed": legacy_masks[legacy_variant.pos] & label,
+            "_TP_non-mixed": legacy_masks[legacy_variant.neg] & label,
         }
         _quality_table(conds_dict_legacy).T.to_hdf(self.output_h5_filename, key="run_quality_table", mode="a")
 
-        # New table using the display split column for display and new h5 key
+        # New table using the display variant's positive group for display and new h5 key
         conds_dict = {
             **base_conds,
-            "_TP_mixed": np.logical_and(self.data_df[self.split.display_col], self.data_df[LABEL]),
-            "_TP_non-mixed": np.logical_and(~self.data_df[self.split.display_col], self.data_df[LABEL]),
+            "_TP_mixed": display_masks[display_variant.pos] & label,
+            "_TP_non-mixed": display_masks[display_variant.neg] & label,
         }
         run_quality_table = _quality_table(conds_dict)
 
@@ -2552,9 +2496,9 @@ class SRSNVReport:
             "_".join(cols) if cols[2] not in ["", "overall"] else "_".join(cols[:2]) for cols in display_columns
         ]
         run_quality_table_display = run_quality_table.loc[:, col_order].copy()
-        # Swap the literal "mixed"/"non-mixed" display labels for this mode's split labels
+        # Swap the literal "mixed"/"non-mixed" display labels for this variant's split labels
         # (the join keys used for col_order above stay literal).
-        label_remap = {"mixed": self.split.pos_lc, "non-mixed": self.split.neg_lc}
+        label_remap = {"mixed": display_variant.pos_lc, "non-mixed": display_variant.neg_lc}
         display_columns_relabeled = [(a, b, label_remap.get(c, c)) for a, b, c in display_columns]
         run_quality_table_display.columns = pd.MultiIndex.from_tuples(display_columns_relabeled)
         # Log in hdf5
@@ -2587,28 +2531,31 @@ class SRSNVReport:
         self._save_plt(output_filename, fig=fig)
 
     def _quality_per_split_group(self, output_filename: str = None):
-        """Consensus/none mode: median SNVQ and % of reads per read group (N rows).
+        """Generic per-read-group median SNVQ + % of reads table (used when a scheme has no
+        ppmSeq start x end cross-tab hook).
 
-        Mirrors the mixed-mode 1D table shape and h5 keys, but groups TP reads by the ordered
-        ``read_group`` column (e.g. single read / one strand / duplex) instead of the ppmSeq tag.
+        Groups TP reads by the ordered ``read_group`` categorical (e.g. single read / one strand /
+        duplex) and writes the summary to the display variant's suffixed key plus the bare
+        ``ppmseq_category_quality_table`` / ``ppmseq_category_quantity_table`` keys (so
+        keys_to_convert / h5->json conversion finds them).
         """
+        variant = self._display_variant
         data_df_tp = self.data_df[self.data_df[LABEL]].copy()
         total_count = len(data_df_tp)
         # Group by the ordered read_group categorical; reindex to keep group order and include
         # any empty groups as 0 rows.
-        grouped = data_df_tp.groupby(self.split.group_col, dropna=False, observed=False)[QUAL]
-        median_qual = grouped.median().reindex(self.split.groups)
-        pct_reads = (grouped.count().reindex(self.split.groups).fillna(0) / total_count) * 100
+        grouped = data_df_tp.groupby(READ_GROUP, dropna=False, observed=False)[QUAL]
+        median_qual = grouped.median().reindex(list(variant.groups))
+        pct_reads = (grouped.count().reindex(list(variant.groups)).fillna(0) / total_count) * 100
         summary_df = pd.DataFrame({"Median SNVQ": median_qual, "% of reads": pct_reads})
         summary_df.index = summary_df.index.astype(str)
-        summary_df.index.name = self.split.tag_axis
+        summary_df.index.name = self.tag_axis
         summary_df["Median SNVQ"] = summary_df["Median SNVQ"].apply(lambda x: signif(x, 3))
         summary_df["% of reads"] = summary_df["% of reads"].apply(lambda x: signif(x, 2))
 
-        # New simplified table -> same key/PNG as the mixed-mode display table.
-        summary_df.to_hdf(self.output_h5_filename, key="ppmseq_category_quality_table_mixed_start", mode="a")
-        # Write the same summary to the legacy 2D keys so downstream keys_to_convert / h5->json
-        # conversion finds them (no start x end cross-tab exists in this mode).
+        # Display table under the variant's suffixed key.
+        summary_df.to_hdf(self.output_h5_filename, key=split_h5_key("ppmseq_category_quality_table", variant), mode="a")
+        # Bare base keys so downstream keys_to_convert / h5->json conversion finds them.
         summary_df["Median SNVQ"].to_hdf(self.output_h5_filename, key="ppmseq_category_quality_table", mode="a")
         summary_df["% of reads"].to_hdf(self.output_h5_filename, key="ppmseq_category_quantity_table", mode="a")
 
@@ -2618,11 +2565,11 @@ class SRSNVReport:
     def quality_per_ppmseq_tags(self, output_filename: str = None):  # noqa: C901, PLR0915
         """Generate table of median quality and data quantity per read-split group.
 
-        In MIXED mode this is the per-ppmSeq-tag table (start tag, and legacy start x end
-        cross-tab). In CONSENSUS/NONE mode there is no ppmSeq tag, so it falls back to a per
-        split-group (e.g. Consensus / Non-consensus) summary with the same shape and h5 keys.
+        Schemes that provide a start x end ppmSeq cross-tab (``scheme.ppmseq_crosstab``) render the
+        legacy 2D tables plus the 1D start-tag display table. Other schemes fall back to a generic
+        per-read-group summary with the same h5 keys.
         """
-        if self.split.mode is not ReportMode.MIXED:
+        if not self.scheme.ppmseq_crosstab:
             self._quality_per_split_group(output_filename=output_filename)
             return
 
@@ -2690,7 +2637,7 @@ class SRSNVReport:
             pct_reads = pct_reads.drop(index=PpmseqCategories.END_UNREACHED.value)
         summary_df = pd.DataFrame({"Median SNVQ": median_qual, "% of reads": pct_reads})
         summary_df.index = summary_df.index.astype(str)
-        summary_df.index.name = self.split.tag_axis
+        summary_df.index.name = self.tag_axis
         summary_df["Median SNVQ"] = summary_df["Median SNVQ"].apply(lambda x: signif(x, 3))
         summary_df["% of reads"] = summary_df["% of reads"].apply(lambda x: signif(x, 2))
 
@@ -2883,16 +2830,18 @@ class SRSNVReport:
     ):
         logger.info("Calculating trinuc context statistics")
 
-        # In consensus (N-group) mode, split the quality panel by the ordered read_group column;
-        # otherwise keep the historical ppmSeq is_mixed split (byte-identical output).
-        if self.split.mode is ReportMode.CONSENSUS:
-            split_col = self.split.group_col
-            palette = self._group_palette()
+        # The display variant declares how to split the trinuc quality panel. Mixed uses the raw
+        # is_mixed bool (trinuc_split_col set, group_specs=None -> the plotter auto-detects, keeping
+        # trinuc_stats byte-identical). N-group schemes leave trinuc_split_col=None: we materialize
+        # the read_group column and pass explicit group_specs.
+        variant = self._display_variant
+        split_col = variant.trinuc_split_col
+        group_specs = variant.trinuc_group_specs
+        if split_col is None:
+            split_col = READ_GROUP
+            palette = self._variant_palette(variant)
             # calc_trinuc_stats names group columns "mixed=<group value>"; match that prefix.
-            group_specs = [(f"mixed={label}", label, palette[label]) for label in self.split.groups]
-        else:
-            split_col = IS_MIXED
-            group_specs = None
+            group_specs = [(f"mixed={label}", label, palette[label]) for label in variant.groups]
 
         # Call the new plotting function
         fig, stats_df = calc_and_plot_trinuc_hist(
@@ -2919,13 +2868,11 @@ class SRSNVReport:
     def _feature_group_series(self):
         """Ordered list of (group_label, color) for the per-feature quality curves.
 
-        For MIXED (2 groups) preserve the historical order/colors: Non-mixed (red) then
-        Mixed (green). For N groups use the group palette in group order.
+        Colors come from the display variant (mixed declares Non-mixed=tab:red, Mixed=tab:green;
+        N-group schemes fall back to a seaborn palette), in the variant's group order.
         """
-        if self.split.mode is ReportMode.MIXED:
-            return [(self.split.neg, "tab:red"), (self.split.pos, "tab:green")]
-        palette = self._group_palette()
-        return [(label, palette[label]) for label in self.split.groups]
+        palette = self._variant_palette()
+        return [(label, palette[label]) for label in self._display_variant.groups]
 
     def _plot_feature_qual_stats(
         self, stats_for_plot, ax, c_true="tab:green", c_false="tab:red", min_count=100, fb_kws=None, step_kws=None
@@ -2936,7 +2883,7 @@ class SRSNVReport:
         col = stats_for_plot.columns[0]
         polys, lines = [], []
         for label, color in self._feature_group_series():
-            group_mask = stats_for_plot[self.split.group_col].astype(str) == str(label)
+            group_mask = stats_for_plot[READ_GROUP].astype(str) == str(label)
             qual_df = stats_for_plot.loc[group_mask & stats_for_plot[LABEL] & (stats_for_plot["count"] > min_count), :]
             fb_kws["color"] = color
             step_kws["color"] = color
@@ -2966,7 +2913,7 @@ class SRSNVReport:
             q2 [float]: upper quantile for interquartile range
             bin_edges [list]: bin edges for discretization. If it is None, use discrete (integer) values
         """
-        required_cols = [col, LABEL, self.split.group_col, QUAL]
+        required_cols = [col, LABEL, READ_GROUP, QUAL]
 
         # If binning is needed, create binned column in a view/subset
         if bin_edges is not None:
@@ -2977,7 +2924,7 @@ class SRSNVReport:
             # Use a view of the original dataframe (no copy needed)
             subset = self.data_df[required_cols]
 
-        stats_for_plot = subset.groupby([col, LABEL, self.split.group_col], observed=True).agg(
+        stats_for_plot = subset.groupby([col, LABEL, READ_GROUP], observed=True).agg(
             median_qual=(QUAL, "median"),
             quantile1_qual=(QUAL, lambda x: x.quantile(q1)),
             quantile3_qual=(QUAL, lambda x: x.quantile(q2)),
@@ -3117,34 +3064,41 @@ class SRSNVReport:
             axes = [ax]
 
         plot_df = self.data_df[self.data_df[LABEL]].copy()
-        hue_col = self.split.tag_axis
+        hue_col = self.tag_axis
+        legacy_variant = self.scheme.legacy_variant
+        display_variant = self._display_variant
 
-        # Legacy histogram for backward-compatible h5 storage. In MIXED mode this is a 3-category
-        # split (non-mixed / mixed exactly one end / mixed both ends); other modes have no
-        # start/end distinction, so it collapses to the same 2-category split as the display plot.
+        # Legacy histogram for backward-compatible h5 storage. ppmSeq (mixed) uses a 3-category
+        # split (non-mixed / exactly one end / both ends); other schemes group by the legacy
+        # variant's read groups.
         plot_df_legacy = plot_df.copy()
-        if self.split.mode is ReportMode.MIXED:
-            legacy_one_end = f"{self.split.pos_lc}, exactly one end"
-            legacy_both_ends = f"{self.split.pos_lc}, both ends"
-            plot_df_legacy[hue_col] = self.split.neg_lc
+        neg_lc, pos_lc = display_variant.neg_lc, display_variant.pos_lc
+        if self.scheme.ppmseq_legacy_hist:
+            legacy_one_end = f"{pos_lc}, exactly one end"
+            legacy_both_ends = f"{pos_lc}, both ends"
+            plot_df_legacy[hue_col] = neg_lc
             one_end_mask = plot_df_legacy[IS_MIXED_START] ^ plot_df_legacy[IS_MIXED_END]
             both_ends_mask = plot_df_legacy[IS_MIXED_START] & plot_df_legacy[IS_MIXED_END]
             plot_df_legacy.loc[one_end_mask, hue_col] = legacy_one_end
             plot_df_legacy.loc[both_ends_mask, hue_col] = legacy_both_ends
-            legacy_hue_order = [self.split.neg_lc, legacy_one_end, legacy_both_ends]
-            legacy_palette = {self.split.neg_lc: "red", legacy_one_end: "blue", legacy_both_ends: "green"}
-            display_hue_order = [self.split.neg_lc, self.split.pos_lc]
-            display_palette = {self.split.neg_lc: "red", self.split.pos_lc: "blue"}
-            plot_df[hue_col] = self.split.neg_lc
-            plot_df.loc[plot_df[self.split.display_col], hue_col] = self.split.pos_lc
+            legacy_hue_order = [neg_lc, legacy_one_end, legacy_both_ends]
+            legacy_palette = {neg_lc: "red", legacy_one_end: "blue", legacy_both_ends: "green"}
+            display_hue_order = [neg_lc, pos_lc]
+            display_palette = {neg_lc: "red", pos_lc: "blue"}
+            # Map the display groups to their lowercase labels (these become the h5 column names,
+            # so they must stay the literal "non-mixed"/"mixed" strings for byte-identical output).
+            lc_map = {display_variant.neg: neg_lc, display_variant.pos: pos_lc}
+            plot_df[hue_col] = [lc_map[g] for g in display_variant.group_fn(plot_df)]
         else:
-            # CONSENSUS / NONE: N groups from read_group; no legacy start/end distinction, so the
-            # legacy plot equals the display plot.
-            plot_df_legacy[hue_col] = plot_df_legacy[self.split.group_col].astype(str)
-            plot_df[hue_col] = plot_df[self.split.group_col].astype(str)
-            legacy_hue_order = display_hue_order = list(self.split.groups)
-            palette = self._group_palette()
-            legacy_palette = display_palette = {str(k): v for k, v in palette.items()}
+            # N-group schemes: legacy plot equals the display plot (no start/end distinction).
+            plot_df_legacy[hue_col] = np.asarray(legacy_variant.group_fn(plot_df_legacy)).astype(str)
+            plot_df[hue_col] = np.asarray(display_variant.group_fn(plot_df)).astype(str)
+            legacy_hue_order = list(legacy_variant.groups)
+            display_hue_order = list(display_variant.groups)
+            legacy_palette = {str(k): v for k, v in self._variant_palette(legacy_variant).items()}
+            display_palette = {str(k): v for k, v in self._variant_palette(display_variant).items()}
+        legacy_col_name = legacy_variant.hist_col_name or self.tag_axis
+        display_col_name = display_variant.hist_col_name or self.tag_axis
         fig_legacy, ax_legacy = plt.subplots(figsize=(12, 7))
         g_legacy = sns.histplot(
             data=plot_df_legacy,
@@ -3158,7 +3112,7 @@ class SRSNVReport:
             ax=ax_legacy,
             palette=legacy_palette,
         )
-        hist_data_df_legacy = self._get_histogram_data(g_legacy, col_name=IS_MIXED)
+        hist_data_df_legacy = self._get_histogram_data(g_legacy, col_name=legacy_col_name)
         hist_data_df_legacy.to_hdf(self.output_h5_filename, key="quality_histogram", mode="a")
         plt.close(fig_legacy)
 
@@ -3184,8 +3138,8 @@ class SRSNVReport:
         ax.set_ylabel("Density")  # , fontsize=label_fontsize)
         ax.grid(visible=True)
         xlims = [0.99 * plot_df[QUAL].min(), plot_df[QUAL].max() * 1.01]
-        hist_data_df = self._get_histogram_data(g, col_name=IS_MIXED_START)
-        hist_data_df.to_hdf(self.output_h5_filename, key="quality_histogram_mixed_start", mode="a")
+        hist_data_df = self._get_histogram_data(g, col_name=display_col_name)
+        hist_data_df.to_hdf(self.output_h5_filename, key=split_h5_key("quality_histogram", display_variant), mode="a")
         if plot_interpolating_function:
             xs = np.arange(self.eps, np.floor(self.data_df[ML_QUAL_1_TEST].max()), 0.1)
             ax = axes[1]
@@ -3215,48 +3169,45 @@ class SRSNVReport:
         fig.tight_layout()
         self._save_plt(output_filename=output_filename, fig=fig)
 
-    def _plot_logit_histogram(self, plot_df, ax, alpha=0.4, mixed_col=None):
-        """Plot a single histogram of logit values, by: FP, TP positive-group, TP negative-group.
+    def _logit_extra_cols(self):
+        """Columns (besides read_group) that the active scheme's variant group_fns read, so the
+        logit-histogram slice includes them. Only columns present in data_df are returned.
 
-        Binary (MIXED/NONE) path: ``mixed_col`` selects which column defines a positive-group
-        ("mixed") read. Defaults to the mode's display split column; pass the legacy split column
-        for the legacy both-ends definition in ppmSeq mode.
+        Covers every scheme's raw group inputs (mixed: is_mixed/_start; consensus: fs/rs); a new
+        scheme should add its raw group columns here so its group_fn can run on the sliced frame."""
+        candidates = [IS_MIXED, IS_MIXED_START, FS, RS]
+        return [c for c in candidates if c in self.data_df.columns]
+
+    def _plot_logit_variant(self, plot_df, ax, variant, alpha=0.4):
+        """Plot one logit histogram for a variant: FP + one TP series per group.
+
+        Binary variants (``variant.pos`` set) reproduce the historical FP / TP {pos_lc} / TP {neg_lc}
+        series and palette (FP blue, neg red, pos green). N-group variants get one TP series per
+        group with a seaborn palette.
         """
-        if mixed_col is None:
-            mixed_col = self.split.display_col
-        tp_pos = f"TP {self.split.pos_lc}"
-        tp_neg = f"TP {self.split.neg_lc}"
-        plot_df[""] = plot_df[LABEL].astype(str)
-        plot_df.loc[~plot_df[LABEL], ""] = "FP"
-        plot_df.loc[plot_df[LABEL] & plot_df[mixed_col], ""] = tp_pos
-        plot_df.loc[plot_df[LABEL] & ~plot_df[mixed_col], ""] = tp_neg
+        grp = np.asarray(variant.group_fn(plot_df))
+        if variant.pos is not None:
+            tp_pos = f"TP {variant.pos_lc}"
+            tp_neg = f"TP {variant.neg_lc}"
+            plot_df[""] = plot_df[LABEL].astype(str)
+            plot_df.loc[~plot_df[LABEL], ""] = "FP"
+            plot_df.loc[plot_df[LABEL] & (grp == variant.pos), ""] = tp_pos
+            plot_df.loc[plot_df[LABEL] & (grp == variant.neg), ""] = tp_neg
+            hue_order = ["FP", tp_pos, tp_neg]
+            palette = {"FP": "tab:blue", tp_neg: "red", tp_pos: "green"}
+        else:
+            tp_labels = [f"TP {label}" for label in variant.groups]
+            plot_df[""] = "FP"
+            for label in variant.groups:
+                plot_df.loc[plot_df[LABEL] & (grp == label), ""] = f"TP {label}"
+            group_colors = list(sns.color_palette(n_colors=len(variant.groups)))
+            palette = {"FP": "tab:blue", **dict(zip(tp_labels, group_colors, strict=False))}
+            hue_order = ["FP", *tp_labels]
         sns.histplot(
             data=plot_df,
             x=ML_LOGIT_TEST,
             hue="",
-            hue_order=["FP", tp_pos, tp_neg],
-            palette={"FP": "tab:blue", tp_neg: "red", tp_pos: "green"},
-            element="step",
-            stat="density",
-            common_norm=False,
-            alpha=alpha,
-            ax=ax,
-        )
-
-    def _plot_logit_histogram_by_group(self, plot_df, ax, alpha=0.4):
-        """N-group logit histogram (consensus/none): FP + one TP series per read group."""
-        tp_labels = [f"TP {label}" for label in self.split.groups]
-        plot_df[""] = "FP"
-        grp = plot_df[self.split.group_col].astype(str)
-        for label in self.split.groups:
-            plot_df.loc[plot_df[LABEL] & (grp == label), ""] = f"TP {label}"
-        group_colors = list(sns.color_palette(n_colors=len(self.split.groups)))
-        palette = {"FP": "tab:blue", **dict(zip(tp_labels, group_colors, strict=False))}
-        sns.histplot(
-            data=plot_df,
-            x=ML_LOGIT_TEST,
-            hue="",
-            hue_order=["FP", *tp_labels],
+            hue_order=hue_order,
             palette=palette,
             element="step",
             stat="density",
@@ -3267,48 +3218,36 @@ class SRSNVReport:
 
     @exception_handler
     def plot_logit_histograms(self, *, plot_by_fold: bool = True, output_filename: str = None):
-        """Plot a histogram of logit values, by: FP, TP positive-group, TP negative-group.
+        """Plot a histogram of logit values, by: FP + one TP series per group.
         If plot_by_fold is True, overlay histograms for each fold.
         """
         # label_fontsize = 12
         # ticklabelsfontsize = 12
         logger.info("Plotting logit histogram")
 
-        is_consensus_mode = self.split.mode is ReportMode.CONSENSUS
-        if is_consensus_mode:
-            plot_df_all = self.data_df[[ML_LOGIT_TEST, LABEL, self.split.group_col, FOLD_ID]].copy()
-        else:
-            split_cols = list(dict.fromkeys([self.split.display_col, self.split.legacy_col]))
-            plot_df_all = self.data_df[[ML_LOGIT_TEST, LABEL, *split_cols, FOLD_ID]].copy()
+        plot_df_all = self.data_df[[ML_LOGIT_TEST, LABEL, READ_GROUP, FOLD_ID, *self._logit_extra_cols()]].copy()
+        legacy_variant = self.scheme.legacy_variant
+        display_variant = self._display_variant
 
-        def _plot_one(df, ax, alpha=0.4, *, use_display):
-            """use_display selects display vs legacy binary column (ignored in consensus mode)."""
-            if is_consensus_mode:
-                self._plot_logit_histogram_by_group(df, ax, alpha=alpha)
-            else:
-                col = self.split.display_col if use_display else self.split.legacy_col
-                self._plot_logit_histogram(df, ax, alpha=alpha, mixed_col=col)
-
-        # Legacy histogram data for backward-compatible h5 storage (consensus: same as display)
+        # Legacy histogram (legacy variant) for backward-compatible h5 storage.
         fig_legacy, ax_legacy = plt.subplots(figsize=(12, 7))
-        _plot_one(plot_df_all.copy(), ax_legacy, use_display=False)
+        self._plot_logit_variant(plot_df_all.copy(), ax_legacy, legacy_variant)
         hist_data_df_legacy = self._get_histogram_data(ax_legacy, col_name="")
         hist_data_df_legacy.to_hdf(self.output_h5_filename, key="logit_histogram", mode="a")
         plt.close(fig_legacy)
 
-        # New histogram (display groups) for display and new h5 key
+        # New histogram (display variant) for display and new h5 key
         fig, ax = plt.subplots(figsize=(12, 7))
-        plot_df = plot_df_all.copy()
-        _plot_one(plot_df, ax, use_display=True)
+        self._plot_logit_variant(plot_df_all.copy(), ax, display_variant)
         hist_data_df = self._get_histogram_data(ax, col_name="")
-        hist_data_df.to_hdf(self.output_h5_filename, key="logit_histogram_mixed_start", mode="a")
+        hist_data_df.to_hdf(self.output_h5_filename, key=split_h5_key("logit_histogram", display_variant), mode="a")
 
         if plot_by_fold:
             plt.close(fig)
             fig, ax = plt.subplots(figsize=(12, 7))
             plot_dfs = [plot_df_all[plot_df_all[FOLD_ID] == k] for k in range(len(self.models))]
             for plot_df in plot_dfs:
-                _plot_one(plot_df.copy(), ax, alpha=0.15, use_display=True)
+                self._plot_logit_variant(plot_df.copy(), ax, display_variant, alpha=0.15)
 
         sns.move_legend(
             ax,

--- a/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
@@ -4,6 +4,7 @@ import functools
 import json
 import os
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -36,17 +37,24 @@ from ugbio_ppmseq.ppmSeq_utils import PpmseqAdapterVersions, PpmseqCategories
 from ugbio_srsnv.shap_plotting import SHAPPlotter
 from ugbio_srsnv.smoothing_utils import AdaptiveKDEPrecisionEstimator
 from ugbio_srsnv.srsnv_utils import (
+    CONSENSUS_GROUPS,
     ET,
     ET_FILLNA,
+    IS_CONSENSUS,
     MAX_PHRED,
+    MIXED_GROUPS,
+    NONE_GROUP_ALL,
+    READ_GROUP,
     ST,
     ST_FILLNA,
-    add_is_mixed_to_featuremap_df,
+    ReportMode,
     construct_trinuc_context_with_alt,
+    detect_report_mode,
     get_base_recall_from_filters,
     phred_to_prob,
     prob_to_logit,
     prob_to_phred,
+    resolve_and_add_split_columns,
     safe_roc_auc,
     split_validation_training_preds,
 )
@@ -62,6 +70,105 @@ IS_MIXED = "is_mixed"
 IS_MIXED_START = "is_mixed_start"
 IS_MIXED_END = "is_mixed_end"
 FOLD_ID = "fold_id"
+
+
+@dataclass(frozen=True)
+class ReadSplit:
+    """Describes how the report splits reads into a positive/negative group.
+
+    The report supports several :class:`~ugbio_srsnv.srsnv_utils.ReportMode` values, each of
+    which splits the reads on a different boolean column and labels the two groups differently.
+    All split-dependent report methods consult a ``ReadSplit`` instead of hard-coding the
+    ppmSeq "mixed" columns/labels, so the same code produces correctly-labelled output for
+    every mode.
+
+    Attributes
+    ----------
+    mode : ReportMode
+        The detected report mode.
+    display_col : str
+        Boolean column driving the display (simplified) tables/plots and their `_mixed_start`
+        h5 keys. For MIXED this is ``is_mixed_start``; for CONSENSUS/NONE it is ``is_consensus``.
+    legacy_col : str
+        Boolean column driving the legacy (backward-compatible) h5 keys. For MIXED this is
+        ``is_mixed`` (both ends); for CONSENSUS/NONE it equals ``display_col`` (no start/end
+        distinction exists).
+    pos, neg : str
+        Capitalised labels for the positive / negative group of the *binary* split used by
+        MIXED (and NONE) mode (e.g. "Mixed"/"Non-mixed").
+    pos_lc, neg_lc : str
+        Lower-case variants of ``pos``/``neg`` used inside plot legends / column keys.
+    tag_axis : str
+        Axis/index label for the per-tag summary table ("ppmSeq tag" / "strand support").
+    groups : list[str]
+        Ordered display labels of the read groups this mode splits into. MIXED has 2
+        (``[neg, pos]``), CONSENSUS has 3 (single / one strand / duplex), NONE has 1.
+        Values match the categories written into the ``read_group`` column.
+    group_col : str
+        Name of the ordered-categorical column carrying the group label (``read_group``).
+
+    Notes
+    -----
+    MIXED mode carries a *dual* split — a legacy both-ends column (``is_mixed``) written to legacy
+    h5 keys and a display start column (``is_mixed_start``) written to ``*_mixed_start`` keys — which
+    a single ``read_group`` column cannot represent. Therefore MIXED (and NONE, for byte-identical
+    output) keep the original binary rendering via ``display_col``/``legacy_col``; only CONSENSUS
+    uses the N-group path driven by ``groups``/``group_col``.
+    """
+
+    mode: ReportMode
+    display_col: str
+    legacy_col: str
+    pos: str
+    neg: str
+    pos_lc: str
+    neg_lc: str
+    tag_axis: str
+    groups: list
+    group_col: str
+
+
+# Note: the split *columns* below keep the historical is_mixed* names for MIXED mode so that
+# all h5 keys and the deep-srsnv report path remain byte-for-byte backward compatible. Only the
+# display *labels* change per mode.
+MODE_SPLIT = {
+    ReportMode.MIXED: ReadSplit(
+        mode=ReportMode.MIXED,
+        display_col=IS_MIXED_START,
+        legacy_col=IS_MIXED,
+        pos="Mixed",
+        neg="Non-mixed",
+        pos_lc="mixed",
+        neg_lc="non-mixed",
+        tag_axis="ppmSeq tag",
+        groups=list(MIXED_GROUPS),
+        group_col=READ_GROUP,
+    ),
+    ReportMode.CONSENSUS: ReadSplit(
+        mode=ReportMode.CONSENSUS,
+        display_col=IS_CONSENSUS,
+        legacy_col=IS_CONSENSUS,
+        pos="Consensus",
+        neg="Non-consensus",
+        pos_lc="consensus",
+        neg_lc="non-consensus",
+        tag_axis="strand support",
+        groups=list(CONSENSUS_GROUPS),
+        group_col=READ_GROUP,
+    ),
+    ReportMode.NONE: ReadSplit(
+        mode=ReportMode.NONE,
+        display_col=IS_CONSENSUS,
+        legacy_col=IS_CONSENSUS,
+        pos="Mixed",
+        neg="Non-mixed",
+        pos_lc="mixed",
+        neg_lc="non-mixed",
+        tag_axis="ppmSeq tag",
+        groups=[NONE_GROUP_ALL],
+        group_col=READ_GROUP,
+    ),
+}
 EDIST = FeatureMapFields.EDIST.value
 SCORE = FeatureMapFields.BCSQ.value
 INDEX = FeatureMapFields.INDEX.value
@@ -76,7 +183,10 @@ edist_filter = f"{EDIST} <= 5"
 HQ_SNV_filter = f"{SCORE} >= 79"
 CSKP_SNV_filter = f"{SCORE} >= 100"
 read_end_filter = f"{INDEX} > 12 and {INDEX} < ({LENGTH} - 12)"
-mixed_read_filter = IS_MIXED  # TODO use adapter_version
+# LoD filters below reference IS_MIXED; in consensus mode the split column carries the
+# consensus flag, so these *_mixed_only filters become consensus-only. The LoD block in
+# create_report is currently disabled, so this has no live effect. TODO: use adapter_version.
+mixed_read_filter = IS_MIXED
 default_LoD_filters = {  # noqa: N816
     "no_filter": f"{SCORE} >= 0",
     "HQ_SNV": f"{HQ_SNV_filter} and {edist_filter}",
@@ -284,6 +394,7 @@ def create_srsnv_report_html(
     out_basename,
     srsnv_metadata_file,
     simple_pipeline=None,
+    split_mode: str = ReportMode.MIXED.value,
 ):
     if len(out_basename) > 0 and not out_basename.endswith("."):
         out_basename += "."
@@ -320,6 +431,7 @@ def create_srsnv_report_html(
         "qual_histogram": qual_histogram,
         "logit_histogram": logit_histogram,
         "calibration_fn_with_hist": calibration_fn_with_hist,
+        "split_mode": split_mode,
     }
 
     generate_report(
@@ -1549,15 +1661,23 @@ class SRSNVReport:
             logger.info(f"Adding {IS_FORWARD} column to data_df as negation of {REV}")
             self.data_df.loc[:, IS_FORWARD] = self.data_df[REV].astype(int) != 1
 
-        # Add is_mixed columns if they don't exist
-        if IS_MIXED not in self.data_df.columns:
-            logger.info(f"Adding {IS_MIXED}, {IS_MIXED_START} columns to data_df")
+        # Resolve the report split mode (mixed vs consensus vs none) and its labels.
+        # The mode may be provided by the caller (params["report_mode"], set by the CLI) or
+        # auto-detected from the columns present in the dataframe.
+        report_mode_param = self.params.get("report_mode")
+        self.report_mode = ReportMode(report_mode_param) if report_mode_param else detect_report_mode(self.data_df)
+        self.split = MODE_SPLIT[self.report_mode]
 
+        # Add the split column(s) if they don't exist yet (e.g. when SRSNVReport is constructed
+        # directly, without going through prepare_report which already adds them).
+        if self.split.display_col not in self.data_df.columns:
+            logger.info(f"Adding split column(s) for report mode {self.report_mode.value} to data_df")
             adapter_version = self.params.get("adapter_version", None)
             categorical_features = [f["name"] for f in self.srsnv_metadata["features"] if f.get("type") == "c"]
-            self.data_df = add_is_mixed_to_featuremap_df(
+            self.data_df, self.report_mode = resolve_and_add_split_columns(
                 self.data_df, adapter_version=adapter_version, categorical_features_names=categorical_features
             )
+            self.split = MODE_SPLIT[self.report_mode]
 
         # add logits to data_df
         self.data_df[ML_LOGIT_TEST] = prob_to_logit(
@@ -1570,6 +1690,28 @@ class SRSNVReport:
         _, preds_train = split_validation_training_preds(all_model_probs, fold_arr=self.data_df[FOLD_ID].to_numpy())
         self.data_df["ML_prob_train"] = preds_train
         self.data_df["ML_logit_train"] = prob_to_logit(preds_train, max_value=self.max_qual)
+
+    def _group_labels(self):
+        """Ordered list of read-group display labels for the current mode."""
+        return list(self.split.groups)
+
+    def _group_masks(self, data_df=None):
+        """Yield ``(label, boolean_mask)`` per read group, in order, for the given dataframe.
+
+        Masks come from the ordered ``read_group`` categorical. Used by the N-group (consensus)
+        report paths so every method splits reads the same way. Defaults to ``self.data_df``.
+        """
+        if data_df is None:
+            data_df = self.data_df
+        col = data_df[self.split.group_col]
+        for label in self.split.groups:
+            yield label, (col == label).to_numpy()
+
+    def _group_palette(self):
+        """A stable {label: color} mapping sized to the number of groups."""
+        labels = self.split.groups
+        colors = sns.color_palette(n_colors=len(labels))
+        return dict(zip(labels, colors, strict=False))
 
     def _save_plt(self, output_filename: str = None, fig=None, *, tight_layout=True, **kwargs):
         if output_filename is not None:
@@ -1738,7 +1880,9 @@ class SRSNVReport:
         return recall, fq
 
     @exception_handler
-    def plot_fq_recall(self, output_filename: str = None, *, only_calculate: bool = False, font_size: int = 24):
+    def plot_fq_recall(  # noqa: C901
+        self, output_filename: str = None, *, only_calculate: bool = False, font_size: int = 24
+    ):
         """Calculate precision and recall metrics for SRSNV quality thresholds.
 
         Parameters
@@ -1781,11 +1925,15 @@ class SRSNVReport:
             pr_df_legacy[f"FQ_{label}"] = fq
         pr_df_legacy.to_hdf(self.output_h5_filename, key="FQ_recall_LoD", mode="a")
 
-        # New conditions using IS_MIXED_START only
+        # New conditions: one curve per read group (consensus) or the binary positive group.
         conditions = {"all reads": None}
-        if IS_MIXED_START in self.data_df.columns:
-            if self.data_df[IS_MIXED_START].any():
-                conditions["mixed"] = self.data_df[IS_MIXED_START]
+        if self.split.mode is ReportMode.CONSENSUS:
+            for label, mask in self._group_masks():
+                if mask.any():
+                    conditions[label] = pd.Series(mask, index=self.data_df.index)
+        elif self.split.display_col in self.data_df.columns:
+            if self.data_df[self.split.display_col].any():
+                conditions[self.split.pos_lc] = self.data_df[self.split.display_col]
 
         if only_calculate:
             for label, condition in conditions.items():
@@ -1866,17 +2014,105 @@ class SRSNVReport:
             }
         return dataset_sizes
 
+    def _calc_run_info_table_by_group(self):
+        """Consensus/none: build run info + quality summary with one column per read group.
+
+        Writes the same 5 h5 keys as the binary path; legacy and display tables are identical
+        (no start/end distinction). Column/label order follows the ordered read groups.
+        """
+        version_info = {
+            ("Pipeline version", ""): (self.params.get("pipeline_version", None)),
+            ("Docker image", ""): self.params.get("docker_image", None),
+            ("Adapter version", ""): self.params.get("adapter_version", None),
+            ("Report created on", ""): datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        }
+        n_tp = self.data_df[LABEL].sum()
+        n_fp = (~self.data_df[LABEL]).sum()
+        general_info = {
+            ("Sample name", ""): self.base_name[:-1],
+            ("Median training read length", ""): np.median(self.data_df[LENGTH]),
+            ("Median training coverage", ""): np.median(self.data_df[READ_COUNT]),
+            ("Training set, % TP reads", ""): signif(self.data_df[LABEL].mean() * 100, 3),
+        }
+        for label, mask in self._group_masks():
+            tp_pct = (mask & self.data_df[LABEL].to_numpy()).sum() / n_tp if n_tp else np.nan
+            fp_pct = (mask & (~self.data_df[LABEL]).to_numpy()).sum() / n_fp if n_fp else np.nan
+            general_info[(f"{label} training reads", "% of TP")] = f"{signif(100 * tp_pct, 3)}%"
+            general_info[(f"{label} training reads", "% of FP")] = f"{signif(100 * fp_pct, 3)}%"
+
+        tp_df = self.data_df[self.data_df[LABEL]]
+        median_qual = tp_df[QUAL].median()
+        recall_at_0 = self._get_recall_at_snvq(snvq=0)
+        roc_auc_phred = prob_to_phred(
+            self._safe_roc_auc(self.data_df[LABEL], self.data_df[ML_PROB_1_TEST], name="run info total"),
+            max_value=self.max_qual,
+        )
+        snvq_thresholds = [50, 60, 70]
+        # Per-group stats keyed by group label
+        grp_median, grp_recall0, grp_recall, grp_roc = {}, {}, {}, {}
+        for label, mask in self._group_masks():
+            cond = pd.Series(mask, index=self.data_df.index)
+            grp_median[label] = tp_df[cond.loc[tp_df.index]][QUAL].median()
+            grp_recall0[label] = self._get_recall_at_snvq(snvq=0, condition=cond)
+            grp_recall[label] = {s: self._get_recall_at_snvq(snvq=s, condition=cond) for s in snvq_thresholds}
+            sub = self.data_df[mask]
+            grp_roc[label] = prob_to_phred(
+                self._safe_roc_auc(sub[LABEL], sub[ML_PROB_1_TEST], name=f"run info {label}"), max_value=self.max_qual
+            )
+
+        performance_info = {("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS)}
+        for label in self.split.groups:
+            performance_info[("Median SNVQ", label)] = signif(grp_median[label], SIG_DIGITS)
+        for snvq in snvq_thresholds:
+            performance_info[(f"Recall at SNVQ={snvq}", "All reads")] = signif(
+                self._get_recall_at_snvq(snvq=snvq) / recall_at_0, SIG_DIGITS
+            )
+            for label in self.split.groups:
+                denom = grp_recall0[label]
+                performance_info[(f"Recall at SNVQ={snvq}", label)] = signif(
+                    grp_recall[label][snvq] / denom if denom else np.nan, SIG_DIGITS
+                )
+        performance_info[("Pre-filter Recall", "All reads")] = signif(recall_at_0, SIG_DIGITS)
+        for label in self.split.groups:
+            performance_info[("Pre-filter Recall", label)] = signif(grp_recall0[label], SIG_DIGITS)
+        performance_info[("ROC AUC (Phred)", "All reads")] = signif(roc_auc_phred, SIG_DIGITS)
+        for label in self.split.groups:
+            performance_info[("ROC AUC (Phred)", label)] = signif(grp_roc[label], SIG_DIGITS)
+
+        training_info = {("Number of CV folds", ""): self.params["num_CV_folds"]}
+        dataset_sizes = self.get_dataset_sizes()
+        run_info_table = pd.Series({**general_info, **version_info}, name="")
+        run_quality_summary_table = pd.Series({**performance_info}, name="")
+        training_info_table = pd.Series({**training_info, **dataset_sizes}, name="")
+        # No legacy/both-ends distinction in consensus: write identical table to both keys.
+        run_info_table.to_hdf(self.output_h5_filename, key="run_info_table", mode="a")
+        run_info_table.to_hdf(self.output_h5_filename, key="run_info_table_mixed_start", mode="a")
+        run_quality_summary_table.to_hdf(self.output_h5_filename, key="run_quality_summary_table", mode="a")
+        run_quality_summary_table.to_hdf(self.output_h5_filename, key="run_quality_summary_table_mixed_start", mode="a")
+        training_info_table.to_hdf(self.output_h5_filename, key="training_info_table", mode="a")
+
     @exception_handler
     def calc_run_info_table(self):  # noqa: PLR0915
         """Calculate run_info_table, a table with general run information."""
         # Generate Run Info table
         logger.info("Generating Run Info table")
-        # Legacy mixed percent using IS_MIXED (both ends)
-        TP_mixed_percent_legacy = (self.data_df[IS_MIXED] & self.data_df[LABEL]).sum() / (self.data_df[LABEL].sum())  # noqa: N806
-        FP_mixed_percent_legacy = (self.data_df[IS_MIXED] & ~self.data_df[LABEL]).sum() / ((~self.data_df[LABEL]).sum())  # noqa: N806
-        # New mixed percent using IS_MIXED_START
-        TP_mixed_percent = (self.data_df[IS_MIXED_START] & self.data_df[LABEL]).sum() / (self.data_df[LABEL].sum())  # noqa: N806
-        FP_mixed_percent = (self.data_df[IS_MIXED_START] & ~self.data_df[LABEL]).sum() / ((~self.data_df[LABEL]).sum())  # noqa: N806
+        if self.split.mode is ReportMode.CONSENSUS:
+            self._calc_run_info_table_by_group()
+            return
+        # "positive-group" label for this mode (Mixed / Consensus). The report keeps two tables:
+        # a display table (mode's display_col) and a legacy backward-compatible one (legacy_col);
+        # in non-mixed modes both columns are identical.
+        pos = self.split.pos
+        display_col = self.split.display_col
+        legacy_col = self.split.legacy_col
+        n_tp = self.data_df[LABEL].sum()
+        n_fp = (~self.data_df[LABEL]).sum()
+        # Legacy positive-group percent using the legacy split column (IS_MIXED both ends for ppmSeq)
+        TP_mixed_percent_legacy = (self.data_df[legacy_col] & self.data_df[LABEL]).sum() / n_tp  # noqa: N806
+        FP_mixed_percent_legacy = (self.data_df[legacy_col] & ~self.data_df[LABEL]).sum() / n_fp  # noqa: N806
+        # New positive-group percent using the display split column
+        TP_mixed_percent = (self.data_df[display_col] & self.data_df[LABEL]).sum() / n_tp  # noqa: N806
+        FP_mixed_percent = (self.data_df[display_col] & ~self.data_df[LABEL]).sum() / n_fp  # noqa: N806
         general_info_base = {
             ("Sample name", ""): self.base_name[:-1],
             ("Median training read length", ""): np.median(self.data_df[LENGTH]),
@@ -1885,33 +2121,33 @@ class SRSNVReport:
         }
         general_info = {
             **general_info_base,
-            ("Mixed training reads", "% of TP"): f"{signif(100 * TP_mixed_percent, 3)}%",
-            ("Mixed training reads", "% of FP"): f"{signif(100 * FP_mixed_percent, 3)}%",
+            (f"{pos} training reads", "% of TP"): f"{signif(100 * TP_mixed_percent, 3)}%",
+            (f"{pos} training reads", "% of FP"): f"{signif(100 * FP_mixed_percent, 3)}%",
         }
         general_info_legacy = {
             **general_info_base,
-            ("Mixed training reads", "% of TP"): f"{signif(100 * TP_mixed_percent_legacy, 3)}%",
-            ("Mixed training reads", "% of FP"): f"{signif(100 * FP_mixed_percent_legacy, 3)}%",
+            (f"{pos} training reads", "% of TP"): f"{signif(100 * TP_mixed_percent_legacy, 3)}%",
+            (f"{pos} training reads", "% of FP"): f"{signif(100 * FP_mixed_percent_legacy, 3)}%",
         }
         # Performance info
-        mixed_start_df = self.data_df[self.data_df[IS_MIXED_START]]
-        mixed_both_df = self.data_df[self.data_df[IS_MIXED]]
+        mixed_start_df = self.data_df[self.data_df[display_col]]
+        mixed_both_df = self.data_df[self.data_df[legacy_col]]
         tp_df = self.data_df[self.data_df[LABEL]]
-        tp_mixed_start_df = tp_df[tp_df[IS_MIXED_START]]
-        tp_mixed_both_df = tp_df[tp_df[IS_MIXED]]
+        tp_mixed_start_df = tp_df[tp_df[display_col]]
+        tp_mixed_both_df = tp_df[tp_df[legacy_col]]
         median_qual = tp_df[QUAL].median()
         median_qual_mixed_start = tp_mixed_start_df[QUAL].median()
         median_qual_mixed_both = tp_mixed_both_df[QUAL].median()
         recall_at_0 = self._get_recall_at_snvq(snvq=0)
-        recall_at_0_mixed_start = self._get_recall_at_snvq(snvq=0, condition=self.data_df[IS_MIXED_START])
-        recall_at_0_mixed_both = self._get_recall_at_snvq(snvq=0, condition=self.data_df[IS_MIXED])
+        recall_at_0_mixed_start = self._get_recall_at_snvq(snvq=0, condition=self.data_df[display_col])
+        recall_at_0_mixed_both = self._get_recall_at_snvq(snvq=0, condition=self.data_df[legacy_col])
         snvq_thresholds = [50, 60, 70]
         recalls = {}
         for snvq in snvq_thresholds:
             recalls[snvq] = {
                 "all": self._get_recall_at_snvq(snvq=snvq),
-                "mixed_start": self._get_recall_at_snvq(snvq=snvq, condition=self.data_df[IS_MIXED_START]),
-                "mixed_both": self._get_recall_at_snvq(snvq=snvq, condition=self.data_df[IS_MIXED]),
+                "mixed_start": self._get_recall_at_snvq(snvq=snvq, condition=self.data_df[display_col]),
+                "mixed_both": self._get_recall_at_snvq(snvq=snvq, condition=self.data_df[legacy_col]),
             }
         roc_auc_phred = prob_to_phred(
             self._safe_roc_auc(self.data_df[LABEL], self.data_df[ML_PROB_1_TEST], name="run info total"),
@@ -1929,42 +2165,43 @@ class SRSNVReport:
         # each metric having all its categories together before the next metric appears.
         performance_info = {
             ("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS),
-            ("Median SNVQ", "Mixed"): signif(median_qual_mixed_start, SIG_DIGITS),
+            ("Median SNVQ", pos): signif(median_qual_mixed_start, SIG_DIGITS),
         }
         for snvq in snvq_thresholds:
             performance_info[(f"Recall at SNVQ={snvq}", "All reads")] = signif(
                 recalls[snvq]["all"] / recall_at_0, SIG_DIGITS
             )
-            performance_info[(f"Recall at SNVQ={snvq}", "Mixed")] = signif(
+            performance_info[(f"Recall at SNVQ={snvq}", pos)] = signif(
                 recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
             )
         performance_info[("Pre-filter Recall", "All reads")] = signif(recall_at_0, SIG_DIGITS)
-        performance_info[("Pre-filter Recall", "Mixed")] = signif(recall_at_0_mixed_start, SIG_DIGITS)
+        performance_info[("Pre-filter Recall", pos)] = signif(recall_at_0_mixed_start, SIG_DIGITS)
         performance_info[("ROC AUC (Phred)", "All reads")] = signif(roc_auc_phred, SIG_DIGITS)
-        performance_info[("ROC AUC (Phred)", "Mixed")] = signif(roc_auc_phred_mixed_start, SIG_DIGITS)
+        performance_info[("ROC AUC (Phred)", pos)] = signif(roc_auc_phred_mixed_start, SIG_DIGITS)
 
-        # Legacy performance info with 3-way split for backward-compatible h5 storage
+        # Legacy performance info with 3-way split for backward-compatible h5 storage.
+        # In non-mixed modes the "start" and "both ends" sub-splits are identical.
         performance_info_legacy = {
             ("Median SNVQ", "All reads"): signif(median_qual, SIG_DIGITS),
-            ("Median SNVQ", "Mixed, start"): signif(median_qual_mixed_start, SIG_DIGITS),
-            ("Median SNVQ", "Mixed, both ends"): signif(median_qual_mixed_both, SIG_DIGITS),
+            ("Median SNVQ", f"{pos}, start"): signif(median_qual_mixed_start, SIG_DIGITS),
+            ("Median SNVQ", f"{pos}, both ends"): signif(median_qual_mixed_both, SIG_DIGITS),
         }
         for snvq in snvq_thresholds:
             performance_info_legacy[(f"Recall at SNVQ={snvq}", "All reads")] = signif(
                 recalls[snvq]["all"] / recall_at_0, SIG_DIGITS
             )
-            performance_info_legacy[(f"Recall at SNVQ={snvq}", "Mixed, start")] = signif(
+            performance_info_legacy[(f"Recall at SNVQ={snvq}", f"{pos}, start")] = signif(
                 recalls[snvq]["mixed_start"] / recall_at_0_mixed_start, SIG_DIGITS
             )
-            performance_info_legacy[(f"Recall at SNVQ={snvq}", "Mixed, both ends")] = signif(
+            performance_info_legacy[(f"Recall at SNVQ={snvq}", f"{pos}, both ends")] = signif(
                 recalls[snvq]["mixed_both"] / recall_at_0_mixed_both, SIG_DIGITS
             )
         performance_info_legacy[("Pre-filter Recall", "All reads")] = signif(recall_at_0, SIG_DIGITS)
-        performance_info_legacy[("Pre-filter Recall", "Mixed, start")] = signif(recall_at_0_mixed_start, SIG_DIGITS)
-        performance_info_legacy[("Pre-filter Recall", "Mixed, both ends")] = signif(recall_at_0_mixed_both, SIG_DIGITS)
+        performance_info_legacy[("Pre-filter Recall", f"{pos}, start")] = signif(recall_at_0_mixed_start, SIG_DIGITS)
+        performance_info_legacy[("Pre-filter Recall", f"{pos}, both ends")] = signif(recall_at_0_mixed_both, SIG_DIGITS)
         performance_info_legacy[("ROC AUC (Phred)", "All reads")] = signif(roc_auc_phred, SIG_DIGITS)
-        performance_info_legacy[("ROC AUC (Phred)", "Mixed, start")] = signif(roc_auc_phred_mixed_start, SIG_DIGITS)
-        performance_info_legacy[("ROC AUC (Phred)", "Mixed, both ends")] = signif(roc_auc_phred_mixed_both, SIG_DIGITS)
+        performance_info_legacy[("ROC AUC (Phred)", f"{pos}, start")] = signif(roc_auc_phred_mixed_start, SIG_DIGITS)
+        performance_info_legacy[("ROC AUC (Phred)", f"{pos}, both ends")] = signif(roc_auc_phred_mixed_both, SIG_DIGITS)
         # Info about versions
         version_info = {
             ("Pipeline version", ""): (self.params.get("pipeline_version", None)),
@@ -2109,152 +2346,111 @@ class SRSNVReport:
         num_cv_folds = self.params["num_CV_folds"]
         holdout_fold_cond = self.data_df[FOLD_ID].isna()
 
-        def _calc_roc_auc_dict(mix_condition, label_suffix=""):
-            auc_total = prob_to_phred(
-                self._safe_roc_auc(self.data_df[LABEL], self.data_df[ML_PROB_1_TEST], name=f"total{label_suffix}"),
-                max_value=self.max_qual,
-            )
-            auc_mixed = prob_to_phred(
-                self._safe_roc_auc(
-                    self.data_df.loc[mix_condition, LABEL],
-                    self.data_df.loc[mix_condition, ML_PROB_1_TEST],
-                    name=f"mixed{label_suffix}",
-                ),
-                max_value=self.max_qual,
-            )
-            auc_non_mixed = prob_to_phred(
-                self._safe_roc_auc(
-                    self.data_df.loc[~mix_condition, LABEL],
-                    self.data_df.loc[~mix_condition, ML_PROB_1_TEST],
-                    name=f"non-mixed{label_suffix}",
-                ),
-                max_value=self.max_qual,
-            )
-            auc_per_fold = []
-            auc_per_fold_mixed = []
-            auc_per_fold_non_mixed = []
-            auc_on_holdout = []
-            auc_on_holdout_mixed = []
-            auc_on_holdout_non_mixed = []
-            error_on_holdout = []
+        def _calc_roc_auc_dict(groups, label_suffix=""):  # noqa: C901
+            """Compute ROC-AUC stats for the whole set plus each group in ``groups``.
+
+            ``groups`` is an ordered list of ``(name, boolean_mask)``. The returned dict maps each
+            statistic to a list ``[total, *per_group]`` aligned with ``["Total", *group_names]``.
+            """
+            data_df = self.data_df
+
+            def _auc(mask, name):
+                sub = data_df.loc[mask]
+                return prob_to_phred(
+                    self._safe_roc_auc(sub[LABEL], sub[ML_PROB_1_TEST], name=name), max_value=self.max_qual
+                )
+
+            all_mask = np.ones(len(data_df), dtype=bool)
+            auc_total = _auc(all_mask, f"total{label_suffix}")
+            auc_per_group = [_auc(mask, f"{gname}{label_suffix}") for gname, mask in groups]
+
+            auc_per_fold_total = []
+            auc_per_fold_groups = [[] for _ in groups]
+            auc_on_holdout_total = []
+            auc_on_holdout_groups = [[] for _ in groups]
+            # Track which series (by name) already produced a NaN on holdout, to stop recomputing.
+            error_on_holdout = set()
             for k in range(num_cv_folds):
-                fold_cond = self.data_df[FOLD_ID] == k
-                mix_fold_cond = fold_cond & mix_condition
-                nonmix_fold_cond = fold_cond & ~mix_condition
-                auc_per_fold.append(
-                    prob_to_phred(
-                        self._safe_roc_auc(
-                            self.data_df.loc[fold_cond, LABEL],
-                            self.data_df.loc[fold_cond, ML_PROB_1_TEST],
-                            name=f"fold {k} total{label_suffix}",
-                        )
-                    )
-                )
-                auc_per_fold_mixed.append(
-                    prob_to_phred(
-                        self._safe_roc_auc(
-                            self.data_df.loc[mix_fold_cond, LABEL],
-                            self.data_df.loc[mix_fold_cond, ML_PROB_1_TEST],
-                            name=f"fold {k} mixed{label_suffix}",
-                        ),
-                        max_value=self.max_qual,
-                    )
-                )
-                auc_per_fold_non_mixed.append(
-                    prob_to_phred(
-                        self._safe_roc_auc(
-                            self.data_df.loc[nonmix_fold_cond, LABEL],
-                            self.data_df.loc[nonmix_fold_cond, ML_PROB_1_TEST],
-                            name=f"fold {k} non-mixed{label_suffix}",
-                        ),
-                        max_value=self.max_qual,
-                    )
-                )
+                fold_cond = (data_df[FOLD_ID] == k).to_numpy()
+                auc_per_fold_total.append(_auc(fold_cond, f"fold {k} total{label_suffix}"))
+                for gi, (gname, mask) in enumerate(groups):
+                    auc_per_fold_groups[gi].append(_auc(fold_cond & mask, f"fold {k} {gname}{label_suffix}"))
                 if holdout_fold_cond.sum() > holdout_fold_size_thresh:
+                    ho = holdout_fold_cond.to_numpy()
+                    preds_ho = data_df.loc[ho, f"prob_fold_{k}"]
                     if "total" not in error_on_holdout:
-                        preds = self.data_df.loc[holdout_fold_cond, f"prob_fold_{k}"]
-                        auc_on_holdout.append(
-                            prob_to_phred(
-                                self._safe_roc_auc(
-                                    self.data_df.loc[holdout_fold_cond, LABEL],
-                                    preds,
-                                    name=f"holdout total{label_suffix}",
-                                )
-                            )
+                        val = prob_to_phred(
+                            self._safe_roc_auc(data_df.loc[ho, LABEL], preds_ho, name=f"holdout total{label_suffix}")
                         )
-                        if np.isnan(auc_on_holdout[-1]):
-                            error_on_holdout.append("total")
+                        auc_on_holdout_total.append(val)
+                        if np.isnan(val):
+                            error_on_holdout.add("total")
                     else:
-                        auc_on_holdout.append(np.nan)
-                    mix_holdout_cond = holdout_fold_cond & mix_condition
-                    nonmix_holdout_cond = holdout_fold_cond & ~mix_condition
-                    if "mixed" not in error_on_holdout:
-                        preds = self.data_df.loc[mix_holdout_cond, f"prob_fold_{k}"]
-                        auc_on_holdout_mixed.append(
-                            prob_to_phred(
+                        auc_on_holdout_total.append(np.nan)
+                    for gi, (gname, mask) in enumerate(groups):
+                        if gname not in error_on_holdout:
+                            gho = ho & mask
+                            val = prob_to_phred(
                                 self._safe_roc_auc(
-                                    self.data_df.loc[mix_holdout_cond, LABEL],
-                                    preds,
-                                    name=f"holdout mixed{label_suffix}",
+                                    data_df.loc[gho, LABEL],
+                                    data_df.loc[gho, f"prob_fold_{k}"],
+                                    name=f"holdout {gname}{label_suffix}",
                                 ),
                                 max_value=self.max_qual,
                             )
-                        )
-                        if np.isnan(auc_on_holdout_mixed[-1]):
-                            error_on_holdout.append("mixed")
-                    else:
-                        auc_on_holdout_mixed.append(np.nan)
-                    if "nonmixed" not in error_on_holdout:
-                        preds = self.data_df.loc[nonmix_holdout_cond, f"prob_fold_{k}"]
-                        auc_on_holdout_non_mixed.append(
-                            prob_to_phred(
-                                self._safe_roc_auc(
-                                    self.data_df.loc[nonmix_holdout_cond, LABEL],
-                                    preds,
-                                    name=f"holdout non-mixed{label_suffix}",
-                                ),
-                                max_value=self.max_qual,
-                            )
-                        )
-                        if np.isnan(auc_on_holdout_non_mixed[-1]):
-                            error_on_holdout.append("nonmixed")
+                            auc_on_holdout_groups[gi].append(val)
+                            if np.isnan(val):
+                                error_on_holdout.add(gname)
+                        else:
+                            auc_on_holdout_groups[gi].append(np.nan)
 
             result = {
-                "ROC AUC": [auc_total, auc_mixed, auc_non_mixed],
+                "ROC AUC": [auc_total, *auc_per_group],
                 "ROC AUC per fold mean": [
-                    np.array(auc_per_fold).mean(),
-                    np.array(auc_per_fold_mixed).mean(),
-                    np.array(auc_per_fold_non_mixed).mean(),
+                    np.array(auc_per_fold_total).mean(),
+                    *[np.array(g).mean() for g in auc_per_fold_groups],
                 ],
                 "ROC AUC per fold std": [
-                    np.array(auc_per_fold).std(),
-                    np.array(auc_per_fold_mixed).std(),
-                    np.array(auc_per_fold_non_mixed).std(),
+                    np.array(auc_per_fold_total).std(),
+                    *[np.array(g).std() for g in auc_per_fold_groups],
                 ],
             }
             if holdout_fold_cond.sum() > holdout_fold_size_thresh:
                 result["ROC AUC on holdout mean"] = [
-                    np.array(auc_on_holdout).mean(),
-                    np.array(auc_on_holdout_mixed).mean(),
-                    np.array(auc_on_holdout_non_mixed).mean(),
+                    np.array(auc_on_holdout_total).mean(),
+                    *[np.array(g).mean() for g in auc_on_holdout_groups],
                 ]
                 result["ROC AUC on holdout std"] = [
-                    np.array(auc_on_holdout).std(),
-                    np.array(auc_on_holdout_mixed).std(),
-                    np.array(auc_on_holdout_non_mixed).std(),
+                    np.array(auc_on_holdout_total).std(),
+                    *[np.array(g).std() for g in auc_on_holdout_groups],
                 ]
             return result
 
-        # Legacy table using IS_MIXED (both ends) for backward compatibility
-        auc_table_dict_legacy = _calc_roc_auc_dict(self.data_df[IS_MIXED], label_suffix=" legacy")
-        pd.DataFrame(auc_table_dict_legacy, index=["Total", "Mixed only", "Non-mixed only"]).T.to_hdf(
-            self.output_h5_filename, key="roc_auc_table", mode="a"
-        )
-        # New table using IS_MIXED_START
-        auc_table_dict = _calc_roc_auc_dict(self.data_df[IS_MIXED_START])
-        pd.DataFrame(auc_table_dict, index=["Total", "Mixed only", "Non-mixed only"]).T.to_hdf(
-            self.output_h5_filename, key="roc_auc_table_mixed_start", mode="a"
-        )
+        if self.split.mode is ReportMode.CONSENSUS:
+            # N-group split: one row per read group, in the group order.
+            groups = list(self._group_masks())
+            auc_index = ["Total", *[f"{label} only" for label in self.split.groups]]
+            # Consensus has no legacy/both-ends distinction; write the same table to both keys.
+            auc_dict = _calc_roc_auc_dict(groups)
+            pd.DataFrame(auc_dict, index=auc_index).T.to_hdf(self.output_h5_filename, key="roc_auc_table", mode="a")
+            pd.DataFrame(auc_dict, index=auc_index).T.to_hdf(
+                self.output_h5_filename, key="roc_auc_table_mixed_start", mode="a"
+            )
+        else:
+            # MIXED / NONE binary split: keep the historical pos/neg row order and labels.
+            auc_index = ["Total", f"{self.split.pos} only", f"{self.split.neg} only"]
+            legacy_mask = self.data_df[self.split.legacy_col].to_numpy()
+            legacy_groups = [(self.split.pos, legacy_mask), (self.split.neg, ~legacy_mask)]
+            auc_table_dict_legacy = _calc_roc_auc_dict(legacy_groups, label_suffix=" legacy")
+            pd.DataFrame(auc_table_dict_legacy, index=auc_index).T.to_hdf(
+                self.output_h5_filename, key="roc_auc_table", mode="a"
+            )
+            display_mask = self.data_df[self.split.display_col].to_numpy()
+            display_groups = [(self.split.pos, display_mask), (self.split.neg, ~display_mask)]
+            auc_table_dict = _calc_roc_auc_dict(display_groups)
+            pd.DataFrame(auc_table_dict, index=auc_index).T.to_hdf(
+                self.output_h5_filename, key="roc_auc_table_mixed_start", mode="a"
+            )
 
     @exception_handler
     def calc_run_quality_table(
@@ -2273,6 +2469,55 @@ class SRSNVReport:
             qual_stat_ps = [0.05, 0.1, 0.25, 0.5, 0.75, 0.90, 0.95]
         if cols_for_stats is None:
             cols_for_stats = {QUAL: QUAL, ML_QUAL_1_TEST: "ML_qual", ML_LOGIT_TEST: "ML_logit"}
+        logger.info("Generating Run Quality table")
+
+        def _quality_table(conds_dict):
+            """Describe QUAL/ML_qual/ML_logit per condition and stack into a table (drop 'count')."""
+            stats = pd.concat(
+                [
+                    self.data_df.loc[cond, list(cols_for_stats.keys())]
+                    .describe(percentiles=qual_stat_ps)
+                    .rename(columns={stat_key: stat_name + key for stat_key, stat_name in cols_for_stats.items()})
+                    for key, cond in conds_dict.items()
+                ],
+                axis=1,
+            )
+            return pd.DataFrame(signif(stats.values, SIG_DIGITS), index=stats.index, columns=stats.columns).drop(
+                index="count"
+            )
+
+        base_conds = {
+            "": np.ones(self.data_df[LABEL].shape, dtype=bool),
+            "_TP": self.data_df[LABEL].to_numpy(),
+            "_FP": (~self.data_df[LABEL]).to_numpy(),
+        }
+
+        if self.split.mode is ReportMode.CONSENSUS:
+            # N-group split: one TP column per read group. The internal join keys use the group
+            # label directly (kept literal for col_order); display uses the same labels.
+            tp = self.data_df[LABEL].to_numpy()
+            conds = dict(base_conds)
+            for label, mask in self._group_masks():
+                conds[f"_TP_{label}"] = mask & tp
+            run_quality_table = _quality_table(conds)
+            display_columns = []
+            for qcol in (QUAL, "ML_qual"):
+                display_columns.append((qcol, "FP", ""))
+                display_columns.append((qcol, "TP", "overall"))
+                for label in self.split.groups:
+                    display_columns.append((qcol, "TP", label))
+            col_order = [
+                "_".join(cols) if cols[2] not in ["", "overall"] else "_".join(cols[:2]) for cols in display_columns
+            ]
+            run_quality_table_display = run_quality_table.loc[:, col_order].copy()
+            run_quality_table_display.columns = pd.MultiIndex.from_tuples(display_columns)
+            # Consensus has no legacy/both-ends distinction: same table to both keys.
+            run_quality_table.T.to_hdf(self.output_h5_filename, key="run_quality_table", mode="a")
+            run_quality_table.T.to_hdf(self.output_h5_filename, key="run_quality_table_mixed_start", mode="a")
+            run_quality_table_display.to_hdf(self.output_h5_filename, key="run_quality_table_display", mode="a")
+            return
+
+        # MIXED / NONE binary split — unchanged historical output.
         if display_columns is None:
             display_columns = [
                 (QUAL, "FP", ""),
@@ -2284,66 +2529,103 @@ class SRSNVReport:
                 ("ML_qual", "TP", "mixed"),
                 ("ML_qual", "TP", "non-mixed"),
             ]
-
-        logger.info("Generating Run Quality table")
-        # Legacy table using IS_MIXED (both ends) for backward-compatible h5 storage
+        # Note: the "_TP_mixed"/"_TP_non-mixed" keys below are internal join keys (matched by
+        # col_order); they stay literal regardless of mode. Only the displayed MultiIndex labels
+        # are swapped to the mode's split labels further down.
+        # Legacy table using the legacy split column (IS_MIXED both ends for ppmSeq)
         conds_dict_legacy = {
-            "": np.ones(self.data_df[LABEL].shape, dtype=bool),
-            "_TP": self.data_df[LABEL],
-            "_FP": ~self.data_df[LABEL],
-            "_TP_mixed": np.logical_and(self.data_df[IS_MIXED], self.data_df[LABEL]),
-            "_TP_non-mixed": np.logical_and(~self.data_df[IS_MIXED], self.data_df[LABEL]),
+            **base_conds,
+            "_TP_mixed": np.logical_and(self.data_df[self.split.legacy_col], self.data_df[LABEL]),
+            "_TP_non-mixed": np.logical_and(~self.data_df[self.split.legacy_col], self.data_df[LABEL]),
         }
-        qual_stats_legacy = pd.concat(
-            [
-                self.data_df.loc[cond, list(cols_for_stats.keys())]
-                .describe(percentiles=qual_stat_ps)
-                .rename(columns={stat_key: stat_name + key for stat_key, stat_name in cols_for_stats.items()})
-                for key, cond in conds_dict_legacy.items()
-            ],
-            axis=1,
-        )
-        run_quality_table_legacy = pd.DataFrame(
-            signif(qual_stats_legacy.values, SIG_DIGITS),
-            index=qual_stats_legacy.index,
-            columns=qual_stats_legacy.columns,
-        ).drop(index="count")
-        run_quality_table_legacy.T.to_hdf(self.output_h5_filename, key="run_quality_table", mode="a")
+        _quality_table(conds_dict_legacy).T.to_hdf(self.output_h5_filename, key="run_quality_table", mode="a")
 
-        # New table using IS_MIXED_START for display and new h5 key
+        # New table using the display split column for display and new h5 key
         conds_dict = {
-            "": np.ones(self.data_df[LABEL].shape, dtype=bool),
-            "_TP": self.data_df[LABEL],
-            "_FP": ~self.data_df[LABEL],
-            "_TP_mixed": np.logical_and(self.data_df[IS_MIXED_START], self.data_df[LABEL]),
-            "_TP_non-mixed": np.logical_and(~self.data_df[IS_MIXED_START], self.data_df[LABEL]),
+            **base_conds,
+            "_TP_mixed": np.logical_and(self.data_df[self.split.display_col], self.data_df[LABEL]),
+            "_TP_non-mixed": np.logical_and(~self.data_df[self.split.display_col], self.data_df[LABEL]),
         }
-        qual_stats_description = {
-            key: self.data_df.loc[cond, list(cols_for_stats.keys())]
-            .describe(percentiles=qual_stat_ps)
-            .rename(columns={stat_key: stat_name + key for stat_key, stat_name in cols_for_stats.items()})
-            for key, cond in conds_dict.items()
-        }
-
-        qual_stats_description = pd.concat(list(qual_stats_description.values()), axis=1)
-        run_quality_table = pd.DataFrame(
-            signif(qual_stats_description.values, SIG_DIGITS),
-            index=qual_stats_description.index,
-            columns=qual_stats_description.columns,
-        ).drop(index="count")
+        run_quality_table = _quality_table(conds_dict)
 
         col_order = [
             "_".join(cols) if cols[2] not in ["", "overall"] else "_".join(cols[:2]) for cols in display_columns
         ]
         run_quality_table_display = run_quality_table.loc[:, col_order].copy()
-        run_quality_table_display.columns = pd.MultiIndex.from_tuples(display_columns)
+        # Swap the literal "mixed"/"non-mixed" display labels for this mode's split labels
+        # (the join keys used for col_order above stay literal).
+        label_remap = {"mixed": self.split.pos_lc, "non-mixed": self.split.neg_lc}
+        display_columns_relabeled = [(a, b, label_remap.get(c, c)) for a, b, c in display_columns]
+        run_quality_table_display.columns = pd.MultiIndex.from_tuples(display_columns_relabeled)
         # Log in hdf5
         run_quality_table.T.to_hdf(self.output_h5_filename, key="run_quality_table_mixed_start", mode="a")
         run_quality_table_display.to_hdf(self.output_h5_filename, key="run_quality_table_display", mode="a")
 
+    def _render_summary_table_figure(self, summary_df: pd.DataFrame, output_filename: str = None):
+        """Render a 2-column (Median SNVQ, % of reads) summary table as a matplotlib figure."""
+        fig, ax = plt.subplots(figsize=(6, max(2, 0.6 * len(summary_df) + 1)))
+        ax.axis("off")
+        table = ax.table(
+            cellText=summary_df.values,
+            rowLabels=summary_df.index,
+            colLabels=summary_df.columns,
+            cellLoc="center",
+            rowLoc="center",
+            loc="center",
+        )
+        _disable_auto_fontsize = False
+        table.auto_set_font_size(_disable_auto_fontsize)
+        table.set_fontsize(12)
+        table.scale(1.2, 1.8)
+        # Style header row
+        for j in range(len(summary_df.columns)):
+            table[0, j].set_facecolor("#4472C4")
+            table[0, j].set_text_props(color="white", fontweight="bold")
+        # Style row labels
+        for i in range(len(summary_df)):
+            table[i + 1, -1].set_facecolor("#D9E2F3")
+        self._save_plt(output_filename, fig=fig)
+
+    def _quality_per_split_group(self, output_filename: str = None):
+        """Consensus/none mode: median SNVQ and % of reads per read group (N rows).
+
+        Mirrors the mixed-mode 1D table shape and h5 keys, but groups TP reads by the ordered
+        ``read_group`` column (e.g. single read / one strand / duplex) instead of the ppmSeq tag.
+        """
+        data_df_tp = self.data_df[self.data_df[LABEL]].copy()
+        total_count = len(data_df_tp)
+        # Group by the ordered read_group categorical; reindex to keep group order and include
+        # any empty groups as 0 rows.
+        grouped = data_df_tp.groupby(self.split.group_col, dropna=False, observed=False)[QUAL]
+        median_qual = grouped.median().reindex(self.split.groups)
+        pct_reads = (grouped.count().reindex(self.split.groups).fillna(0) / total_count) * 100
+        summary_df = pd.DataFrame({"Median SNVQ": median_qual, "% of reads": pct_reads})
+        summary_df.index = summary_df.index.astype(str)
+        summary_df.index.name = self.split.tag_axis
+        summary_df["Median SNVQ"] = summary_df["Median SNVQ"].apply(lambda x: signif(x, 3))
+        summary_df["% of reads"] = summary_df["% of reads"].apply(lambda x: signif(x, 2))
+
+        # New simplified table -> same key/PNG as the mixed-mode display table.
+        summary_df.to_hdf(self.output_h5_filename, key="ppmseq_category_quality_table_mixed_start", mode="a")
+        # Write the same summary to the legacy 2D keys so downstream keys_to_convert / h5->json
+        # conversion finds them (no start x end cross-tab exists in this mode).
+        summary_df["Median SNVQ"].to_hdf(self.output_h5_filename, key="ppmseq_category_quality_table", mode="a")
+        summary_df["% of reads"].to_hdf(self.output_h5_filename, key="ppmseq_category_quantity_table", mode="a")
+
+        self._render_summary_table_figure(summary_df, output_filename=output_filename)
+
     @exception_handler
     def quality_per_ppmseq_tags(self, output_filename: str = None):  # noqa: C901, PLR0915
-        """Generate table of median quality and data quantity per start ppmseq tag."""
+        """Generate table of median quality and data quantity per read-split group.
+
+        In MIXED mode this is the per-ppmSeq-tag table (start tag, and legacy start x end
+        cross-tab). In CONSENSUS/NONE mode there is no ppmSeq tag, so it falls back to a per
+        split-group (e.g. Consensus / Non-consensus) summary with the same shape and h5 keys.
+        """
+        if self.split.mode is not ReportMode.MIXED:
+            self._quality_per_split_group(output_filename=output_filename)
+            return
+
         data_df_tp = self.data_df[self.data_df[LABEL]].copy()
         # Determine start and end tag columns
         ppmseq_fillna_tags_in_data = ST_FILLNA in data_df_tp.columns and ET_FILLNA in data_df_tp.columns
@@ -2408,7 +2690,7 @@ class SRSNVReport:
             pct_reads = pct_reads.drop(index=PpmseqCategories.END_UNREACHED.value)
         summary_df = pd.DataFrame({"Median SNVQ": median_qual, "% of reads": pct_reads})
         summary_df.index = summary_df.index.astype(str)
-        summary_df.index.name = "ppmSeq tag"
+        summary_df.index.name = self.split.tag_axis
         summary_df["Median SNVQ"] = summary_df["Median SNVQ"].apply(lambda x: signif(x, 3))
         summary_df["% of reads"] = summary_df["% of reads"].apply(lambda x: signif(x, 2))
 
@@ -2416,28 +2698,7 @@ class SRSNVReport:
         summary_df.to_hdf(self.output_h5_filename, key="ppmseq_category_quality_table_mixed_start", mode="a")
 
         # Render as a table figure
-        fig, ax = plt.subplots(figsize=(6, max(2, 0.6 * len(summary_df) + 1)))
-        ax.axis("off")
-        table = ax.table(
-            cellText=summary_df.values,
-            rowLabels=summary_df.index,
-            colLabels=summary_df.columns,
-            cellLoc="center",
-            rowLoc="center",
-            loc="center",
-        )
-        _disable_auto_fontsize = False
-        table.auto_set_font_size(_disable_auto_fontsize)
-        table.set_fontsize(12)
-        table.scale(1.2, 1.8)
-        # Style header row
-        for j in range(len(summary_df.columns)):
-            table[0, j].set_facecolor("#4472C4")
-            table[0, j].set_text_props(color="white", fontweight="bold")
-        # Style row labels
-        for i in range(len(summary_df)):
-            table[i + 1, -1].set_facecolor("#D9E2F3")
-        self._save_plt(output_filename, fig=fig)
+        self._render_summary_table_figure(summary_df, output_filename=output_filename)
 
     @exception_handler
     def training_progress_plot(self, output_filename: str = None, ylims=None):
@@ -2622,6 +2883,17 @@ class SRSNVReport:
     ):
         logger.info("Calculating trinuc context statistics")
 
+        # In consensus (N-group) mode, split the quality panel by the ordered read_group column;
+        # otherwise keep the historical ppmSeq is_mixed split (byte-identical output).
+        if self.split.mode is ReportMode.CONSENSUS:
+            split_col = self.split.group_col
+            palette = self._group_palette()
+            # calc_trinuc_stats names group columns "mixed=<group value>"; match that prefix.
+            group_specs = [(f"mixed={label}", label, palette[label]) for label in self.split.groups]
+        else:
+            split_col = IS_MIXED
+            group_specs = None
+
         # Call the new plotting function
         fig, stats_df = calc_and_plot_trinuc_hist(
             self.data_df,
@@ -2637,23 +2909,35 @@ class SRSNVReport:
             motif_orientation=motif_orientation,
             q1=0.1,
             q2=0.9,
+            split_col=split_col,
+            group_specs=group_specs,
         )
         stats_df.to_hdf(self.output_h5_filename, key="trinuc_stats", mode="a")
 
         self._save_plt(output_filename=output_filename, fig=fig)
 
+    def _feature_group_series(self):
+        """Ordered list of (group_label, color) for the per-feature quality curves.
+
+        For MIXED (2 groups) preserve the historical order/colors: Non-mixed (red) then
+        Mixed (green). For N groups use the group palette in group order.
+        """
+        if self.split.mode is ReportMode.MIXED:
+            return [(self.split.neg, "tab:red"), (self.split.pos, "tab:green")]
+        palette = self._group_palette()
+        return [(label, palette[label]) for label in self.split.groups]
+
     def _plot_feature_qual_stats(
         self, stats_for_plot, ax, c_true="tab:green", c_false="tab:red", min_count=100, fb_kws=None, step_kws=None
     ):
-        """Generate a plot of quality median + 10-90 percentile range, for mixed and non-mixed reads."""
+        """Generate a plot of quality median + 10-90 percentile range, per read group."""
         fb_kws = fb_kws or {}
         step_kws = step_kws or {}
         col = stats_for_plot.columns[0]
         polys, lines = [], []
-        for is_mixed, color in zip(
-            [~stats_for_plot[IS_MIXED_START], stats_for_plot[IS_MIXED_START]], [c_false, c_true], strict=False
-        ):
-            qual_df = stats_for_plot.loc[is_mixed & stats_for_plot[LABEL] & (stats_for_plot["count"] > min_count), :]
+        for label, color in self._feature_group_series():
+            group_mask = stats_for_plot[self.split.group_col].astype(str) == str(label)
+            qual_df = stats_for_plot.loc[group_mask & stats_for_plot[LABEL] & (stats_for_plot["count"] > min_count), :]
             fb_kws["color"] = color
             step_kws["color"] = color
             if qual_df.shape[0] > 0:
@@ -2682,7 +2966,7 @@ class SRSNVReport:
             q2 [float]: upper quantile for interquartile range
             bin_edges [list]: bin edges for discretization. If it is None, use discrete (integer) values
         """
-        required_cols = [col, LABEL, IS_MIXED_START, QUAL]
+        required_cols = [col, LABEL, self.split.group_col, QUAL]
 
         # If binning is needed, create binned column in a view/subset
         if bin_edges is not None:
@@ -2693,7 +2977,7 @@ class SRSNVReport:
             # Use a view of the original dataframe (no copy needed)
             subset = self.data_df[required_cols]
 
-        stats_for_plot = subset.groupby([col, LABEL, IS_MIXED_START], observed=True).agg(
+        stats_for_plot = subset.groupby([col, LABEL, self.split.group_col], observed=True).agg(
             median_qual=(QUAL, "median"),
             quantile1_qual=(QUAL, lambda x: x.quantile(q1)),
             quantile3_qual=(QUAL, lambda x: x.quantile(q2)),
@@ -2779,17 +3063,24 @@ class SRSNVReport:
             ncol=1,
             frameon=False,
         )
-        # Next two lines are to display correctly the legend if there are no mixed reads
+        # Replace missing handles (e.g. an empty group) so the legend still renders.
         lines = [line if line is not None else empty_handle for line in lines]
         polys = [poly if poly is not None else empty_handle for poly in polys]
+        # One legend block per read group, in group order.
+        group_labels = [label for label, _ in self._feature_group_series()]
+        legend_handles = []
+        legend_texts = []
+        for gi, label in enumerate(group_labels):
+            legend_handles += [empty_handle, lines[gi], polys[gi]]
+            legend_texts += [label, "median", "10%-90% range"]
         fig.legend(
-            [empty_handle, lines[0], polys[0], empty_handle, lines[1], polys[1]],
-            ["Non-mixed", "median", "10%-90% range", "Mixed", "median", "10%-90% range"],
+            legend_handles,
+            legend_texts,
             fontsize=legend_fontsize,
             title_fontsize=legend_fontsize,
             loc="lower center",
             bbox_to_anchor=(0.7, -0.15),
-            ncol=2,
+            ncol=len(group_labels),
             frameon=False,
         )
         self._save_plt(output_filename=output_filename, fig=fig)
@@ -2809,8 +3100,10 @@ class SRSNVReport:
         return pd.DataFrame(hist_dict)
 
     @exception_handler
-    def plot_quality_histogram(self, *, plot_interpolating_function: bool = False, output_filename: str = None):
-        """Plot a histogram of qual values for TP reads, both mixed and non-mixed."""
+    def plot_quality_histogram(  # noqa: PLR0915
+        self, *, plot_interpolating_function: bool = False, output_filename: str = None
+    ):
+        """Plot a histogram of qual values for TP reads, split by the mode's read groups."""
         # label_fontsize = 12
         # ticklabelsfontsize = 12
         logger.info("Plotting SNVQ histogram")
@@ -2824,41 +3117,57 @@ class SRSNVReport:
             axes = [ax]
 
         plot_df = self.data_df[self.data_df[LABEL]].copy()
+        hue_col = self.split.tag_axis
 
-        # Legacy histogram with 3 categories for backward-compatible h5 storage
+        # Legacy histogram for backward-compatible h5 storage. In MIXED mode this is a 3-category
+        # split (non-mixed / mixed exactly one end / mixed both ends); other modes have no
+        # start/end distinction, so it collapses to the same 2-category split as the display plot.
         plot_df_legacy = plot_df.copy()
-        plot_df_legacy["ppmSeq tags"] = "non-mixed"
-        plot_df_legacy.loc[plot_df_legacy[IS_MIXED_START] ^ plot_df_legacy[IS_MIXED_END], "ppmSeq tags"] = (
-            "mixed, exactly one end"
-        )
-        plot_df_legacy.loc[plot_df_legacy[IS_MIXED_START] & plot_df_legacy[IS_MIXED_END], "ppmSeq tags"] = (
-            "mixed, both ends"
-        )
+        if self.split.mode is ReportMode.MIXED:
+            legacy_one_end = f"{self.split.pos_lc}, exactly one end"
+            legacy_both_ends = f"{self.split.pos_lc}, both ends"
+            plot_df_legacy[hue_col] = self.split.neg_lc
+            one_end_mask = plot_df_legacy[IS_MIXED_START] ^ plot_df_legacy[IS_MIXED_END]
+            both_ends_mask = plot_df_legacy[IS_MIXED_START] & plot_df_legacy[IS_MIXED_END]
+            plot_df_legacy.loc[one_end_mask, hue_col] = legacy_one_end
+            plot_df_legacy.loc[both_ends_mask, hue_col] = legacy_both_ends
+            legacy_hue_order = [self.split.neg_lc, legacy_one_end, legacy_both_ends]
+            legacy_palette = {self.split.neg_lc: "red", legacy_one_end: "blue", legacy_both_ends: "green"}
+            display_hue_order = [self.split.neg_lc, self.split.pos_lc]
+            display_palette = {self.split.neg_lc: "red", self.split.pos_lc: "blue"}
+            plot_df[hue_col] = self.split.neg_lc
+            plot_df.loc[plot_df[self.split.display_col], hue_col] = self.split.pos_lc
+        else:
+            # CONSENSUS / NONE: N groups from read_group; no legacy start/end distinction, so the
+            # legacy plot equals the display plot.
+            plot_df_legacy[hue_col] = plot_df_legacy[self.split.group_col].astype(str)
+            plot_df[hue_col] = plot_df[self.split.group_col].astype(str)
+            legacy_hue_order = display_hue_order = list(self.split.groups)
+            palette = self._group_palette()
+            legacy_palette = display_palette = {str(k): v for k, v in palette.items()}
         fig_legacy, ax_legacy = plt.subplots(figsize=(12, 7))
         g_legacy = sns.histplot(
             data=plot_df_legacy,
             x=QUAL,
-            hue="ppmSeq tags",
-            hue_order=["non-mixed", "mixed, exactly one end", "mixed, both ends"],
+            hue=hue_col,
+            hue_order=legacy_hue_order,
             element="step",
             stat="density",
             common_norm=False,
             linewidth=1,
             ax=ax_legacy,
-            palette={"non-mixed": "red", "mixed, exactly one end": "blue", "mixed, both ends": "green"},
+            palette=legacy_palette,
         )
         hist_data_df_legacy = self._get_histogram_data(g_legacy, col_name=IS_MIXED)
         hist_data_df_legacy.to_hdf(self.output_h5_filename, key="quality_histogram", mode="a")
         plt.close(fig_legacy)
 
-        # New histogram with 2 categories for display
-        plot_df["ppmSeq tags"] = "non-mixed"
-        plot_df.loc[plot_df[IS_MIXED_START], "ppmSeq tags"] = "mixed"
+        # New histogram (display groups)
         g = sns.histplot(
             data=plot_df,
             x=QUAL,
-            hue="ppmSeq tags",
-            hue_order=["non-mixed", "mixed"],
+            hue=hue_col,
+            hue_order=display_hue_order,
             element="step",
             stat="density",
             common_norm=False,
@@ -2866,7 +3175,7 @@ class SRSNVReport:
             kde_kws={"bw_adjust": 3},
             linewidth=1,
             ax=ax,
-            palette={"non-mixed": "red", "mixed": "blue"},
+            palette=display_palette,
         )
         sns.move_legend(
             ax,
@@ -2906,23 +3215,49 @@ class SRSNVReport:
         fig.tight_layout()
         self._save_plt(output_filename=output_filename, fig=fig)
 
-    def _plot_logit_histogram(self, plot_df, ax, alpha=0.4, mixed_col=IS_MIXED_START):
-        """Plot a single histogram of logit values, by: FP, TP mixed, TP non-mixed.
+    def _plot_logit_histogram(self, plot_df, ax, alpha=0.4, mixed_col=None):
+        """Plot a single histogram of logit values, by: FP, TP positive-group, TP negative-group.
 
-        ``mixed_col`` selects which column defines a "mixed" read. It defaults to IS_MIXED_START
-        (start ppmSeq tag is MIXED) to match the report's simplified mixed definition; pass
-        IS_MIXED for the legacy both-ends definition.
+        Binary (MIXED/NONE) path: ``mixed_col`` selects which column defines a positive-group
+        ("mixed") read. Defaults to the mode's display split column; pass the legacy split column
+        for the legacy both-ends definition in ppmSeq mode.
         """
+        if mixed_col is None:
+            mixed_col = self.split.display_col
+        tp_pos = f"TP {self.split.pos_lc}"
+        tp_neg = f"TP {self.split.neg_lc}"
         plot_df[""] = plot_df[LABEL].astype(str)
         plot_df.loc[~plot_df[LABEL], ""] = "FP"
-        plot_df.loc[plot_df[LABEL] & plot_df[mixed_col], ""] = "TP mixed"
-        plot_df.loc[plot_df[LABEL] & ~plot_df[mixed_col], ""] = "TP non-mixed"
+        plot_df.loc[plot_df[LABEL] & plot_df[mixed_col], ""] = tp_pos
+        plot_df.loc[plot_df[LABEL] & ~plot_df[mixed_col], ""] = tp_neg
         sns.histplot(
             data=plot_df,
             x=ML_LOGIT_TEST,
             hue="",
-            hue_order=["FP", "TP mixed", "TP non-mixed"],
-            palette={"FP": "tab:blue", "TP non-mixed": "red", "TP mixed": "green"},
+            hue_order=["FP", tp_pos, tp_neg],
+            palette={"FP": "tab:blue", tp_neg: "red", tp_pos: "green"},
+            element="step",
+            stat="density",
+            common_norm=False,
+            alpha=alpha,
+            ax=ax,
+        )
+
+    def _plot_logit_histogram_by_group(self, plot_df, ax, alpha=0.4):
+        """N-group logit histogram (consensus/none): FP + one TP series per read group."""
+        tp_labels = [f"TP {label}" for label in self.split.groups]
+        plot_df[""] = "FP"
+        grp = plot_df[self.split.group_col].astype(str)
+        for label in self.split.groups:
+            plot_df.loc[plot_df[LABEL] & (grp == label), ""] = f"TP {label}"
+        group_colors = list(sns.color_palette(n_colors=len(self.split.groups)))
+        palette = {"FP": "tab:blue", **dict(zip(tp_labels, group_colors, strict=False))}
+        sns.histplot(
+            data=plot_df,
+            x=ML_LOGIT_TEST,
+            hue="",
+            hue_order=["FP", *tp_labels],
+            palette=palette,
             element="step",
             stat="density",
             common_norm=False,
@@ -2932,26 +3267,39 @@ class SRSNVReport:
 
     @exception_handler
     def plot_logit_histograms(self, *, plot_by_fold: bool = True, output_filename: str = None):
-        """Plot a histogram of logit values, by: FP, TP mixed, TP non-mixed.
+        """Plot a histogram of logit values, by: FP, TP positive-group, TP negative-group.
         If plot_by_fold is True, overlay histograms for each fold.
         """
         # label_fontsize = 12
         # ticklabelsfontsize = 12
         logger.info("Plotting logit histogram")
 
-        plot_df_all = self.data_df[[ML_LOGIT_TEST, LABEL, IS_MIXED, IS_MIXED_START, FOLD_ID]].copy()
+        is_consensus_mode = self.split.mode is ReportMode.CONSENSUS
+        if is_consensus_mode:
+            plot_df_all = self.data_df[[ML_LOGIT_TEST, LABEL, self.split.group_col, FOLD_ID]].copy()
+        else:
+            split_cols = list(dict.fromkeys([self.split.display_col, self.split.legacy_col]))
+            plot_df_all = self.data_df[[ML_LOGIT_TEST, LABEL, *split_cols, FOLD_ID]].copy()
 
-        # Legacy histogram data (both-ends IS_MIXED) for backward-compatible h5 storage
+        def _plot_one(df, ax, alpha=0.4, *, use_display):
+            """use_display selects display vs legacy binary column (ignored in consensus mode)."""
+            if is_consensus_mode:
+                self._plot_logit_histogram_by_group(df, ax, alpha=alpha)
+            else:
+                col = self.split.display_col if use_display else self.split.legacy_col
+                self._plot_logit_histogram(df, ax, alpha=alpha, mixed_col=col)
+
+        # Legacy histogram data for backward-compatible h5 storage (consensus: same as display)
         fig_legacy, ax_legacy = plt.subplots(figsize=(12, 7))
-        self._plot_logit_histogram(plot_df_all.copy(), ax_legacy, mixed_col=IS_MIXED)
+        _plot_one(plot_df_all.copy(), ax_legacy, use_display=False)
         hist_data_df_legacy = self._get_histogram_data(ax_legacy, col_name="")
         hist_data_df_legacy.to_hdf(self.output_h5_filename, key="logit_histogram", mode="a")
         plt.close(fig_legacy)
 
-        # New histogram (IS_MIXED_START) for display and new h5 key
+        # New histogram (display groups) for display and new h5 key
         fig, ax = plt.subplots(figsize=(12, 7))
         plot_df = plot_df_all.copy()
-        self._plot_logit_histogram(plot_df, ax, mixed_col=IS_MIXED_START)
+        _plot_one(plot_df, ax, use_display=True)
         hist_data_df = self._get_histogram_data(ax, col_name="")
         hist_data_df.to_hdf(self.output_h5_filename, key="logit_histogram_mixed_start", mode="a")
 
@@ -2960,7 +3308,7 @@ class SRSNVReport:
             fig, ax = plt.subplots(figsize=(12, 7))
             plot_dfs = [plot_df_all[plot_df_all[FOLD_ID] == k] for k in range(len(self.models))]
             for plot_df in plot_dfs:
-                self._plot_logit_histogram(plot_df.copy(), ax, alpha=0.15, mixed_col=IS_MIXED_START)
+                _plot_one(plot_df.copy(), ax, alpha=0.15, use_display=True)
 
         sns.move_legend(
             ax,

--- a/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_plotting_utils.py
@@ -45,10 +45,10 @@ from ugbio_srsnv.split_scheme import (
 from ugbio_srsnv.srsnv_utils import (
     ET,
     ET_FILLNA,
-    FS,
     MAX_PHRED,
+    NF,
+    NR,
     READ_GROUP,
-    RS,
     ST,
     ST_FILLNA,
     construct_trinuc_context_with_alt,
@@ -3173,9 +3173,9 @@ class SRSNVReport:
         """Columns (besides read_group) that the active scheme's variant group_fns read, so the
         logit-histogram slice includes them. Only columns present in data_df are returned.
 
-        Covers every scheme's raw group inputs (mixed: is_mixed/_start; consensus: fs/rs); a new
+        Covers every scheme's raw group inputs (mixed: is_mixed/_start; consensus: nf/nr); a new
         scheme should add its raw group columns here so its group_fn can run on the sliced frame."""
-        candidates = [IS_MIXED, IS_MIXED_START, FS, RS]
+        candidates = [IS_MIXED, IS_MIXED_START, NF, NR]
         return [c for c in candidates if c in self.data_df.columns]
 
     def _plot_logit_variant(self, plot_df, ax, variant, alpha=0.4):

--- a/src/srsnv/ugbio_srsnv/srsnv_report.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_report.py
@@ -33,11 +33,11 @@ from ugbio_core.logger import logger
 from ugbio_core.vcfbed.variant_annotation import get_cycle_skip_dataframe
 from ugbio_featuremap.featuremap_utils import FeatureMapFields
 
+from ugbio_srsnv.split_scheme import resolve_scheme_and_add_columns
 from ugbio_srsnv.srsnv_plotting_utils import SRSNVReport, create_srsnv_report_html
 from ugbio_srsnv.srsnv_utils import (
     ET,
     ST,
-    resolve_and_add_split_columns,
 )
 
 FOLD_COL = "fold_id"
@@ -276,14 +276,14 @@ def prepare_report(
     # Build params dictionary from metadata
     params = _build_params(metadata, user_meta, len(models))
 
-    # Detect the report mode (mixed / consensus / none) from the columns present and add the
-    # split column(s) it needs. The mode is stored in params so SRSNVReport uses it directly.
-    data_df, report_mode = resolve_and_add_split_columns(
+    # Resolve the active split scheme (recipe) from the columns present and add the split columns +
+    # ordered read_group it needs. The mode is stored in params so SRSNVReport uses it directly.
+    data_df, scheme = resolve_scheme_and_add_columns(
         data_df,
         params["adapter_version"],
         params["categorical_features_names"],
     )
-    params["report_mode"] = report_mode.value
+    params["report_mode"] = scheme.mode.value
     data_df[IS_CYCLE_SKIP] = compute_is_cycle_skip_column(data_df)
 
     # Handle random seed
@@ -324,7 +324,8 @@ def prepare_report(
         out_basename=basename,
         srsnv_metadata_file=srsnv_metadata,
         simple_pipeline=None,
-        split_mode=report_mode.value,
+        split_mode=scheme.mode.value,
+        display_suffix=scheme.display_suffix,
     )
 
 

--- a/src/srsnv/ugbio_srsnv/srsnv_report.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_report.py
@@ -37,7 +37,7 @@ from ugbio_srsnv.srsnv_plotting_utils import SRSNVReport, create_srsnv_report_ht
 from ugbio_srsnv.srsnv_utils import (
     ET,
     ST,
-    add_is_mixed_to_featuremap_df,
+    resolve_and_add_split_columns,
 )
 
 FOLD_COL = "fold_id"
@@ -276,12 +276,14 @@ def prepare_report(
     # Build params dictionary from metadata
     params = _build_params(metadata, user_meta, len(models))
 
-    # Add columns to featuremap_df
-    data_df = add_is_mixed_to_featuremap_df(
+    # Detect the report mode (mixed / consensus / none) from the columns present and add the
+    # split column(s) it needs. The mode is stored in params so SRSNVReport uses it directly.
+    data_df, report_mode = resolve_and_add_split_columns(
         data_df,
         params["adapter_version"],
         params["categorical_features_names"],
     )
+    params["report_mode"] = report_mode.value
     data_df[IS_CYCLE_SKIP] = compute_is_cycle_skip_column(data_df)
 
     # Handle random seed
@@ -322,6 +324,7 @@ def prepare_report(
         out_basename=basename,
         srsnv_metadata_file=srsnv_metadata,
         simple_pipeline=None,
+        split_mode=report_mode.value,
     )
 
 

--- a/src/srsnv/ugbio_srsnv/srsnv_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_utils.py
@@ -77,18 +77,18 @@ TM = "tm"  # Trimmer tags column
 ST_FILLNA = "st_fillna"  # start tag with NAs filled in
 ET_FILLNA = "et_fillna"  # end tag with NAs filled in
 
-FS = "fs"  # forward-strand read count (consensus data)
-RS = "rs"  # reverse-strand read count (consensus data)
-IS_CONSENSUS = "is_consensus"  # read is a consensus read (fs >= 1 and rs >= 1)
+NF = "nf"  # forward-strand read count (consensus data)
+NR = "nr"  # reverse-strand read count (consensus data)
+IS_CONSENSUS = "is_consensus"  # read is a consensus read (nf >= 1 and nr >= 1)
 
 # Ordered read-group column: reads are split into N ordered groups per mode (see
 # add_read_group_column). The report iterates these groups instead of a binary split.
 READ_GROUP = "read_group"
 
 # Consensus groups, ordered by ascending strand support (single -> one strand -> duplex).
-CONSENSUS_GROUP_SINGLE = "single read"  # fs + rs <= 1
-CONSENSUS_GROUP_ONE_STRAND = "consensus, one strand"  # fs + rs >= 2 and (fs == 0) xor (rs == 0)
-CONSENSUS_GROUP_DUPLEX = "consensus, duplex"  # fs >= 1 and rs >= 1
+CONSENSUS_GROUP_SINGLE = "single read"  # nf + nr <= 1
+CONSENSUS_GROUP_ONE_STRAND = "consensus, one strand"  # nf + nr >= 2 and (nf == 0) xor (nr == 0)
+CONSENSUS_GROUP_DUPLEX = "consensus, duplex"  # nf >= 1 and nr >= 1
 CONSENSUS_GROUPS = [CONSENSUS_GROUP_SINGLE, CONSENSUS_GROUP_ONE_STRAND, CONSENSUS_GROUP_DUPLEX]
 
 # Mixed groups (2), reproducing the historical binary ppmSeq labels/order.
@@ -109,7 +109,7 @@ class ReportMode(Enum):
     """
 
     MIXED = "mixed"  # ppmSeq data: split on mixed vs non-mixed reads (st/et tags)
-    CONSENSUS = "consensus"  # consensus data: split on consensus vs non-consensus (fs/rs)
+    CONSENSUS = "consensus"  # consensus data: split on consensus vs non-consensus (nf/nr)
     NONE = "none"  # neither available: single "all reads" group
 
 
@@ -121,7 +121,7 @@ def detect_report_mode(data_df: pd.DataFrame) -> ReportMode:
 
     ppmSeq tags take priority over consensus counts: if the start/end strand-ratio tags
     (``st``/``et``, or the v5 ``as``/``ae``/``ts``/``te`` tags from which they are derived)
-    are present, the mode is MIXED even if ``fs``/``rs`` happen to also be present.
+    are present, the mode is MIXED even if ``nf``/``nr`` happen to also be present.
 
     Parameters
     ----------
@@ -131,13 +131,13 @@ def detect_report_mode(data_df: pd.DataFrame) -> ReportMode:
     Returns
     -------
     ReportMode
-        MIXED if ppmSeq tags are present, CONSENSUS if fs/rs are present, else NONE.
+        MIXED if ppmSeq tags are present, CONSENSUS if nf/nr are present, else NONE.
     """
     cols = data_df.columns
     v5_tags_present = AS in cols and AE in cols and TS in cols and TE in cols
     if (ST in cols and ET in cols) or v5_tags_present:
         return ReportMode.MIXED
-    if FS in cols and RS in cols:
+    if NF in cols and NR in cols:
         return ReportMode.CONSENSUS
     return ReportMode.NONE
 
@@ -145,13 +145,13 @@ def detect_report_mode(data_df: pd.DataFrame) -> ReportMode:
 def add_is_consensus_to_featuremap_df(data_df: pd.DataFrame) -> pd.DataFrame:
     """Add the ``is_consensus`` column to a consensus featuremap dataframe.
 
-    A read is a consensus read iff it has at least one forward-strand read (``fs >= 1``)
-    and at least one reverse-strand read (``rs >= 1``).
+    A read is a consensus read iff it has at least one forward-strand read (``nf >= 1``)
+    and at least one reverse-strand read (``nr >= 1``).
 
     Parameters
     ----------
     data_df : pd.DataFrame
-        The featuremap dataframe, expected to contain the ``fs`` and ``rs`` columns.
+        The featuremap dataframe, expected to contain the ``nf`` and ``nr`` columns.
 
     Returns
     -------
@@ -159,7 +159,7 @@ def add_is_consensus_to_featuremap_df(data_df: pd.DataFrame) -> pd.DataFrame:
         The same dataframe with the ``is_consensus`` boolean column added.
     """
     logger.info("Adding is_consensus column to featuremap")
-    data_df[IS_CONSENSUS] = (data_df[FS] >= 1) & (data_df[RS] >= 1)
+    data_df[IS_CONSENSUS] = (data_df[NF] >= 1) & (data_df[NR] >= 1)
     return data_df
 
 
@@ -168,9 +168,9 @@ def add_read_group_column(data_df: pd.DataFrame, mode: ReportMode) -> pd.DataFra
 
     The report splits reads into N ordered groups depending on the mode:
 
-    - CONSENSUS: three groups by strand support (from ``fs``/``rs``), ascending:
-      ``single read`` (fs + rs <= 1), ``consensus, one strand``
-      (fs + rs >= 2 and exactly one of fs/rs is 0), ``consensus, duplex`` (fs >= 1 and rs >= 1).
+    - CONSENSUS: three groups by strand support (from ``nf``/``nr``), ascending:
+      ``single read`` (nf + nr <= 1), ``consensus, one strand``
+      (nf + nr >= 2 and exactly one of nf/nr is 0), ``consensus, duplex`` (nf >= 1 and nr >= 1).
       These are exhaustive and mutually exclusive.
     - MIXED: two groups reproducing the historical binary ppmSeq split, derived from
       ``is_mixed_start``: ``Non-mixed`` / ``Mixed`` (in that order). NOTE: mixed-mode report code
@@ -193,13 +193,13 @@ def add_read_group_column(data_df: pd.DataFrame, mode: ReportMode) -> pd.DataFra
         The dataframe with the ``read_group`` ordered-categorical column added.
     """
     if mode is ReportMode.CONSENSUS:
-        min_consensus_reads = 2  # fs + rs >= 2 to be more than a single read
-        fs = data_df[FS]
-        rs = data_df[RS]
-        total = fs + rs
+        min_consensus_reads = 2  # nf + nr >= 2 to be more than a single read
+        nf = data_df[NF]
+        nr = data_df[NR]
+        total = nf + nr
         group = pd.Series(CONSENSUS_GROUP_SINGLE, index=data_df.index, dtype=object)
-        one_strand = (total >= min_consensus_reads) & ((fs == 0) ^ (rs == 0))
-        duplex = (fs >= 1) & (rs >= 1)
+        one_strand = (total >= min_consensus_reads) & ((nf == 0) ^ (nr == 0))
+        duplex = (nf >= 1) & (nr >= 1)
         group[one_strand] = CONSENSUS_GROUP_ONE_STRAND
         group[duplex] = CONSENSUS_GROUP_DUPLEX
         categories = CONSENSUS_GROUPS
@@ -223,7 +223,7 @@ def resolve_and_add_split_columns(
     """Detect the report mode and add the boolean split column(s) it needs.
 
     - MIXED: delegates to :func:`add_is_mixed_to_featuremap_df` (adds is_mixed/_start/_end).
-    - CONSENSUS: adds ``is_consensus`` = (fs >= 1) & (rs >= 1).
+    - CONSENSUS: adds ``is_consensus`` = (nf >= 1) & (nr >= 1).
     - NONE: adds ``is_consensus`` = False (single "all reads" group).
 
     Parameters

--- a/src/srsnv/ugbio_srsnv/srsnv_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_utils.py
@@ -1241,12 +1241,12 @@ def construct_trinuc_context_with_alt(
 ) -> pd.Series:
     """Construct trinuc_context_with_alt column from prev1, ref, next1, alt columns.
 
-    The "alt" base used is the read's actual substituted base. Featuremaps differ in where this
-    lives: in some (XGBoost SRSNV) the ``ALT`` column holds it directly; in others (DNN) the
-    ``ALT`` column equals ``REF`` for TP reads and the real substitution is in ``X_ALT``. To
-    support both, the effective alt is taken from ``x_alt`` wherever that is a valid base
-    (A/C/G/T), falling back to ``alt`` otherwise. If the ``x_alt`` column is absent, ``alt`` is
-    used as-is (unchanged legacy behavior).
+    The "alt" base used must be the read's actual substituted base (different from REF). The
+    ``ALT`` column normally holds it, and is used as-is (legacy behavior). However some DNN
+    featuremaps store ``ALT == REF`` for TP reads, with the real substitution in ``X_ALT``. To
+    support both conventions robustly, ``ALT`` is used wherever it already differs from ``REF``;
+    only where ``ALT == REF`` (and ``X_ALT`` is a valid base A/C/G/T that differs from ``REF``) is
+    ``X_ALT`` substituted in. When the ``x_alt`` column is absent, ``alt`` is used unchanged.
 
     Args:
         df: DataFrame containing the required columns
@@ -1266,11 +1266,13 @@ def construct_trinuc_context_with_alt(
     if missing_cols:
         raise ValueError(f"Missing required columns: {missing_cols}")
 
+    ref_series = df[ref].astype(str)
     alt_series = df[alt].astype(str)
-    # Prefer the per-read substituted base (X_ALT) where it is a valid base; else keep ALT.
+    # ALT is authoritative when it already differs from REF (the normal case). Only when ALT == REF
+    # (e.g. DNN featuremaps that carry the substitution in X_ALT) do we fall back to a valid X_ALT.
     if x_alt in df.columns:
         x_alt_series = df[x_alt].astype(str)
-        use_x_alt = x_alt_series.isin(VALID_BASES)
+        use_x_alt = (alt_series == ref_series) & x_alt_series.isin(VALID_BASES) & (x_alt_series != ref_series)
         alt_series = alt_series.where(~use_x_alt, x_alt_series)
 
     # Convert categorical columns to string to enable concatenation

--- a/src/srsnv/ugbio_srsnv/srsnv_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_utils.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import importlib
 import warnings
+from enum import Enum
 from functools import partial
 from itertools import cycle
 from typing import TYPE_CHECKING
@@ -57,7 +58,9 @@ PREV1 = "X_PREV1"
 REF = "REF"
 NEXT1 = "X_NEXT1"
 ALT = "ALT"
+X_ALT = "X_ALT"  # per-read substituted base (present in featuremaps where ALT == REF for TP reads)
 REV = "REV"
+VALID_BASES = ("A", "C", "G", "T")
 
 NUMERATOR = "numerator"
 DENOMINATOR = "denominator"
@@ -75,6 +78,182 @@ TE = "te"
 TM = "tm"  # Trimmer tags column
 ST_FILLNA = "st_fillna"  # start tag with NAs filled in
 ET_FILLNA = "et_fillna"  # end tag with NAs filled in
+
+FS = "fs"  # forward-strand read count (consensus data)
+RS = "rs"  # reverse-strand read count (consensus data)
+IS_CONSENSUS = "is_consensus"  # read is a consensus read (fs >= 1 and rs >= 1)
+
+# Ordered read-group column: reads are split into N ordered groups per mode (see
+# add_read_group_column). The report iterates these groups instead of a binary split.
+READ_GROUP = "read_group"
+
+# Consensus groups, ordered by ascending strand support (single -> one strand -> duplex).
+CONSENSUS_GROUP_SINGLE = "single read"  # fs + rs <= 1
+CONSENSUS_GROUP_ONE_STRAND = "consensus, one strand"  # fs + rs >= 2 and (fs == 0) xor (rs == 0)
+CONSENSUS_GROUP_DUPLEX = "consensus, duplex"  # fs >= 1 and rs >= 1
+CONSENSUS_GROUPS = [CONSENSUS_GROUP_SINGLE, CONSENSUS_GROUP_ONE_STRAND, CONSENSUS_GROUP_DUPLEX]
+
+# Mixed groups (2), reproducing the historical binary ppmSeq labels/order.
+MIXED_GROUP_NON = "Non-mixed"
+MIXED_GROUP_POS = "Mixed"
+MIXED_GROUPS = [MIXED_GROUP_NON, MIXED_GROUP_POS]
+
+# None mode: a single "all reads" group.
+NONE_GROUP_ALL = "all reads"
+
+
+class ReportMode(Enum):
+    """How the SRSNV report splits reads into two groups.
+
+    The mode is detected automatically from the columns present in the featuremap
+    dataframe (see :func:`detect_report_mode`). Its ``.value`` is a plain string, so the
+    mode can be stored in the params dict / JSON and reconstructed via ``ReportMode(value)``.
+    """
+
+    MIXED = "mixed"  # ppmSeq data: split on mixed vs non-mixed reads (st/et tags)
+    CONSENSUS = "consensus"  # consensus data: split on consensus vs non-consensus (fs/rs)
+    NONE = "none"  # neither available: single "all reads" group
+
+
+def detect_report_mode(data_df: pd.DataFrame) -> ReportMode:
+    """Detect the report split mode from the columns present in the featuremap dataframe.
+
+    Detection is column-presence based (not adapter-version based), because the adapter
+    version is unreliable in some pipelines (e.g. the DNN report path stores it as None).
+
+    ppmSeq tags take priority over consensus counts: if the start/end strand-ratio tags
+    (``st``/``et``, or the v5 ``as``/``ae``/``ts``/``te`` tags from which they are derived)
+    are present, the mode is MIXED even if ``fs``/``rs`` happen to also be present.
+
+    Parameters
+    ----------
+    data_df : pd.DataFrame
+        The featuremap dataframe.
+
+    Returns
+    -------
+    ReportMode
+        MIXED if ppmSeq tags are present, CONSENSUS if fs/rs are present, else NONE.
+    """
+    cols = data_df.columns
+    v5_tags_present = AS in cols and AE in cols and TS in cols and TE in cols
+    if (ST in cols and ET in cols) or v5_tags_present:
+        return ReportMode.MIXED
+    if FS in cols and RS in cols:
+        return ReportMode.CONSENSUS
+    return ReportMode.NONE
+
+
+def add_is_consensus_to_featuremap_df(data_df: pd.DataFrame) -> pd.DataFrame:
+    """Add the ``is_consensus`` column to a consensus featuremap dataframe.
+
+    A read is a consensus read iff it has at least one forward-strand read (``fs >= 1``)
+    and at least one reverse-strand read (``rs >= 1``).
+
+    Parameters
+    ----------
+    data_df : pd.DataFrame
+        The featuremap dataframe, expected to contain the ``fs`` and ``rs`` columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        The same dataframe with the ``is_consensus`` boolean column added.
+    """
+    logger.info("Adding is_consensus column to featuremap")
+    data_df[IS_CONSENSUS] = (data_df[FS] >= 1) & (data_df[RS] >= 1)
+    return data_df
+
+
+def add_read_group_column(data_df: pd.DataFrame, mode: ReportMode) -> pd.DataFrame:
+    """Add the ordered categorical ``read_group`` column used to split the report.
+
+    The report splits reads into N ordered groups depending on the mode:
+
+    - CONSENSUS: three groups by strand support (from ``fs``/``rs``), ascending:
+      ``single read`` (fs + rs <= 1), ``consensus, one strand``
+      (fs + rs >= 2 and exactly one of fs/rs is 0), ``consensus, duplex`` (fs >= 1 and rs >= 1).
+      These are exhaustive and mutually exclusive.
+    - MIXED: two groups reproducing the historical binary ppmSeq split, derived from
+      ``is_mixed_start``: ``Non-mixed`` / ``Mixed`` (in that order). NOTE: mixed-mode report code
+      keeps its own dual (legacy both-ends + display start) logic and does not rely on this column;
+      it is added only for a uniform N-group interface.
+    - NONE: a single ``all reads`` group.
+
+    The column is an *ordered* pandas Categorical so group order is stable in tables/plots.
+
+    Parameters
+    ----------
+    data_df : pd.DataFrame
+        The featuremap dataframe (with split boolean columns already added).
+    mode : ReportMode
+        The resolved report mode.
+
+    Returns
+    -------
+    pd.DataFrame
+        The dataframe with the ``read_group`` ordered-categorical column added.
+    """
+    if mode is ReportMode.CONSENSUS:
+        min_consensus_reads = 2  # fs + rs >= 2 to be more than a single read
+        fs = data_df[FS]
+        rs = data_df[RS]
+        total = fs + rs
+        group = pd.Series(CONSENSUS_GROUP_SINGLE, index=data_df.index, dtype=object)
+        one_strand = (total >= min_consensus_reads) & ((fs == 0) ^ (rs == 0))
+        duplex = (fs >= 1) & (rs >= 1)
+        group[one_strand] = CONSENSUS_GROUP_ONE_STRAND
+        group[duplex] = CONSENSUS_GROUP_DUPLEX
+        categories = CONSENSUS_GROUPS
+    elif mode is ReportMode.MIXED:
+        group = pd.Series(MIXED_GROUP_NON, index=data_df.index, dtype=object)
+        group[data_df[IS_MIXED_START]] = MIXED_GROUP_POS
+        categories = MIXED_GROUPS
+    else:  # ReportMode.NONE
+        group = pd.Series(NONE_GROUP_ALL, index=data_df.index, dtype=object)
+        categories = [NONE_GROUP_ALL]
+
+    data_df[READ_GROUP] = pd.Categorical(group, categories=categories, ordered=True)
+    return data_df
+
+
+def resolve_and_add_split_columns(
+    data_df: pd.DataFrame,
+    adapter_version: str = None,
+    categorical_features_names: list[str] | None = None,
+) -> tuple[pd.DataFrame, ReportMode]:
+    """Detect the report mode and add the boolean split column(s) it needs.
+
+    - MIXED: delegates to :func:`add_is_mixed_to_featuremap_df` (adds is_mixed/_start/_end).
+    - CONSENSUS: adds ``is_consensus`` = (fs >= 1) & (rs >= 1).
+    - NONE: adds ``is_consensus`` = False (single "all reads" group).
+
+    Parameters
+    ----------
+    data_df : pd.DataFrame
+        The featuremap dataframe.
+    adapter_version : str, optional
+        ppmSeq adapter version, forwarded to the MIXED path.
+    categorical_features_names : list[str], optional
+        Categorical feature names, forwarded to the MIXED path.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, ReportMode]
+        The dataframe with split columns added, and the detected mode.
+    """
+    mode = detect_report_mode(data_df)
+    logger.info("Detected SRSNV report mode: %s", mode.value)
+    if mode is ReportMode.MIXED:
+        data_df = add_is_mixed_to_featuremap_df(data_df, adapter_version, categorical_features_names)
+    elif mode is ReportMode.CONSENSUS:
+        data_df = add_is_consensus_to_featuremap_df(data_df)
+    else:  # ReportMode.NONE — no split information available, degrade to a single group
+        data_df[IS_CONSENSUS] = False
+    # Add the ordered read_group column used by the N-group report split.
+    data_df = add_read_group_column(data_df, mode)
+    return data_df, mode
+
 
 FLOW_ORDER = ["T", "G", "C", "A"]
 
@@ -1052,9 +1231,22 @@ def get_filter_ratio(
 
 
 def construct_trinuc_context_with_alt(
-    df: pd.DataFrame, *, prev1: str = PREV1, ref: str = REF, next1: str = NEXT1, alt: str = ALT
+    df: pd.DataFrame,
+    *,
+    prev1: str = PREV1,
+    ref: str = REF,
+    next1: str = NEXT1,
+    alt: str = ALT,
+    x_alt: str = X_ALT,
 ) -> pd.Series:
     """Construct trinuc_context_with_alt column from prev1, ref, next1, alt columns.
+
+    The "alt" base used is the read's actual substituted base. Featuremaps differ in where this
+    lives: in some (XGBoost SRSNV) the ``ALT`` column holds it directly; in others (DNN) the
+    ``ALT`` column equals ``REF`` for TP reads and the real substitution is in ``X_ALT``. To
+    support both, the effective alt is taken from ``x_alt`` wherever that is a valid base
+    (A/C/G/T), falling back to ``alt`` otherwise. If the ``x_alt`` column is absent, ``alt`` is
+    used as-is (unchanged legacy behavior).
 
     Args:
         df: DataFrame containing the required columns
@@ -1062,6 +1254,7 @@ def construct_trinuc_context_with_alt(
         ref: Name of the reference nucleotide column, default 'REF'
         next1: Name of the next nucleotide column, default 'X_NEXT1'
         alt: Name of the alternate nucleotide column, default 'ALT'
+        x_alt: Name of the per-read substituted-base column, default 'X_ALT' (optional)
 
     Returns:
         pd.Series: The trinuc_context_with_alt column constructed by concatenating the four columns
@@ -1073,8 +1266,15 @@ def construct_trinuc_context_with_alt(
     if missing_cols:
         raise ValueError(f"Missing required columns: {missing_cols}")
 
+    alt_series = df[alt].astype(str)
+    # Prefer the per-read substituted base (X_ALT) where it is a valid base; else keep ALT.
+    if x_alt in df.columns:
+        x_alt_series = df[x_alt].astype(str)
+        use_x_alt = x_alt_series.isin(VALID_BASES)
+        alt_series = alt_series.where(~use_x_alt, x_alt_series)
+
     # Convert categorical columns to string to enable concatenation
-    return df[prev1].astype(str) + df[ref].astype(str) + df[next1].astype(str) + df[alt].astype(str)
+    return df[prev1].astype(str) + df[ref].astype(str) + df[next1].astype(str) + alt_series
 
 
 def get_trinuc_context_with_alt_fwd_vectorized(tcwa, is_forward):

--- a/src/srsnv/ugbio_srsnv/srsnv_utils.py
+++ b/src/srsnv/ugbio_srsnv/srsnv_utils.py
@@ -58,9 +58,7 @@ PREV1 = "X_PREV1"
 REF = "REF"
 NEXT1 = "X_NEXT1"
 ALT = "ALT"
-X_ALT = "X_ALT"  # per-read substituted base (present in featuremaps where ALT == REF for TP reads)
 REV = "REV"
-VALID_BASES = ("A", "C", "G", "T")
 
 NUMERATOR = "numerator"
 DENOMINATOR = "denominator"
@@ -1231,22 +1229,13 @@ def get_filter_ratio(
 
 
 def construct_trinuc_context_with_alt(
-    df: pd.DataFrame,
-    *,
-    prev1: str = PREV1,
-    ref: str = REF,
-    next1: str = NEXT1,
-    alt: str = ALT,
-    x_alt: str = X_ALT,
+    df: pd.DataFrame, *, prev1: str = PREV1, ref: str = REF, next1: str = NEXT1, alt: str = ALT
 ) -> pd.Series:
     """Construct trinuc_context_with_alt column from prev1, ref, next1, alt columns.
 
-    The "alt" base used must be the read's actual substituted base (different from REF). The
-    ``ALT`` column normally holds it, and is used as-is (legacy behavior). However some DNN
-    featuremaps store ``ALT == REF`` for TP reads, with the real substitution in ``X_ALT``. To
-    support both conventions robustly, ``ALT`` is used wherever it already differs from ``REF``;
-    only where ``ALT == REF`` (and ``X_ALT`` is a valid base A/C/G/T that differs from ``REF``) is
-    ``X_ALT`` substituted in. When the ``x_alt`` column is absent, ``alt`` is used unchanged.
+    The ``ALT`` column holds the read's actual substituted base in the report featuremap
+    (produced by prepare_dnn_report for the DNN path, or directly for XGBoost), so it is used
+    as-is.
 
     Args:
         df: DataFrame containing the required columns
@@ -1254,7 +1243,6 @@ def construct_trinuc_context_with_alt(
         ref: Name of the reference nucleotide column, default 'REF'
         next1: Name of the next nucleotide column, default 'X_NEXT1'
         alt: Name of the alternate nucleotide column, default 'ALT'
-        x_alt: Name of the per-read substituted-base column, default 'X_ALT' (optional)
 
     Returns:
         pd.Series: The trinuc_context_with_alt column constructed by concatenating the four columns
@@ -1266,17 +1254,8 @@ def construct_trinuc_context_with_alt(
     if missing_cols:
         raise ValueError(f"Missing required columns: {missing_cols}")
 
-    ref_series = df[ref].astype(str)
-    alt_series = df[alt].astype(str)
-    # ALT is authoritative when it already differs from REF (the normal case). Only when ALT == REF
-    # (e.g. DNN featuremaps that carry the substitution in X_ALT) do we fall back to a valid X_ALT.
-    if x_alt in df.columns:
-        x_alt_series = df[x_alt].astype(str)
-        use_x_alt = (alt_series == ref_series) & x_alt_series.isin(VALID_BASES) & (x_alt_series != ref_series)
-        alt_series = alt_series.where(~use_x_alt, x_alt_series)
-
     # Convert categorical columns to string to enable concatenation
-    return df[prev1].astype(str) + df[ref].astype(str) + df[next1].astype(str) + alt_series
+    return df[prev1].astype(str) + df[ref].astype(str) + df[next1].astype(str) + df[alt].astype(str)
 
 
 def get_trinuc_context_with_alt_fwd_vectorized(tcwa, is_forward):

--- a/src/srsnv/ugbio_srsnv/trinuc_histogram_plotting.py
+++ b/src/srsnv/ugbio_srsnv/trinuc_histogram_plotting.py
@@ -124,6 +124,39 @@ def plot_trinuc_hist(  # noqa: C901
     return ax, bars
 
 
+def _resolve_qual_group_specs(stats_df, group_specs=None):
+    """Resolve which quality group columns to plot, plus their labels and colors.
+
+    Returns a list of ``(col_prefix, display_label, color)``.
+
+    - If ``group_specs`` is provided (list of ``(col_prefix, display_label, color)``), it is used
+      directly for any prefix that has a ``<prefix> median_qual`` column present. This is how the
+      N-group (consensus) path drives an arbitrary ordered set of read groups.
+    - Otherwise the historical ppmSeq auto-detection is used: plot ``mixed=True``/``mixed=False``
+      if both present, else ``mixed=all``. Labels/colors match the original hardcoded values, so
+      mixed-mode output is unchanged.
+    """
+    if group_specs is not None:
+        return [
+            (prefix, label, color)
+            for prefix, label, color in group_specs
+            if f"{prefix} median_qual" in stats_df.columns
+        ]
+
+    has_mixed_true = any("mixed=True median_qual" in col for col in stats_df.columns)
+    has_mixed_false = any("mixed=False median_qual" in col for col in stats_df.columns)
+    has_mixed_all = any("mixed=all median_qual" in col for col in stats_df.columns)
+    if has_mixed_true and has_mixed_false:
+        prefixes = ["mixed=True", "mixed=False"]
+    elif has_mixed_all:
+        prefixes = ["mixed=all"]
+    else:
+        prefixes = []
+    default_colors = {"mixed=all": "tab:blue", "mixed=True": "tab:green", "mixed=False": "tab:red"}
+    default_labels = {"mixed=all": "All reads", "mixed=True": "Mixed reads", "mixed=False": "Non-mixed reads"}
+    return [(p, default_labels[p], default_colors[p]) for p in prefixes]
+
+
 def plot_trinuc_qual(  # noqa: C901, PLR0912, PLR0915
     stats_df,
     panel_num=0,
@@ -132,6 +165,7 @@ def plot_trinuc_qual(  # noqa: C901, PLR0912, PLR0915
     xtick_fontsize=10,
     order="symmetric",
     qual_colors=None,
+    group_specs=None,
     *,
     add_annotations=True,
 ):
@@ -140,7 +174,9 @@ def plot_trinuc_qual(  # noqa: C901, PLR0912, PLR0915
     Parameters
     ----------
     stats_df : pd.DataFrame
-        DataFrame with quality statistics in new format (mixed=all, mixed=True, mixed=False)
+        DataFrame with quality statistics. Group columns are named ``<prefix> median_qual`` etc.,
+        where ``<prefix>`` is ``mixed=all``/``mixed=True``/``mixed=False`` (ppmSeq) or
+        ``mixed=<read group>`` (consensus N-group).
     panel_num : int
         Panel number (0 or 1 for forward/reverse)
     ax : matplotlib.Axes, optional
@@ -152,7 +188,10 @@ def plot_trinuc_qual(  # noqa: C901, PLR0912, PLR0915
     order : str
         Trinucleotide ordering
     qual_colors : dict, optional
-        Colors for quality lines
+        (Deprecated / unused when ``group_specs`` is given.) Colors for quality lines.
+    group_specs : list, optional
+        Ordered list of ``(col_prefix, display_label, color)`` selecting which groups to plot and
+        how to label/color them. When None, ppmSeq auto-detection is used (unchanged behavior).
 
     Returns
     -------
@@ -163,8 +202,6 @@ def plot_trinuc_qual(  # noqa: C901, PLR0912, PLR0915
     """
     if x_values is None:
         x_values = X_VALUES
-    if qual_colors is None:
-        qual_colors = {"mixed=all": "tab:blue", "mixed=True": "tab:green", "mixed=False": "tab:red"}
 
     trinuc_symmetric_ref_alt, symmetric_index, snv_labels = _get_trinuc_with_alt_in_order(order=order)
     trinuc_is_cycle_skip = np.array([is_cycle_skip(tcwa, flow_order=FLOW_ORDER) for tcwa in trinuc_symmetric_ref_alt])
@@ -175,22 +212,9 @@ def plot_trinuc_qual(  # noqa: C901, PLR0912, PLR0915
     inds = np.array(x_values) + 96 * panel_num
     lines = {}
 
-    # Determine which mixed categories to plot
-    # Check if we have mixed=True and mixed=False columns
-    has_mixed_true = any("mixed=True median_qual" in col for col in stats_df.columns)
-    has_mixed_false = any("mixed=False median_qual" in col for col in stats_df.columns)
-    has_mixed_all = any("mixed=all median_qual" in col for col in stats_df.columns)
-
-    # Determine which categories to plot based on priority
-    if has_mixed_true and has_mixed_false:
-        # If we have both True and False, plot only these (not 'all')
-        mixed_categories = ["mixed=True", "mixed=False"]
-    elif has_mixed_all:
-        # If we only have 'all', plot only this
-        mixed_categories = ["mixed=all"]
-    else:
-        # No quality data available
-        mixed_categories = []
+    # Resolve which group columns to plot, with labels and colors (ppmSeq auto-detect or N-group).
+    resolved_specs = _resolve_qual_group_specs(stats_df, group_specs)
+    mixed_categories = [prefix for prefix, _, _ in resolved_specs]
 
     # Create extended x_values for step plotting (like in calc_and_plot_trinuc_plot)
     x_values_ext = (
@@ -198,15 +222,13 @@ def plot_trinuc_qual(  # noqa: C901, PLR0912, PLR0915
     )
     inds_ext = [inds[0]] + list(inds) + [inds[-1]]
 
-    # Plot quality lines and shaded areas for each mixed category
-    for mixed_cat in mixed_categories:
+    # Plot quality lines and shaded areas for each group
+    for mixed_cat, display_label, color in resolved_specs:
         median_col = f"{mixed_cat} median_qual"
         q1_col = f"{mixed_cat} q1_qual"
         q2_col = f"{mixed_cat} q2_qual"
 
         if median_col in stats_df.columns:
-            color = qual_colors.get(mixed_cat, "black")
-
             # Get data for this panel (extended for step plotting)
             median_data = stats_df[median_col].iloc[inds_ext]
             q1_data = stats_df[q1_col].iloc[inds_ext] if q1_col in stats_df.columns else median_data
@@ -222,12 +244,7 @@ def plot_trinuc_qual(  # noqa: C901, PLR0912, PLR0915
                 where="mid",
                 color=color,
                 alpha=0.7,
-                label=(
-                    mixed_cat.replace("mixed=", "")
-                    .replace("all", "All reads")
-                    .replace("True", "Mixed reads")
-                    .replace("False", "Non-mixed reads")
-                ),
+                label=display_label,
             )
             lines[mixed_cat] = line
 
@@ -530,7 +547,7 @@ def reverse_engineer_hist_stats(hist_stats_df: pd.DataFrame):
     return labels, hist_stats, total_snvs_per_label
 
 
-def plot_trinuc_hist_and_qual_panels(  # noqa: C901, PLR0912, PLR0913, PLR0915
+def plot_trinuc_hist_and_qual_panels(  # noqa: C901, PLR0912, PLR0913, PLR0915, PLR0917
     stats_df,
     q1=0.1,
     q2=0.9,
@@ -545,6 +562,7 @@ def plot_trinuc_hist_and_qual_panels(  # noqa: C901, PLR0912, PLR0913, PLR0915
     bottom_scale=1.0,
     hist_to_qual_height_ratio=2.0,
     motif_orientation="seq_dir",
+    group_specs=None,
 ):
     """Plot trinuc histogram and quality panels from stats_df DataFrame.
 
@@ -613,7 +631,13 @@ def plot_trinuc_hist_and_qual_panels(  # noqa: C901, PLR0912, PLR0913, PLR0915
 
         # Plot quality panel
         _, lines = plot_trinuc_qual(
-            stats_df, panel_num=panel_idx, ax=qual_ax, order=order, xtick_fontsize=xtick_fontsize, add_annotations=True
+            stats_df,
+            panel_num=panel_idx,
+            ax=qual_ax,
+            order=order,
+            xtick_fontsize=xtick_fontsize,
+            group_specs=group_specs,
+            add_annotations=True,
         )
         qual_ax.set_ylabel("SNVQ", fontsize=ylabel_fontsize)
         qual_ax.tick_params(axis="y", labelsize=ytick_fontsize)
@@ -657,14 +681,19 @@ def plot_trinuc_hist_and_qual_panels(  # noqa: C901, PLR0912, PLR0913, PLR0915
                 label_name = str(label)
             labels_hist.append(f"{label_name} ({total_snvs_per_label[label]})")
 
+    # Map each plotted group prefix to its display label (from group_specs when provided).
+    label_by_prefix = {prefix: label for prefix, label, _ in (group_specs or [])}
     for mixed_cat in lines_for_legend:
         handles_qual.append(lines_for_legend[mixed_cat])
-        clean_label = (
-            mixed_cat.replace("mixed=", "")
-            .replace("all", "All reads")
-            .replace("True", "Mixed reads")
-            .replace("False", "Non-mixed reads")
-        )
+        if mixed_cat in label_by_prefix:
+            clean_label = label_by_prefix[mixed_cat]
+        else:
+            clean_label = (
+                mixed_cat.replace("mixed=", "")
+                .replace("all", "All reads")
+                .replace("True", "Mixed reads")
+                .replace("False", "Non-mixed reads")
+            )
         labels_qual.append(clean_label)
 
     # Apply bottom_scale to layout
@@ -865,7 +894,7 @@ def plot_trinuc_hist_panels(  # noqa: C901, PLR0912, PLR0915
     return fig
 
 
-def calc_and_plot_trinuc_hist(  # noqa: PLR0913
+def calc_and_plot_trinuc_hist(  # noqa: PLR0913, PLR0917
     plot_df,
     trinuc_col,
     label_col="label",
@@ -881,6 +910,8 @@ def calc_and_plot_trinuc_hist(  # noqa: PLR0913
     q1: float = 0.1,
     q2: float = 0.9,
     motif_orientation: str = "seq_dir",
+    split_col: str = "is_mixed",
+    group_specs=None,
     *,
     collapsed=False,
     include_quality: bool = False,
@@ -930,6 +961,7 @@ def calc_and_plot_trinuc_hist(  # noqa: PLR0913
         label_col=label_col,
         is_forward_col=is_forward_col,
         qual_col=qual_col,
+        is_mixed_col=split_col,
         order=order,
         labels=labels,
         q1=q1,
@@ -962,6 +994,7 @@ def calc_and_plot_trinuc_hist(  # noqa: PLR0913
             hspace=hspace,
             hist_to_qual_height_ratio=hist_to_qual_height_ratio,
             bottom_scale=bottom_scale,
+            group_specs=group_specs,
         )
     else:
         # Extract only histogram columns for backward compatibility


### PR DESCRIPTION
## Summary
Makes the SRSNV report auto-detect its read-split type from the featuremap columns (no CLI/WDL change) and generalizes the binary ppmSeq split into **N ordered read groups**, via a single data-driven **"recipe"** so adding a new split type touches zero figure/table methods.

- **mixed** (ppmSeq, `st`/`et` tags): **byte-identical** output and h5 keys.
- **consensus** (`fs`/`rs` read counts): 3 ordered groups — `single read` (fs+rs≤1) / `consensus, one strand` / `consensus, duplex` (fs≥1 & rs≥1).
- **none** (neither present): single "all reads" group, degrades gracefully.

## How — the recipe
- New `split_scheme.py`: `SplitScheme` (detector predicate + `add_columns` + ordered `SplitVariant`s) and a registry (`MIXED` / `CONSENSUS` / `NONE`). A variant's `group_fn` is the single source of truth for row→group mapping. **Adding a scheme = register one `SplitScheme` + detector; no figure-method edits.**
- Every split-dependent `SRSNVReport` method (fq_recall, run_info, roc_auc, run_quality, per-tag table, quality/logit histograms, per-feature curves, trinuc) now loops `scheme.variants` uniformly — **all `if self.split.mode is …` branches removed**. Dispatch is via capability flags (`ppmseq_crosstab`, `ppmseq_legacy_hist`) and the `variant.pos is None` discriminator, never on scheme name.
- **h5 keys** = `base + "_" + variant.suffix`. Mixed keeps its historical suffixes exactly (`""` legacy / `mixed_start` display). Consensus uses its own `strand_support` suffix and additionally writes the bare `base` key as an alias so h5→json conversion keeps working. Notebook reads the active scheme's keys via a `display_suffix` papermill param + `_k(base)` helper.

## Backward compatibility
- **Mixed byte-identical**: all 23 h5 keys match the pre-refactor ppmSeq baseline (verified before/after, only the `Report created on` timestamp differs).
- Consensus/none use the new per-scheme suffix keys (+ base alias). deep-srsnv report reuses `SRSNVReport` verbatim; auto-detects the scheme when `params["report_mode"]` is absent.

## Tests
- New `test_split_scheme.py` (detection, h5-key composition, group_fns, add_columns, **extensibility contract**). Updated consensus/prepare_report tests to the new keys. Added a mixed h5-key-surface regression lock. **418 srsnv unit tests pass; pre-commit clean.**

## Verification
- Local E2E: mixed byte-identical; consensus report renders with 8 `_strand_support` keys + the 3 groups in the display tables/figures.
- Cloud re-run (docker `ugbio_srsnv:srsnv-report-auto-mode-d7111a9a`): srsnv+dsrsnv nightly (mixed unchanged) + evrony consensus run — see PR comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
