### PR TITLE
BIOIN-2965 Fixed a bug in filtering CNV calls where some nones were not filled

### DIFF
--- a/src/filtering/tests/unit/test_transformers.py
+++ b/src/filtering/tests/unit/test_transformers.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 from ugbio_filtering.tprep_constants import VcfType
@@ -178,3 +179,50 @@ class TestTransformers:
         # Check that copynumber column exists and has the max value (3)
         assert "cipos__cipos" in result.columns
         assert result["cipos__cipos"].iloc[0] == 200
+
+    def test_cnv_transformer_fills_all_nan_object_columns(self):
+        # Regression test: on a contig that has only cn.mops calls, the cnvpytor-only pytor*
+        # fields (and the conditional insert-size fields) are absent from every variant, so
+        # get_vcf_df yields all-NaN object-dtype columns. A bare numeric SimpleImputer used to
+        # silently pass these through, leaving NaNs that broke apply_model validation. The
+        # numeric_filler must coerce them to numeric and fill with 0.
+        transformer = get_transformer(VcfType.CNV)
+        object_all_nan = pd.Series([np.nan, np.nan], dtype=object)
+        test_df = pd.DataFrame(
+            {
+                "svtype": ["DEL", "DUP"],
+                "region_annotations": [(), ()],
+                "pytorq0": object_all_nan.copy(),
+                "pytorp2": object_all_nan.copy(),
+                "pytorrd": object_all_nan.copy(),
+                "pytorp1": object_all_nan.copy(),
+                "pytorp3": object_all_nan.copy(),
+                "gap_percentage": [0.01, 0.02],
+                "cnv_dup_reads": [10, 20],
+                "cnv_del_reads": [5, 6],
+                "cnv_dup_frac": [0.6, 0.7],
+                "cnv_del_frac": [0.3, 0.4],
+                "del_reads_median_insert_size": object_all_nan.copy(),
+                "dup_reads_median_insert_size": object_all_nan.copy(),
+                "jalign_dup_support": [8, 9],
+                "jalign_del_support": [4, 5],
+                "jalign_dup_support_strong": [6, 7],
+                "jalign_del_support_strong": [3, 4],
+                "svlen": [(1000,), (2000,)],
+                "cn": [2, 3],
+                "copynumber": [3, 4],
+                "cnv_source": [("cn.mops",), ("cn.mops",)],
+                "cipos": [(-100, 100), (-50, 50)],
+            }
+        )
+        # sanity: these columns start as object dtype, as get_vcf_df would produce
+        assert test_df["pytorq0"].dtype == object
+        result = transformer.fit_transform(test_df)
+        assert result.isna().sum().sum() == 0
+        for col in [
+            "pytorq0__pytorq0",
+            "pytorp2__pytorp2",
+            "del_reads_median_insert_size__del_reads_median_insert_size",
+        ]:
+            assert col in result.columns
+            assert (result[col] == 0).all()

--- a/src/filtering/ugbio_filtering/transformers.py
+++ b/src/filtering/ugbio_filtering/transformers.py
@@ -123,6 +123,17 @@ def region_annotation_encode(x):
     return encoding[tuple(sorted(x))]
 
 
+def coerce_to_numeric_df(df):
+    """Coerce all columns of a dataframe to numeric dtype (NaN on failure).
+
+    When an INFO field is absent from every variant in a chunk (e.g. cnvpytor-only fields on a
+    contig that has only cn.mops calls), get_vcf_df yields an all-NaN column with ``object``
+    dtype. A numeric ``SimpleImputer`` passes such object columns through untouched, leaving NaNs.
+    Coercing to numeric first turns them into a proper float all-NaN column the imputer can fill.
+    """
+    return df.apply(pd.to_numeric, errors="coerce")
+
+
 def get_needed_features(vtype: VcfType = VcfType.SINGLE_SAMPLE, custom_annotations: list | None = None) -> list:
     """Get the list of features that are needed for the model
 
@@ -207,6 +218,10 @@ def modify_features_based_on_vcf_type(  # noqa C901
         return pd.DataFrame(df.apply(lambda x: x[1] - x[0] - 1), index=df.index)
 
     default_filler = impute.SimpleImputer(strategy="constant", fill_value=0)
+    numeric_filler = make_pipeline(
+        preprocessing.FunctionTransformer(coerce_to_numeric_df),
+        default_filler,
+    )
     tuple_filter = preprocessing.FunctionTransformer(tuple_encode_df)
     ins_del_encode_filter = preprocessing.FunctionTransformer(ins_del_encode_df)
     tuple_encode_df_transformer = preprocessing.FunctionTransformer(tuple_encode_df)
@@ -295,18 +310,18 @@ def modify_features_based_on_vcf_type(  # noqa C901
     elif vtype == VcfType.CNV:
         transform_list = [
             ("svtype", svtype_encode_filter, "svtype"),
-            ("pytorq0", default_filler, ["pytorq0"]),
-            ("pytorp2", default_filler, ["pytorp2"]),
-            ("pytorrd", default_filler, ["pytorrd"]),
-            ("pytorp1", default_filler, ["pytorp1"]),
-            ("pytorp3", default_filler, ["pytorp3"]),
+            ("pytorq0", numeric_filler, ["pytorq0"]),
+            ("pytorp2", numeric_filler, ["pytorp2"]),
+            ("pytorrd", numeric_filler, ["pytorrd"]),
+            ("pytorp1", numeric_filler, ["pytorp1"]),
+            ("pytorp3", numeric_filler, ["pytorp3"]),
             ("gap_percentage", "passthrough", ["gap_percentage"]),
             ("cnv_dup_reads", "passthrough", ["cnv_dup_reads"]),
             ("cnv_del_reads", "passthrough", ["cnv_del_reads"]),
             ("cnv_dup_frac", "passthrough", ["cnv_dup_frac"]),
             ("cnv_del_frac", "passthrough", ["cnv_del_frac"]),
-            ("del_reads_median_insert_size", default_filler, ["del_reads_median_insert_size"]),
-            ("dup_reads_median_insert_size", default_filler, ["dup_reads_median_insert_size"]),
+            ("del_reads_median_insert_size", numeric_filler, ["del_reads_median_insert_size"]),
+            ("dup_reads_median_insert_size", numeric_filler, ["dup_reads_median_insert_size"]),
             ("jalign_dup_support", "passthrough", ["jalign_dup_support"]),
             ("jalign_del_support", "passthrough", ["jalign_del_support"]),
             ("jalign_dup_support_strong", "passthrough", ["jalign_dup_support_strong"]),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Scoped to CNV feature preprocessing with a regression test; behavior change is filling previously leaked NaNs with 0 for optional INFO fields.
> 
> **Overview**
> Fixes CNV filtering failures when **cn.mops-only** contigs leave cnvpytor-specific INFO fields (`pytor*`) and conditional insert-size columns as **all-NaN object** columns from `get_vcf_df`. A plain `SimpleImputer` did not fill those dtypes, so NaNs reached **`apply_model`** validation.
> 
> Adds **`coerce_to_numeric_df`** and a **`numeric_filler`** pipeline (coerce → constant 0) and wires it into the **CNV** transformer for the seven affected numeric INFO fields. A regression unit test asserts the transformed matrix has no NaNs and missing pytor/insert-size features become **0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c41ae02cb144ad66903ee6580486d37dd022e191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->