### PR TITLE
Migrate CNV Docker to bookworm with static bookworm para_jalign

### DIFF
--- a/src/cnv/DATA-9903-jalign-bookworm-migration.md
+++ b/src/cnv/DATA-9903-jalign-bookworm-migration.md
@@ -1,12 +1,16 @@
-# CNV Docker: Bookworm Migration — Blocked by libparasail8
+# CNV Docker: Bookworm Migration
 
 **Ticket:** DATA-9903
-**Status:** Reverted — CNV pinned to `ugbio_base:1.7.0` (bullseye)
-**Date:** 2026-07-12
+**Status:** Migrated — CNV now builds on bookworm (`ugbio_base`), using a statically-linked bookworm `para_jalign`
+**Date:** 2026-07-27 (migrated); 2026-07-12 (original block)
 
 ## Decision
 
-The CNV module remains on bullseye (`ugbio_base:1.7.0`) while all other modules migrate to bookworm (`ugbio_base:1.8.3`). The migration is blocked by incompatibilities between `para_jalign` and bookworm's `libparasail8`.
+The CNV module has been migrated to bookworm alongside the rest of the fleet. The blocker below (an `libparasail8` ABI mismatch with the bullseye-compiled `para_jalign`) was resolved by a **statically-linked bookworm `para_jalign` binary** — its only `NEEDED` shared libs are `libstdc++.so.6`, `libgcc_s.so.1`, `libc.so.6` (no dynamic `libparasail`), so the parasail soname change (3 → 8) no longer affects it.
+
+The binary comes from jalign GitHub Actions run **30259845869** (branch `add-bookworm-support`), artifact `jalign-debian-bookworm-x64-...`, and is fetched in the CNV Dockerfile via the Actions artifacts API. The same binary is also published as release asset `para_jalign-1.4.1.1-debian-bookworm-x64` (release `1.4.1.1`) as a non-expiring fallback.
+
+The section below documents the *original* investigation that blocked the first attempt; it is kept for history.
 
 ---
 

--- a/src/cnv/Dockerfile
+++ b/src/cnv/Dockerfile
@@ -121,8 +121,8 @@ RUN R CMD INSTALL --preclean --no-multiarch --with-keep.source /opt/cn.mops/
 # NOTE: Actions artifacts expire (~90 days). The same binary is also published as release asset
 #       para_jalign-1.4.1.1-debian-bookworm-x64 (release 1.4.1.1) for a permanent source.
 # The github_token secret must have actions:read scope (artifact download), not just contents:read.
-ARG JALIGN_RUN_ID=30259845869
-ARG JALIGN_ARTIFACT_NAME=jalign-debian-bookworm-x64-57e4ccddc244a76ba6208ac501699b9b089343a8
+ARG JALIGN_RUN_ID=30343516696
+ARG JALIGN_ARTIFACT_NAME=jalign-debian-bookworm-x64-7132d3751cddeac3ea3dac817792f6ef1a60a9fa
 RUN --mount=type=secret,id=github_token \
     if [ ! -f /run/secrets/github_token ]; then \
         echo "ERROR: Authentication required to download dependencies" && exit 1; \

--- a/src/cnv/Dockerfile
+++ b/src/cnv/Dockerfile
@@ -1,8 +1,8 @@
-# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE)
-# Pinned to bullseye (1.7.0) — bookworm migration blocked by libparasail8 incompatibility (DATA-9903)
-ARG BASE_IMAGE=ugbio_base:1.7.0
+# BASE_IMAGE is injected by build-workspace-docker.yml (defaults to DEFAULT_BASE_IMAGE = bookworm-based ugbio_base)
+# Migrated to bookworm (DATA-9903): uses a statically-linked bookworm para_jalign binary (no libparasail ABI dependency)
+ARG BASE_IMAGE
 ARG OUT_DIR=/tmp/ugbio
-FROM python:3.11-bullseye AS build
+FROM python:3.11-bookworm AS build
 
 ARG OUT_DIR
 ARG MODULE_DIR=cnv
@@ -37,11 +37,11 @@ RUN apt-get update && \
     libpcre2-dev \
     tar \
     bzip2 \
-    libncurses5-dev \
-    libncursesw5-dev \
+    unzip \
+    libncurses-dev \
     libopenblas-dev \
-    libstdc++-10-dev \
-    libparasail3 libparasail-dev \
+    libstdc++-12-dev \
+    libparasail8 libparasail-dev \
     libhdf5-dev \
     tzdata \
     && apt-get clean && \
@@ -59,11 +59,11 @@ RUN apt-get update && \
     software-properties-common && \
     gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-key '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' && \
     gpg --armor --export '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' | tee /etc/apt/trusted.gpg.d/cran_debian_key.asc && \
-    echo "deb https://cloud.r-project.org/bin/linux/debian bullseye-cran40/" | tee /etc/apt/sources.list.d/cran.list && \
+    echo "deb https://cloud.r-project.org/bin/linux/debian bookworm-cran40/" | tee /etc/apt/sources.list.d/cran.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    r-base=4.5.1-1~bullseyecran.0 \
-    r-base-dev=4.5.1-1~bullseyecran.0 && \
+    r-base=4.5.3-1~bookwormcran.0 \
+    r-base-dev=4.5.3-1~bookwormcran.0 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -115,38 +115,43 @@ RUN rm -rf /tmp/* /var/tmp/* /usr/share/doc /usr/share/man /usr/share/info
 # Install cn.mops packages from local
 RUN R CMD INSTALL --preclean --no-multiarch --with-keep.source /opt/cn.mops/
 
-# Download para_jalign binary from private jalign repository
-ARG JALIGN_VERSION=1.4.1
+# Download the bookworm para_jalign binary from a jalign GitHub Actions artifact.
+# Source: Ultimagen/jalign run 30259845869 (branch add-bookworm-support), artifact below.
+# The binary statically links parasail, so it has no runtime libparasail ABI dependency (DATA-9903).
+# NOTE: Actions artifacts expire (~90 days). The same binary is also published as release asset
+#       para_jalign-1.4.1.1-debian-bookworm-x64 (release 1.4.1.1) for a permanent source.
+# The github_token secret must have actions:read scope (artifact download), not just contents:read.
+ARG JALIGN_RUN_ID=30259845869
+ARG JALIGN_ARTIFACT_NAME=jalign-debian-bookworm-x64-57e4ccddc244a76ba6208ac501699b9b089343a8
 RUN --mount=type=secret,id=github_token \
     if [ ! -f /run/secrets/github_token ]; then \
         echo "ERROR: Authentication required to download dependencies" && exit 1; \
     fi && \
     GITHUB_TOKEN=$(cat /run/secrets/github_token) && \
-    ASSET_NAME="para_jalign-${JALIGN_VERSION}-debian-bullseye-x64" && \
-    echo "Looking for asset: ${ASSET_NAME}" && \
+    echo "Looking for artifact: ${JALIGN_ARTIFACT_NAME} in run ${JALIGN_RUN_ID}" && \
     curl -sL \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${GITHUB_TOKEN}" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        "https://api.github.com/repos/Ultimagen/jalign/releases/tags/${JALIGN_VERSION}" \
-        -o /tmp/release_data.json && \
-    ASSET_URL=$(cat /tmp/release_data.json | \
-        jq -r ".assets[] | select(.name == \"${ASSET_NAME}\") | .url" | head -1) && \
-    echo "Asset URL: ${ASSET_URL}" && \
-    if [ -z "$ASSET_URL" ] || [ "$ASSET_URL" = "null" ]; then \
-        echo "ERROR: Could not find asset '${ASSET_NAME}' in release ${JALIGN_VERSION}" && \
-        echo "Available assets:" && \
-        cat /tmp/release_data.json | jq -r '.assets[].name' && \
+        "https://api.github.com/repos/Ultimagen/jalign/actions/runs/${JALIGN_RUN_ID}/artifacts?per_page=100" \
+        -o /tmp/artifacts.json && \
+    ARTIFACT_URL=$(jq -r ".artifacts[] | select(.name == \"${JALIGN_ARTIFACT_NAME}\") | .archive_download_url" /tmp/artifacts.json | head -1) && \
+    echo "Artifact URL: ${ARTIFACT_URL}" && \
+    if [ -z "$ARTIFACT_URL" ] || [ "$ARTIFACT_URL" = "null" ]; then \
+        echo "ERROR: Could not find artifact '${JALIGN_ARTIFACT_NAME}' in run ${JALIGN_RUN_ID}" && \
+        echo "Available artifacts:" && \
+        jq -r '.artifacts[].name' /tmp/artifacts.json && \
         exit 1; \
     fi && \
     curl -sLf \
-        -H "Accept: application/octet-stream" \
+        -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${GITHUB_TOKEN}" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        "${ASSET_URL}" \
-        -o /opt/para_jalign && \
-    chmod +x /opt/para_jalign && \
-    rm /tmp/release_data.json
+        "${ARTIFACT_URL}" \
+        -o /tmp/jalign.zip && \
+    unzip -o /tmp/jalign.zip -d /tmp/jalign && \
+    install -m 0755 /tmp/jalign/para_jalign /opt/para_jalign && \
+    rm -rf /tmp/jalign.zip /tmp/jalign /tmp/artifacts.json
 
 ARG OUT_DIR
 


### PR DESCRIPTION
Switch the CNV module image from bullseye (ugbio_base:1.7.0) to bookworm, aligning it with the rest of the ugbio_utils fleet.

- Build stage: python:3.11-bullseye -> python:3.11-bookworm
- Drop the ugbio_base:1.7.0 pin so CI injects the bookworm DEFAULT_BASE_IMAGE
- apt: libparasail3 -> libparasail8, libstdc++-10-dev -> libstdc++-12-dev, libncurses5-dev/libncursesw5-dev -> libncurses-dev, add unzip
- R/CRAN: bullseye-cran40 -> bookworm-cran40, r-base 4.5.1 -> 4.5.3
- para_jalign: fetch the bookworm binary from jalign Actions run 30259845869 artifact (statically links parasail, so no libparasail ABI dependency), replacing the release-asset download

The static bookworm binary resolves the libparasail8 ABI mismatch that previously blocked this migration (DATA-9903).